### PR TITLE
Set target product preferred tile size equals to determined tile size.

### DIFF
--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/WriteOp.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/WriteOp.java
@@ -263,6 +263,7 @@ public class WriteOp extends Operator {
         for (int i = 0; i < writableBands.size(); i++) {
             Band writableBand = writableBands.get(i);
             Dimension tileSize = determineTileSize(writableBand);
+
             tileSizes[i] = tileSize;
             int tileCountX = MathUtils.ceilInt(writableBand.getRasterWidth() / (double) tileSize.width);
             tileCountsX[i] = tileCountX;
@@ -273,6 +274,11 @@ public class WriteOp extends Operator {
                 writeEntireTileRows = false;        // don't writeEntireTileRows for multisize bands
             }
         }
+
+        if(writeEntireTileRows && writableBands.size() > 0) {
+            targetProduct.setPreferredTileSize(tileSizes[0]);
+        }
+
     }
 
     private Dimension determineTileSize(Band band) {


### PR DESCRIPTION
There is a problem when trying to write some bands of a multisize product. If the selected bands have all the same size but this size is different from the scene size, the writeEntireTileRows will be used but there is a conflict with the tile size (the target preferred tile size will be the same that in the source product but this one is different from the size calculated (in determineTileSize) for the writableBands).