### PR TITLE
fix assignment when asciiValues may be zero length

### DIFF
--- a/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/TiffFileInfo.java
+++ b/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/TiffFileInfo.java
@@ -96,7 +96,7 @@ class TiffFileInfo {
                 final double[] doubles = new double[count];
                 System.arraycopy(doubleValues, offsetOrValue, doubles, 0, count);
                 value = doubles;
-            } else if (tiffTagLocation == TAG_GEO_ASCII_PARAMS___SPOT) {
+            } else if (tiffTagLocation == TAG_GEO_ASCII_PARAMS___SPOT && asciiValues.length > strIdx) {
                 value = asciiValues[strIdx++];
             } else {
                 value = new Integer(offsetOrValue);


### PR DESCRIPTION
With some GeoTiffs getGeoAsciiParamValues return zero length asciiValues