### PR TITLE
Ignore unknown GeoTIFF geokeys instead of failing

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/util/geotiff/GeoTIFFCodes.java
+++ b/snap-core/src/main/java/org/esa/snap/util/geotiff/GeoTIFFCodes.java
@@ -37,6 +37,7 @@ public class GeoTIFFCodes extends IntMap {
     public static final int GeogInvFlatteningGeoKey = 2059;
     public static final int GeogAzimuthUnitsGeoKey = 2060;
     public static final int GeogPrimeMeridianLongGeoKey = 2061;
+    public static final int GeogTOWGS84GeoKey = 2062;
     public static final int ProjectedCSTypeGeoKey = 3072;
     public static final int PCSCitationGeoKey = 3073;
     public static final int ProjectionGeoKey = 3074;

--- a/snap-core/src/main/java/org/esa/snap/util/geotiff/codes/geokey.properties
+++ b/snap-core/src/main/java/org/esa/snap/util/geotiff/codes/geokey.properties
@@ -28,6 +28,7 @@
    GeogInvFlatteningGeoKey  =  	2059
    GeogAzimuthUnitsGeoKey  =  	2060
    GeogPrimeMeridianLongGeoKey  =  	2061
+   GeogTOWGS84GeoKey  =  	2062
    ProjectedCSTypeGeoKey  =  	3072
    PCSCitationGeoKey  =  	3073
    ProjectionGeoKey  =  	3074

--- a/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/TiffTagToMetadataConverter.java
+++ b/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/TiffTagToMetadataConverter.java
@@ -87,10 +87,14 @@ class TiffTagToMetadataConverter {
         for (Map.Entry<Integer, GeoKeyEntry> entry : geoKeyMap.entrySet()) {
             final GeoKeyEntry geoKeyEntry = entry.getValue();
             final String name = geoKeyEntry.getName();
-            final ProductData data = getGeoKeyValue(geoKeyEntry);
-            if (data != null) {
-                final MetadataAttribute attribute = new MetadataAttribute(name, data, true);
-                geoKeyDirMetadata.addAttribute(attribute);
+            if (name != null) {
+                final ProductData data = getGeoKeyValue(geoKeyEntry);
+                if (data != null) {
+                    final MetadataAttribute attribute = new MetadataAttribute(name, data, true);
+                    geoKeyDirMetadata.addAttribute(attribute);
+                }
+            } else {
+                // Log a warning?
             }
         }
 


### PR DESCRIPTION
GDAL ver >= 1.9 writes GeoTIFF files with a GeogTOWGS84GeoKey geokey set in its metadata, which is unrecognised by SNAP's GeoTIFF reader, resulting in a NullPointerException and the image failing to open.
Unknown geokeys should probably just be ignored. I added the GeogTOWGS84GeoKey to the geokey registry, too.