### PR TITLE
Ensure file filters do not appear several times

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/util/io/SnapFileFilter.java
+++ b/snap-core/src/main/java/org/esa/snap/util/io/SnapFileFilter.java
@@ -21,10 +21,7 @@ import org.esa.snap.util.StringUtils;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * A <code>FileFilter</code> with file extensions support.
@@ -48,6 +45,28 @@ public class SnapFileFilter extends FileFilter {
         setFormatName(formatName);
         setExtensions(extensions);
         setDescription(description);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SnapFileFilter that = (SnapFileFilter) o;
+
+        if (description != null ? !description.equals(that.description) : that.description != null) return false;
+        if (!Arrays.equals(extensions, that.extensions)) return false;
+        if (formatName != null ? !formatName.equals(that.formatName) : that.formatName != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = formatName != null ? formatName.hashCode() : 0;
+        result = 31 * result + (extensions != null ? Arrays.hashCode(extensions) : 0);
+        result = 31 * result + (description != null ? description.hashCode() : 0);
+        return result;
     }
 
     public String getFormatName() {
@@ -278,13 +297,14 @@ public class SnapFileFilter extends FileFilter {
      * @since BEAM 4.10
      */
     public static <T extends ProductIOPlugIn> List<SnapFileFilter> getSortedFileFilters(Iterator<T> pluginIterator) {
-        List<SnapFileFilter> fileFilterList = new ArrayList<>();
+        HashSet<SnapFileFilter> fileFilterSet = new HashSet<>();
         while (pluginIterator.hasNext()) {
             final SnapFileFilter productFileFilter = pluginIterator.next().getProductFileFilter();
             if (productFileFilter != null) {
-                fileFilterList.add(productFileFilter);
+                fileFilterSet.add(productFileFilter);
             }
         }
+        List<SnapFileFilter> fileFilterList = new ArrayList<>(fileFilterSet);
         Collections.sort(fileFilterList, (bff1, bff2) -> bff1.getDescription().compareTo(bff2.getDescription()));
         return fileFilterList;
     }


### PR DESCRIPTION
Different readers can return the same file filter (for example the different Sentinel2 MSI L1C readers specific to each UTM zone).
This commit allows for different reader plugin to return the same file filter.
The list of file filters appearing in the Open Product dialog then shows only unique file filters.