### PR TITLE
Added StoredGraphOp for configuration optimiser.

### DIFF
--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/graph/StoredGraphOp.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/graph/StoredGraphOp.java
@@ -1,0 +1,74 @@
+package org.esa.snap.core.gpf.graph;
+
+import com.bc.ceres.core.ProgressMonitor;
+import org.esa.snap.core.datamodel.Product;
+import org.esa.snap.core.datamodel.ProductData;
+import org.esa.snap.core.gpf.Operator;
+import org.esa.snap.core.gpf.OperatorException;
+import org.esa.snap.core.gpf.OperatorSpi;
+import org.esa.snap.core.gpf.annotations.OperatorMetadata;
+import org.esa.snap.core.gpf.annotations.Parameter;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+
+
+/**
+ * Created by obarrile on 11/08/2016.
+ */
+@OperatorMetadata(alias = "StoredGraph",
+        description = "Encapsulates an stored graph into an operator.",
+        internal = true,
+        autoWriteDisabled = true)
+public class StoredGraphOp extends Operator {
+
+    @Parameter(description = "The file from which the graph is read.", notNull = true, notEmpty = true)
+    private File file;
+
+    GraphProcessor processor = null;
+    GraphContext graphContext = null;
+
+    @Override
+    public void initialize() throws OperatorException {
+        setDummyTargetProduct();
+        if (file == null) {
+            throw new OperatorException("'file' parameter must be set");
+        }
+        try {
+            FileReader reader = new FileReader(file);
+            Graph graph = GraphIO.read(reader);
+
+            processor = new GraphProcessor();
+            graphContext = new GraphContext(graph);
+        } catch (GraphException e) {
+            throw new OperatorException(e);
+        } catch (FileNotFoundException e) {
+            throw new OperatorException("'file' not found");
+        }
+    }
+
+    @Override
+    public void doExecute(ProgressMonitor pm) {
+        processor.executeGraph(graphContext, ProgressMonitor.NULL);
+    }
+
+    @Override
+    public void dispose() {
+        graphContext.dispose();
+        super.dispose();
+    }
+
+    private void setDummyTargetProduct() {
+        final Product product = new Product("dummy", "dummy", 2, 2);
+        product.addBand("dummy", ProductData.TYPE_INT8);
+        setTargetProduct(product);
+    }
+
+    public static class Spi extends OperatorSpi {
+        public Spi() {
+            super(StoredGraphOp.class);
+        }
+    }
+
+}

--- a/snap-gpf/src/main/resources/META-INF/services/org.esa.snap.core.gpf.OperatorSpi
+++ b/snap-gpf/src/main/resources/META-INF/services/org.esa.snap.core.gpf.OperatorSpi
@@ -10,3 +10,4 @@ org.esa.snap.core.gpf.common.BandMathsOp$Spi
 org.esa.snap.core.gpf.common.reproject.ReprojectionOp$Spi
 org.esa.snap.core.gpf.common.resample.ResamplingOp$Spi
 org.esa.snap.core.gpf.common.ImportVectorOp$Spi
+org.esa.snap.core.gpf.graph.StoredGraphOp$Spi

--- a/snap-smart-configurator/src/main/java/org/esa/snap/smart/configurator/SNAPEngineBenchmarkOperatorProvider.java
+++ b/snap-smart-configurator/src/main/java/org/esa/snap/smart/configurator/SNAPEngineBenchmarkOperatorProvider.java
@@ -27,7 +27,7 @@ public class SNAPEngineBenchmarkOperatorProvider extends BenchmarkOperatorProvid
 
     @Override
     protected List<String> getBenchmarkOperatorAliases() {
-        String[] snapEngineBenchmarkOperatorNames = {"GLCM", "Reproject", "KMeansClusterAnalysis", "Write"};
+        String[] snapEngineBenchmarkOperatorNames = {"GLCM", "Reproject", "KMeansClusterAnalysis", "Write", "StoredGraph"};
         return Arrays.asList(snapEngineBenchmarkOperatorNames);
     }
 }


### PR DESCRIPTION
Related to https://senbox.atlassian.net/projects/SNAP/issues/SNAP-371 : Smart installer does not allow execution of user-defined graphs.

A new operator has been created to execute a graph and it has been added to BenchmarkOperatorAliases. The user only has to select as parameter the file graph.

As a graph can have more than one output, we create a dummy target product (as it is made in StatisticsOp).
