### PR TITLE
scaling should be applied first if needed

### DIFF
--- a/snap-raster/src/main/java/org/esa/snap/raster/gpf/ConvertDataTypeOp.java
+++ b/snap-raster/src/main/java/org/esa/snap/raster/gpf/ConvertDataTypeOp.java
@@ -264,6 +264,10 @@ public class ConvertDataTypeOp extends Operator {
             double srcValue;
             for (int i = 0; i < numElem; ++i) {
                 srcValue = srcData.getElemDoubleAt(i);
+                if(sourceBand.isScalingApplied()) {
+                    srcValue = sourceBand.scale(srcValue);
+                }
+
                 if (srcNoDataValue.equals(srcValue)) {
                     dstData.setElemDoubleAt(i, destNoDataValue);
                 } else {


### PR DESCRIPTION
If a product scales the data like Landsat-8, the convertDataType will process the wrong data values unless scaling is applied first.

Test: Convert a Landsat-8 product from UInt16 to UInt8