### PR TITLE
make gpf commandline public

### DIFF
--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/main/CommandLineContext.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/main/CommandLineContext.java
@@ -23,10 +23,12 @@ import org.esa.snap.core.gpf.graph.GraphException;
 import org.esa.snap.core.gpf.graph.GraphProcessingObserver;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.util.Map;
 import java.util.logging.Logger;
 
-interface CommandLineContext extends SimpleFileSystem {
+public interface CommandLineContext extends SimpleFileSystem {
     Product readProduct(String productFilepath) throws IOException;
 
     void writeProduct(Product targetProduct, String filePath, String formatName, boolean clearCacheAfterRowWrite) throws IOException;

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/main/CommandLineTool.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/main/CommandLineTool.java
@@ -76,13 +76,13 @@ import java.util.logging.Logger;
  * The common command-line tool for the GPF.
  * For usage, see {@link org/esa/snap/core/gpf/main/CommandLineUsage.txt}.
  */
-class CommandLineTool implements GraphProcessingObserver {
+public class CommandLineTool implements GraphProcessingObserver {
 
     static final String TOOL_NAME = "gpt";
-    static final String DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-    static final SimpleDateFormat DATETIME_FORMAT = new SimpleDateFormat(DATETIME_PATTERN, Locale.ENGLISH);
-    static final String READ_OP_ID_PREFIX = "ReadOp@";
-    public static final String WRITE_OP_ID_PREFIX = "WriteOp@";
+    private static final String DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+    private static final SimpleDateFormat DATETIME_FORMAT = new SimpleDateFormat(DATETIME_PATTERN, Locale.ENGLISH);
+    private static final String READ_OP_ID_PREFIX = "ReadOp@";
+    private static final String WRITE_OP_ID_PREFIX = "WriteOp@";
 
     private final CommandLineContext commandLineContext;
     //    private final VelocityContext velocityContext;
@@ -92,7 +92,7 @@ class CommandLineTool implements GraphProcessingObserver {
     /**
      * Constructs a new tool.
      */
-    CommandLineTool() {
+    public CommandLineTool() {
         this(new DefaultCommandLineContext());
     }
 
@@ -101,12 +101,12 @@ class CommandLineTool implements GraphProcessingObserver {
      *
      * @param commandLineContext The context used to run the tool.
      */
-    CommandLineTool(CommandLineContext commandLineContext) {
+    public CommandLineTool(CommandLineContext commandLineContext) {
         this.commandLineContext = commandLineContext;
         this.metadataResourceEngine = new MetadataResourceEngine(commandLineContext);
     }
 
-    void run(String... args) throws Exception {
+    public void run(String... args) throws Exception {
         boolean stackTraceDumpEnabled = CommandLineArgs.isStackTraceDumpEnabled(args);
         try {
             commandLineArgs = CommandLineArgs.parseArgs(args);


### PR DESCRIPTION
Should fix #107

Make enough bits public to be able to call it from another java application.

