### PR TITLE
allow execute gpt anywhere and error if failed

### DIFF
--- a/snap-engine-kit/src/main/assembly/bin/gpt.sh
+++ b/snap-engine-kit/src/main/assembly/bin/gpt.sh
@@ -1,2 +1,4 @@
-#!/bin/sh
-java -cp "../modules/*:../lib/*" -Dsnap.mainClass=org.esa.snap.core.gpf.main.GPT -Dsnap.home="../" -Xmx4G org.esa.snap.runtime.Launcher "$@"
+#!/bin/sh -x
+set -e
+CUR_DIR="$( cd -P "$( dirname "$0" )" && pwd )"
+java -cp "$CUR_DIR/modules/*:$CUR_DIR/lib/*" -Dsnap.mainClass=org.esa.snap.core.gpf.main.GPT -Dsnap.home="$HOME/.snap" -Djava.net.useSystemProxies=true -Xmx4G org.esa.snap.runtime.Launcher "$@"


### PR DESCRIPTION
* add chmod +x on gpt.sh
* allow to execute gpt not only from its 'bin' directory
* set snap.home=$HOME/.snap 
* add useSystemProxies=true (I guess won't affect system without proxies.)
