### PR TITLE
Supporting NetCDF NCML files

### DIFF
--- a/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/util/NetcdfFileOpener.java
+++ b/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/util/NetcdfFileOpener.java
@@ -18,6 +18,7 @@ package org.esa.snap.dataio.netcdf.util;
 
 import org.esa.snap.core.util.SystemUtils;
 import ucar.nc2.NetcdfFile;
+import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.iosp.IOServiceProvider;
 import ucar.nc2.iosp.hdf4.H4iosp;
 import ucar.nc2.iosp.hdf5.H5header;
@@ -112,6 +113,16 @@ public class NetcdfFileOpener {
                     if (!(input instanceof ImageInputStream)) {
                         rafForTesting.close();
                     }
+                }
+                String filePath = null;
+                if (input instanceof File) {
+                    final File file = (File) input;
+                    filePath = file.getAbsolutePath();
+                } else if (input instanceof String){
+                    filePath = (String) input;
+                }
+                if (filePath != null && filePath.toLowerCase().endsWith(".ncml")) {
+                    return NetcdfDataset.acquireFile(filePath, null);
                 }
             }
         } catch (IOException ioe) {

--- a/snap-netcdf/src/test/resources/org/esa/snap/dataio/netcdf/test.ncml
+++ b/snap-netcdf/src/test/resources/org/esa/snap/dataio/netcdf/test.ncml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ncml:netcdf xmlns:ncml="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" location="test.nc">
+  <ncml:variable name="CHL1_renamed" orgName="CHL1_value" />
+</ncml:netcdf>


### PR DESCRIPTION
Add support for NetCDF Markup Language [NCML](http://www.unidata.ucar.edu/software/thredds/current/netcdf-java/ncml/) files to NetcdfFileOpener.

NCML allows to aggregate NetCDFs, rename variable/attributes, change values, remove variable/attributes without actually editing the real NetCDF nc files.
