### PR TITLE
Add a null check to DefaultNetCdfWriter

### DIFF
--- a/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/DefaultNetCdfWriter.java
+++ b/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/DefaultNetCdfWriter.java
@@ -109,7 +109,10 @@ public class DefaultNetCdfWriter extends AbstractProductWriter {
     }
 
     private boolean shallWriteVariable(String variableName) {
-        final NVariable variable = writeable.findVariable(variableName);
+        if (this.writeable == null) {
+            return false;
+        }
+        final NVariable variable = this.writeable.findVariable(variableName);
         return variable != null;
     }
 


### PR DESCRIPTION
I called writeRasterData method of Band. but DefaultNetCdfWriter throw NullPointerException.
I think DefaultNetCdfWriter need to add writeable null check logic.

thank you.