### PR TITLE
[SNAP-817] Land-Sea-Mask fails when source has a pixel based geo-coding

### DIFF
--- a/snap-raster/src/main/java/org/esa/snap/raster/gpf/masks/CreateLandMaskOp.java
+++ b/snap-raster/src/main/java/org/esa/snap/raster/gpf/masks/CreateLandMaskOp.java
@@ -118,7 +118,9 @@ public class CreateLandMaskOp extends Operator {
             final Band[] bands = sourceProduct.getBands();
             final List<String> bandNameList = new ArrayList<>(sourceProduct.getNumBands());
             for (Band band : bands) {
-                bandNameList.add(band.getName());
+                if(!targetProduct.containsBand(band.getName())) {
+                    bandNameList.add(band.getName());
+                }
             }
             sourceBandNames = bandNameList.toArray(new String[bandNameList.size()]);
         }

--- a/snap-raster/src/test/java/org/esa/snap/raster/gpf/masks/CreateLandMaskOpTest.java
+++ b/snap-raster/src/test/java/org/esa/snap/raster/gpf/masks/CreateLandMaskOpTest.java
@@ -1,0 +1,37 @@
+package org.esa.snap.raster.gpf.masks;
+
+import org.esa.snap.core.datamodel.Product;
+import org.esa.snap.core.gpf.GPF;
+import org.esa.snap.core.util.DummyProductBuilder;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Marco Peters
+ */
+public class CreateLandMaskOpTest {
+
+    @Test
+    public void testWithPixelGeoCodingProduct() throws Exception {
+        final Product source = new DummyProductBuilder()
+                .size(DummyProductBuilder.Size.SMALL)
+                .gc(DummyProductBuilder.GC.PER_PIXEL)
+                .gp(DummyProductBuilder.GP.NULL_MERIDIAN)
+                .sizeOcc(DummyProductBuilder.SizeOcc.SINGLE)
+                .gcOcc(DummyProductBuilder.GCOcc.UNIQUE)
+                .create();
+
+        Map<String, Object> params = new HashMap<>();
+        Product target = GPF.createProduct("Land-Sea-Mask", params, source);
+        assertNotNull(target);
+        List<String> bandNames = Arrays.asList(target.getBandNames());
+        assertTrue(bandNames.containsAll(Arrays.asList("band_a", "band_b", "band_c", "latitude", "longitude")));
+        assertNotNull(target.getSceneGeoCoding());
+    }
+}


### PR DESCRIPTION
@jun--lu can check this please?
I hope it breaks nothing else