### PR TITLE
Add a flag to allow for Geoid-height on NaN points in DEM generation

### DIFF
--- a/snap-dem/src/main/java/org/esa/snap/dem/gpf/AddElevationOp.java
+++ b/snap-dem/src/main/java/org/esa/snap/dem/gpf/AddElevationOp.java
@@ -78,6 +78,9 @@ public final class AddElevationOp extends Operator {
     @Parameter(description = "The elevation band name.", defaultValue = "elevation", label = "Elevation Band Name")
     private String elevationBandName = "elevation";
 
+    @Parameter(description = "Fill nodata values by geod values", defaultValue = "false", label = "Fill Nodata with Geod")
+    private Boolean fillWithGeoid = false;
+
     private boolean isElevationModelAvailable = false;
     private ElevationModel dem = null;
     private double demNoDataValue = 0; // no data value for DEM
@@ -176,7 +179,7 @@ public final class AddElevationOp extends Operator {
 
             final boolean valid = DEMFactory.getLocalDEM(
                     dem, demNoDataValue, demResamplingMethod, tileGeoRef, x0, y0, w, h,
-                    sourceProduct, true, localDEM);
+                    sourceProduct, !fillWithGeoid, localDEM);
 
             if (!valid)
                 return;


### PR DESCRIPTION
This allows to avoid NaN values at places where the DEM is NaN, by using Geoid heights instead. This is very favorable for coastal regions. It is a switch that does not affect the default. 

I will also update the UI (snap-desktop), see pull-request.