### PR TITLE
Fix ESA url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Coverity Scan Status](https://scan.coverity.com/projects/7219/badge.svg)](https://scan.coverity.com/projects/senbox-org-snap-engine)
 
 SNAP is the common software platform for the three Sentinel Toolboxes which are developed 
-by the [European Space Agency (ESA)](www.esa.org) for the scientific exploitation 
+by the [European Space Agency (ESA)](https://www.esa.org) for the scientific exploitation 
 of the [Sentinel-1, Sentinel-2 and Sentinel-3 missions](https://sentinel.esa.int/web/sentinel/home).
 
 The project page of SNAP and the sentinel toolboxes can be found at http://step.esa.int. There you will find a tutorial about the usage of the application, a [forum](http://forum.step.esa.int/) where you can ask questions and lots of other interesting things.


### PR DESCRIPTION
Missing protocol off the front of the ESA link at the top of the readme. This adds it so the link works.