### PR TITLE
FIX-95 Include causing exception in thrown exception

### DIFF
--- a/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/gpf/OperatorUtils.java
+++ b/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/gpf/OperatorUtils.java
@@ -429,7 +429,7 @@ public final class OperatorUtils {
         }
 
         System.out.println(message);
-        throw new OperatorException(message);
+        throw new OperatorException(message, e);
     }
 
     /**


### PR DESCRIPTION
Include the causing exception on the thrown exception.

This seems like the smallest change to resolve #95  much else starts to need changes at the call sites. 