### PR TITLE
Added new constructor with layout for DefaultMultiLevelImage

### DIFF
--- a/ceres-glayer/src/main/java/com/bc/ceres/glevel/support/DefaultMultiLevelImage.java
+++ b/ceres-glayer/src/main/java/com/bc/ceres/glevel/support/DefaultMultiLevelImage.java
@@ -42,10 +42,15 @@ public class DefaultMultiLevelImage extends MultiLevelImage {
      * @param source The multi-level image source.
      */
     public DefaultMultiLevelImage(MultiLevelSource source) {
-        super(new ImageLayout(source.getImage(0)), null, null);
-        this.source = source;
+        this(source,new ImageLayout(source.getImage(0)));
     }
 
+    /**
+     * Constructs a new multi-level image from the given source and the image layout.
+     *
+     * @param source The multi-level image source.
+     * @param layout The image layout.
+     */
     public DefaultMultiLevelImage(MultiLevelSource source, ImageLayout layout) {
         super(layout, null, null);
         this.source = source;

--- a/ceres-glayer/src/main/java/com/bc/ceres/glevel/support/DefaultMultiLevelImage.java
+++ b/ceres-glayer/src/main/java/com/bc/ceres/glevel/support/DefaultMultiLevelImage.java
@@ -46,6 +46,11 @@ public class DefaultMultiLevelImage extends MultiLevelImage {
         this.source = source;
     }
 
+    public DefaultMultiLevelImage(MultiLevelSource source, ImageLayout layout) {
+        super(layout, null, null);
+        this.source = source;
+    }
+
     /**
      * @return The multi-level image source.
      */


### PR DESCRIPTION
In Sentinel-2, we know the tilelayout before creating the multilevel image. If we use this new constructor the performance is improved because we do not need to create the level 0 image until the user open a specific band.