### PR TITLE
[SNAP-650] add progress indicator to gpt

### DIFF
--- a/ceres-core/src/main/java/com/bc/ceres/core/PrintWriterConciseProgressMonitor.java
+++ b/ceres-core/src/main/java/com/bc/ceres/core/PrintWriterConciseProgressMonitor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017 Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
+package com.bc.ceres.core;
+
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+
+/**
+ * A progress monitor which prints progress using a {@link PrintWriter}.
+ */
+public class PrintWriterConciseProgressMonitor extends PrintWriterProgressMonitor {
+
+    public PrintWriterConciseProgressMonitor(OutputStream output) {
+        super(new PrintWriter(output, true));
+    }
+
+    @Override
+    protected void printStartMessage(PrintWriter pw) {
+        pw.print(MessageFormat.format("{0}", getMessage()));
+        pw.flush();
+    }
+
+    @Override
+    protected void printWorkedMessage(PrintWriter pw) {
+        pw.print(MessageFormat.format("{0}%", getPercentageWorked()));
+        pw.flush();
+    }
+
+    @Override
+    protected void printMinorWorkedMessage(PrintWriter pw) {
+        pw.print(".");
+        pw.flush();
+    }
+
+    @Override
+    protected void printDoneMessage(PrintWriter pw) {
+        pw.println(" done.");
+        pw.flush();
+    }
+}

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/main/DefaultCommandLineContext.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/main/DefaultCommandLineContext.java
@@ -16,6 +16,8 @@
 
 package org.esa.snap.core.gpf.main;
 
+import com.bc.ceres.core.PrintWriterConciseProgressMonitor;
+import com.bc.ceres.core.PrintWriterProgressMonitor;
 import com.bc.ceres.core.ProgressMonitor;
 import org.esa.snap.core.dataio.ProductIO;
 import org.esa.snap.core.dataio.ProductReader;
@@ -63,7 +65,7 @@ class DefaultCommandLineContext implements CommandLineContext {
 
     @Override
     public void writeProduct(Product targetProduct, String filePath, String formatName, boolean clearCacheAfterRowWrite) throws IOException {
-        GPF.writeProduct(targetProduct, new File(filePath), formatName, clearCacheAfterRowWrite, false, ProgressMonitor.NULL);
+        GPF.writeProduct(targetProduct, new File(filePath), formatName, clearCacheAfterRowWrite, false, new PrintWriterConciseProgressMonitor(System.out));
     }
 
     @Override
@@ -81,7 +83,7 @@ class DefaultCommandLineContext implements CommandLineContext {
         if (observer != null) {
             processor.addObserver(observer);
         }
-        processor.executeGraph(graph, ProgressMonitor.NULL);
+        processor.executeGraph(graph, new PrintWriterConciseProgressMonitor(System.out));
     }
 
     @Override


### PR DESCRIPTION
Adds progress monitor for gpt operator and graph processing
Added PrintWriterConciseProgressMonitor to avoid being too verbal on the output
It adds minor ticks to show some progress for heavy processing jobs:
....10%....20%....