### PR TITLE
add larger kernel sizes for bisinc

### DIFF
--- a/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/BiSinc11PointInterpolationResampling.java
+++ b/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/BiSinc11PointInterpolationResampling.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2014 Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
+
+package org.esa.beam.framework.dataop.resamp;
+
+final class BiSinc11PointInterpolationResampling extends BiSincInterpolationResampling {
+
+    BiSinc11PointInterpolationResampling()   {
+        super(11);
+    }
+
+    public String getName() {
+        return "BISINC_11_POINT_INTERPOLATION";
+    }
+}
+

--- a/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/BiSinc21PointInterpolationResampling.java
+++ b/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/BiSinc21PointInterpolationResampling.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2014 Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
+
+package org.esa.beam.framework.dataop.resamp;
+
+final class BiSinc21PointInterpolationResampling extends BiSincInterpolationResampling {
+
+    BiSinc21PointInterpolationResampling()   {
+        super(21);
+    }
+
+    public String getName() {
+        return "BISINC_21_POINT_INTERPOLATION";
+    }
+}
+

--- a/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/BiSinc5PointInterpolationResampling.java
+++ b/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/BiSinc5PointInterpolationResampling.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2014 Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
+
+package org.esa.beam.framework.dataop.resamp;
+
+final class BiSinc5PointInterpolationResampling extends BiSincInterpolationResampling {
+
+    BiSinc5PointInterpolationResampling()   {
+        super(5);
+    }
+
+    public String getName() {
+        return "BISINC_5_POINT_INTERPOLATION";
+    }
+}
+

--- a/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/BiSincInterpolationResampling.java
+++ b/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/BiSincInterpolationResampling.java
@@ -16,21 +16,25 @@
 
 package org.esa.beam.framework.dataop.resamp;
 
-
 import org.apache.commons.math3.util.FastMath;
 
-final class BiSincInterpolationResampling implements Resampling {
+class BiSincInterpolationResampling implements Resampling {
 
     private static final double DoublePI = 2.0 * Math.PI;
-    private static final int filterLength = 5;
-    private static final double halfFilterLength = filterLength * 0.5;
+    private int kernelSize = 0;
+    private int halfKernelSize = 0;
+
+    public BiSincInterpolationResampling(final int kernelSize) {
+        this.kernelSize = kernelSize;
+        this.halfKernelSize = kernelSize/2;
+    }
 
     public String getName() {
         return "BISINC_INTERPOLATION";
     }
 
     public final Index createIndex() {
-        return new Index(5, 1);
+        return new Index(kernelSize, 1);
     }
 
     public final void computeIndex(final double x,
@@ -55,108 +59,87 @@ final class BiSincInterpolationResampling implements Resampling {
         final int iMax = width - 1;
         final int jMax = height - 1;
 
-        int i_0, i_1, i_2, i_3, i_4;
         if (di >= 0) {
-            i_0 = i0 - 2;
-            i_1 = i0 - 1;
-            i_2 = i0;
-            i_3 = i0 + 1;
-            i_4 = i0 + 2;
+            for (int i = 0; i < kernelSize; i++) {
+                index.i[i] = Math.min(Math.max(i0 - halfKernelSize + i, 0), iMax);
+            }
             index.ki[0] = di;
         } else {
-            i_0 = i0 - 3;
-            i_1 = i0 - 2;
-            i_2 = i0 - 1;
-            i_3 = i0;
-            i_4 = i0 + 1;
+            for (int i = 0; i < kernelSize; i++) {
+                index.i[i] = Math.min(Math.max(i0 - halfKernelSize - 1 + i, 0), iMax);
+            }
             index.ki[0] = di + 1;
         }
-        index.i[0] = (i_0 < 0) ? 0 : (i_0 > iMax) ? iMax : i_0;
-        index.i[1] = (i_1 < 0) ? 0 : (i_1 > iMax) ? iMax : i_1;
-        index.i[2] = (i_2 < 0) ? 0 : (i_2 > iMax) ? iMax : i_2;
-        index.i[3] = (i_3 < 0) ? 0 : (i_3 > iMax) ? iMax : i_3;
-        index.i[4] = (i_4 < 0) ? 0 : (i_4 > iMax) ? iMax : i_4;
 
-        int j_0, j_1, j_2, j_3, j_4;
         if (dj >= 0) {
-            j_0 = j0 - 2;
-            j_1 = j0 - 1;
-            j_2 = j0;
-            j_3 = j0 + 1;
-            j_4 = j0 + 2;
+            for (int j = 0; j < kernelSize; j++) {
+                index.j[j] = Math.min(Math.max(j0 - halfKernelSize + j, 0), jMax);
+            }
             index.kj[0] = dj;
         } else {
-            j_0 = j0 - 3;
-            j_1 = j0 - 2;
-            j_2 = j0 - 1;
-            j_3 = j0;
-            j_4 = j0 + 1;
+            for (int j = 0; j < kernelSize; j++) {
+                index.j[j] = Math.min(Math.max(j0 - halfKernelSize - 1 + j, 0), jMax);
+            }
             index.kj[0] = dj + 1;
         }
-        index.j[0] = (j_0 < 0) ? 0 : (j_0 > jMax) ? jMax : j_0;
-        index.j[1] = (j_1 < 0) ? 0 : (j_1 > jMax) ? jMax : j_1;
-        index.j[2] = (j_2 < 0) ? 0 : (j_2 > jMax) ? jMax : j_2;
-        index.j[3] = (j_3 < 0) ? 0 : (j_3 > jMax) ? jMax : j_3;
-        index.j[4] = (j_4 < 0) ? 0 : (j_4 > jMax) ? jMax : j_4;
     }
 
     public final double resample(final Raster raster,
                                  final Index index) throws Exception {
 
-        final int[] x = new int[5];
-        final int[] y = new int[5];
-        final double[][] samples = new double[5][5];
+        final int[] x = new int[kernelSize];
+        final int[] y = new int[kernelSize];
+        final double[][] samples = new double[kernelSize][kernelSize];
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < kernelSize; i++) {
             x[i] = (int) index.i[i];
             y[i] = (int) index.j[i];
         }
 
         if (!raster.getSamples(x, y, samples)) {
-            if (Double.isNaN(samples[2][2])) {
-                return samples[2][2];
+            if (Double.isNaN(samples[halfKernelSize][halfKernelSize])) {
+                return samples[halfKernelSize][halfKernelSize];
             }
             BiCubicInterpolationResampling.replaceNaNWithMean(samples);
         }
 
         final double muX = index.ki[0];
         final double muY = index.kj[0];
+        final double cx = muX + halfKernelSize;
+        final double cy = muY + halfKernelSize;
 
-        final double f0 = sinc(muX + 2.0) * hanning(muX + 2.0);
-        final double f1 = sinc(muX + 1.0) * hanning(muX + 1.0);
-        final double f2 = sinc(muX + 0.0) * hanning(muX + 0.0);
-        final double f3 = sinc(muX - 1.0) * hanning(muX - 1.0);
-        final double f4 = sinc(muX - 2.0) * hanning(muX - 2.0);
-        final double sum = f0 + f1 + f2 + f3 + f4;
+        final double[] winX = new double[kernelSize];
+        final double[] winY = new double[kernelSize];
+        double sumX = 0.0, sumY = 0.0;
+        for (int n = 0; n < kernelSize; n++) {
+            winX[n] = sinc(cx - n) * hanning(cx - n);
+            winY[n] = sinc(cy - n) * hanning(cy - n);
+            sumX += winX[n];
+            sumY += winY[n];
+        }
 
-        final double tmpV0 = (f0 * samples[0][0] + f1 * samples[0][1] + f2 * samples[0][2] + f3 * samples[0][3] + f4 * samples[0][4]) / sum;
-        final double tmpV1 = (f0 * samples[1][0] + f1 * samples[1][1] + f2 * samples[1][2] + f3 * samples[1][3] + f4 * samples[1][4]) / sum;
-        final double tmpV2 = (f0 * samples[2][0] + f1 * samples[2][1] + f2 * samples[2][2] + f3 * samples[2][3] + f4 * samples[2][4]) / sum;
-        final double tmpV3 = (f0 * samples[3][0] + f1 * samples[3][1] + f2 * samples[3][2] + f3 * samples[3][3] + f4 * samples[3][4]) / sum;
-        final double tmpV4 = (f0 * samples[4][0] + f1 * samples[4][1] + f2 * samples[4][2] + f3 * samples[4][3] + f4 * samples[4][4]) / sum;
+        double v = 0.0;
+        for (int j = 0; j < kernelSize; j++) {
+            for (int i = 0; i < kernelSize; i++) {
+                v += samples[j][i]*winX[i]*winY[j];
+            }
+        }
+        v /= sumX*sumY;
 
-        return interpolationSinc(tmpV0, tmpV1, tmpV2, tmpV3, tmpV4, muY);
-    }
-
-    private static double interpolationSinc(
-            final double y0, final double y1, final double y2, final double y3, final double y4, final double mu) {
-
-        final double f0 = sinc(mu + 2.0) * hanning(mu + 2.0);
-        final double f1 = sinc(mu + 1.0) * hanning(mu + 1.0);
-        final double f2 = sinc(mu + 0.0) * hanning(mu + 0.0);
-        final double f3 = sinc(mu - 1.0) * hanning(mu - 1.0);
-        final double f4 = sinc(mu - 2.0) * hanning(mu - 2.0);
-        final double sum = f0 + f1 + f2 + f3 + f4;
-        return (f0 * y0 + f1 * y1 + f2 * y2 + f3 * y3 + f4 * y4) / sum;
+        return v;
     }
 
     private static double sinc(final double x) {
         return (Double.compare(x, 0.0) == 0) ? 1.0 : FastMath.sin(x * Math.PI) / (x * Math.PI);
     }
 
-    public static double hanning(final double x) {
-        return (x >= -halfFilterLength && x <= halfFilterLength) ?
-                0.5 * (1.0 + FastMath.cos(DoublePI * x / (filterLength + 1))) : 0.0;
+    public double hanning(final double x) {
+        return (x >= -halfKernelSize && x <= halfKernelSize) ?
+                0.5 * (1.0 + FastMath.cos(DoublePI * x / (kernelSize + 1))) : 0.0;
+    }
+
+    public int getKernelSize() {
+        return kernelSize;
     }
 
     @Override

--- a/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/Resampling.java
+++ b/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/Resampling.java
@@ -39,7 +39,9 @@ public interface Resampling {
     /**
      * The bisinc interpolation resampling method.
      */
-    Resampling BISINC_INTERPOLATION = new BiSincInterpolationResampling();
+    Resampling BISINC_5_POINT_INTERPOLATION = new BiSinc5PointInterpolationResampling();
+    Resampling BISINC_11_POINT_INTERPOLATION = new BiSinc11PointInterpolationResampling();
+    Resampling BISINC_21_POINT_INTERPOLATION = new BiSinc21PointInterpolationResampling();
     /**
      * The bicubic spline interpolation resampling method.
      */
@@ -81,6 +83,10 @@ public interface Resampling {
      * @throws Exception if a non-runtime error occurs, e.g I/O error
      */
     double resample(Raster raster, Index index) throws Exception;
+
+    default int getKernelSize() {
+        return 4;
+    }
 
     /**
      * A raster is a rectangular grid which provides sample values at a given raster position x,y.

--- a/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/ResamplingFactory.java
+++ b/beam-core/src/main/java/org/esa/beam/framework/dataop/resamp/ResamplingFactory.java
@@ -26,14 +26,18 @@ public final class ResamplingFactory {
     public static final String NEAREST_NEIGHBOUR_NAME = "NEAREST_NEIGHBOUR";
     public static final String BILINEAR_INTERPOLATION_NAME = "BILINEAR_INTERPOLATION";
     public static final String CUBIC_CONVOLUTION_NAME = "CUBIC_CONVOLUTION";
-    public static final String BISINC_INTERPOLATION_NAME = "BISINC_INTERPOLATION";
+    public static final String BISINC_5_POINT_INTERPOLATION_NAME = "BISINC_5_POINT_INTERPOLATION";
+    public static final String BISINC_11_POINT_INTERPOLATION_NAME = "BISINC_11_POINT_INTERPOLATION";
+    public static final String BISINC_21_POINT_INTERPOLATION_NAME = "BISINC_21_POINT_INTERPOLATION";
     public static final String BICUBIC_INTERPOLATION_NAME = "BICUBIC_INTERPOLATION";
 
     public static final String[] resamplingNames = new String[]{
             NEAREST_NEIGHBOUR_NAME,
             BILINEAR_INTERPOLATION_NAME,
             CUBIC_CONVOLUTION_NAME,
-            BISINC_INTERPOLATION_NAME,
+            BISINC_5_POINT_INTERPOLATION_NAME,
+            BISINC_11_POINT_INTERPOLATION_NAME,
+            BISINC_21_POINT_INTERPOLATION_NAME,
             BICUBIC_INTERPOLATION_NAME};
 
     /**
@@ -44,7 +48,9 @@ public final class ResamplingFactory {
      * @see ResamplingFactory#NEAREST_NEIGHBOUR_NAME
      * @see ResamplingFactory#BILINEAR_INTERPOLATION_NAME
      * @see ResamplingFactory#CUBIC_CONVOLUTION_NAME
-     * @see ResamplingFactory#BISINC_INTERPOLATION_NAME
+     * @see ResamplingFactory#BISINC_5_POINT_INTERPOLATION_NAME
+     * @see ResamplingFactory#BISINC_11_POINT_INTERPOLATION_NAME
+     * @see ResamplingFactory#BISINC_21_POINT_INTERPOLATION_NAME
      * @see ResamplingFactory#BICUBIC_INTERPOLATION_NAME
      */
     public static Resampling createResampling(final String resamplingName) {
@@ -56,8 +62,12 @@ public final class ResamplingFactory {
                 return Resampling.BILINEAR_INTERPOLATION;
             case CUBIC_CONVOLUTION_NAME:
                 return Resampling.CUBIC_CONVOLUTION;
-            case BISINC_INTERPOLATION_NAME:
-                return Resampling.BISINC_INTERPOLATION;
+            case BISINC_5_POINT_INTERPOLATION_NAME:
+                return Resampling.BISINC_5_POINT_INTERPOLATION;
+            case BISINC_11_POINT_INTERPOLATION_NAME:
+                return Resampling.BISINC_11_POINT_INTERPOLATION;
+            case BISINC_21_POINT_INTERPOLATION_NAME:
+                return Resampling.BISINC_21_POINT_INTERPOLATION;
             case BICUBIC_INTERPOLATION_NAME:
                 return Resampling.BICUBIC_INTERPOLATION;
             default:


### PR DESCRIPTION
phase preserving resampling needed with larger kernel sizes

At some point the interface may need to change to allow for a user specified kernel size. For now, 5, 11 and 21 have been added.
