### PR TITLE
Reuse products

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/util/ProductUtils.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/ProductUtils.java
@@ -963,6 +963,30 @@ public class ProductUtils {
     }
 
     /**
+     * Copies a virtual band and keeps it as a virtual band
+     *
+     * @param sourceProduct   the source product.
+     * @param srcBand   the virtual band to copy.
+     * @param name the name of the new band.
+     * @return the copy of the band.
+     */
+    public static VirtualBand copyVirtualBand(final Product product, final VirtualBand srcBand, final String name) {
+
+        final VirtualBand virtBand = new VirtualBand(name,
+                                                     srcBand.getDataType(),
+                                                     srcBand.getRasterWidth(),
+                                                     srcBand.getRasterHeight(),
+                                                     srcBand.getExpression());
+        virtBand.setUnit(srcBand.getUnit());
+        virtBand.setDescription(srcBand.getDescription());
+        virtBand.setNoDataValue(srcBand.getNoDataValue());
+        virtBand.setNoDataValueUsed(srcBand.isNoDataValueUsed());
+        virtBand.setOwner(product);
+        product.addBand(virtBand);
+        return virtBand;
+    }
+
+    /**
      * Copies the named band from the source product to the target product.
      * <p>
      * The method does not copy any image geo-coding/geometry information.

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/graph/NodeContext.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/graph/NodeContext.java
@@ -140,12 +140,14 @@ public class NodeContext {
         }
     }
 
-    private static boolean productIsOpened(ProductManager productManager, Product targetProduct) {
+    private static boolean isPproductOpened(ProductManager productManager, Product targetProduct) {
         if(productManager.contains(targetProduct))
             return true;
+        final File file = targetProduct.getFileLocation();
+        if(file == null)
+            return false;
 
         final Product[] openedProducts = productManager.getProducts();
-        final File file = targetProduct.getFileLocation();
         for(Product openedProduct : openedProducts) {
             if (file != null && file.equals(openedProduct.getFileLocation())) {
                 return true;
@@ -156,7 +158,7 @@ public class NodeContext {
 
     public synchronized void dispose() {
         if (targetProduct != null) {
-            if(!(operator != null && productIsOpened(operator.getProductManager(), targetProduct))) {
+            if(!(operator != null && isPproductOpened(operator.getProductManager(), targetProduct))) {
                 targetProduct.dispose();
                 targetProduct = null;
             }

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/graph/NodeContext.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/graph/NodeContext.java
@@ -19,6 +19,7 @@ package org.esa.snap.core.gpf.graph;
 import com.bc.ceres.core.Assert;
 import org.esa.snap.core.datamodel.Band;
 import org.esa.snap.core.datamodel.Product;
+import org.esa.snap.core.datamodel.ProductManager;
 import org.esa.snap.core.gpf.GPF;
 import org.esa.snap.core.gpf.Operator;
 import org.esa.snap.core.gpf.OperatorException;
@@ -28,6 +29,7 @@ import org.esa.snap.core.gpf.internal.OperatorConfiguration;
 import org.esa.snap.core.gpf.internal.OperatorContext;
 
 import javax.media.jai.PlanarImage;
+import java.io.File;
 import java.lang.reflect.Field;
 
 /**
@@ -138,15 +140,31 @@ public class NodeContext {
         }
     }
 
+    private static boolean productIsOpened(ProductManager productManager, Product targetProduct) {
+        if(productManager.contains(targetProduct))
+            return true;
+
+        final Product[] openedProducts = productManager.getProducts();
+        final File file = targetProduct.getFileLocation();
+        for(Product openedProduct : openedProducts) {
+            if (file != null && file.equals(openedProduct.getFileLocation())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public synchronized void dispose() {
+        if (targetProduct != null) {
+            if(!(operator != null && productIsOpened(operator.getProductManager(), targetProduct))) {
+                targetProduct.dispose();
+                targetProduct = null;
+            }
+        }
         if (operatorContext != null && !operatorContext.isDisposed()) {
             operatorContext.dispose(); // disposes operator as well
             operatorContext = null;
             operator = null;
-        }
-        if (targetProduct != null) {
-            targetProduct.dispose();
-            targetProduct = null;
         }
     }
 }

--- a/snap-gpf/src/test/java/org/esa/snap/core/gpf/graph/GraphCallSequenceTest.java
+++ b/snap-gpf/src/test/java/org/esa/snap/core/gpf/graph/GraphCallSequenceTest.java
@@ -115,10 +115,10 @@ public class GraphCallSequenceTest extends TestCase {
                 "N2:Product.construct",
                 "N2:Operator.computeBand",
                 "N1:Operator.computeBand",
-                "N2:Operator.dispose",
                 "N2:Product.dispose",
-                "N1:Operator.dispose",
+                "N2:Operator.dispose",
                 "N1:Product.dispose",
+                "N1:Operator.dispose",
         };
 
         assertEquals(expectedRecordStrings.length, callRecordList.size());
@@ -171,12 +171,12 @@ public class GraphCallSequenceTest extends TestCase {
                 "N3:Operator.computeBand",
                 "N2:Operator.computeBand",
                 "N1:Operator.computeBand",
-                "N3:Operator.dispose",
                 "N3:Product.dispose",
-                "N2:Operator.dispose",
+                "N3:Operator.dispose",
                 "N2:Product.dispose",
-                "N1:Operator.dispose",
+                "N2:Operator.dispose",
                 "N1:Product.dispose",
+                "N1:Operator.dispose",
         };
 
         assertEquals(expectedRecordStrings.length, callRecordList.size());


### PR DESCRIPTION
This allows the Graph Builder to reuse Products already opened in the ProductManager and in particular to use a modified product rather than reread from disk where the modification may not exist.

Also, copyVirtualBands is a useful function which was in OperatorUtils and now is in ProductUtils. It allows a virtual band to be copied from a source product to a target product without triggering any processing and still remaining a virtual band.