### PR TITLE
Snap 1060 downsampling fails

### DIFF
--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/AggregatedOpImage.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/AggregatedOpImage.java
@@ -123,10 +123,10 @@ class AggregatedOpImage extends GeometricOpImage {
     @Override
     protected Rectangle forwardMapRect(Rectangle rectangle, int i) {
         //calculates the dest rectangle for a source rectangle
-        final int x = (int) (rectangle.getX() * (1 / scaleX) - offsetX);
-        final int y = (int) (rectangle.getY() * (1 / scaleY) - offsetY);
-        final int width = (int) Math.ceil(rectangle.getWidth() * (1 / scaleX));
-        final int height = (int) Math.ceil(rectangle.getHeight() * (1 / scaleY));
+        final int x = (int) Math.floor(rectangle.getX() * (1 / scaleX) - offsetX);
+        final int y = (int) Math.floor(rectangle.getY() * (1 / scaleY) - offsetY);
+        final int width = (int) Math.ceil((rectangle.getX() + rectangle.getWidth()) * (1 / scaleX) - offsetX) - x;
+        final int height = (int) Math.ceil((rectangle.getY() + rectangle.getHeight()) * (1 / scaleY) - offsetY) - y;
         return new Rectangle(x, y, width, height);
     }
 
@@ -144,10 +144,10 @@ class AggregatedOpImage extends GeometricOpImage {
     @Override
     protected Rectangle backwardMapRect(Rectangle rectangle, int i) {
         //calculates the source rectangle for a dest rectangle
-        final int x = (int) (offsetX + rectangle.getX() * scaleX);
-        final int y = (int) (offsetY + rectangle.getY() * scaleY);
-        final int width = (int) Math.ceil(rectangle.getWidth() * scaleX);
-        final int height = (int) Math.ceil(rectangle.getHeight() * scaleY);
+        final int x = (int) Math.floor(offsetX + rectangle.getX() * scaleX);
+        final int y = (int) Math.floor(offsetY + rectangle.getY() * scaleY);
+        final int width = (int) Math.ceil(offsetX + (rectangle.getX() + rectangle.getWidth()) * scaleX) - x;
+        final int height = (int) Math.ceil(offsetY + (rectangle.getY() + rectangle.getHeight()) * scaleY) - y;
         return new Rectangle(x, y, width, height);
     }
 

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/DoubleDataAggregator.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/DoubleDataAggregator.java
@@ -110,6 +110,9 @@ public abstract class DoubleDataAggregator implements Aggregator {
                 }
                 srcIndexY += srcScanlineStride;
             }
+            if (Double.isInfinite(minValue)) {
+                minValue = getNoDataValue();
+            }
             setDstData(dstPos, minValue);
         }
     }
@@ -129,6 +132,9 @@ public abstract class DoubleDataAggregator implements Aggregator {
                     }
                 }
                 srcIndexY += srcScanlineStride;
+            }
+            if (Double.isInfinite(maxValue)) {
+                maxValue = getNoDataValue();
             }
             setDstData(dstPos, maxValue);
         }

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/Resample.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/Resample.java
@@ -294,31 +294,4 @@ public class Resample {
 
     }
 
-    private class NewImage extends PlanarImage {
-
-
-        @Override
-        public Raster getTile(int i, int i1) {
-            return null;
-        }
-    }
-
-    private class NewOp extends GeometricOpImage {
-
-
-        public NewOp(Vector sources, ImageLayout layout, Map configuration, boolean cobbleSources, BorderExtender extender, Interpolation interp) {
-            super(sources, layout, configuration, cobbleSources, extender, interp);
-        }
-
-        @Override
-        protected Rectangle forwardMapRect(Rectangle rectangle, int i) {
-            return null;
-        }
-
-        @Override
-        protected Rectangle backwardMapRect(Rectangle rectangle, int i) {
-            return null;
-        }
-    }
-
 }

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/ResampleUtils.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/ResampleUtils.java
@@ -1,0 +1,69 @@
+package org.esa.snap.core.gpf.common.resample;
+
+import org.esa.snap.core.datamodel.Band;
+import org.esa.snap.core.datamodel.Product;
+import org.esa.snap.core.datamodel.ProductNodeGroup;
+import org.esa.snap.core.datamodel.RasterDataNode;
+import org.esa.snap.core.datamodel.TiePointGrid;
+import org.opengis.referencing.operation.MathTransform;
+
+import java.awt.geom.AffineTransform;
+import java.util.ArrayList;
+
+public class ResampleUtils {
+
+    public static boolean allGridsAlignAtUpperLeftPixel(Product product) {
+        MathTransform mapTransform = product.getSceneGeoCoding().getImageToMapTransform();
+        if (!(mapTransform instanceof AffineTransform)) {
+            return false;
+        }
+        AffineTransform affineTransform = (AffineTransform) mapTransform;
+        ProductNodeGroup<Band> bandGroup = product.getBandGroup();
+        ProductNodeGroup<TiePointGrid> tiePointGridGroup = product.getTiePointGridGroup();
+        return allGridsAlignAtUpperLeftPixelCenter(affineTransform, bandGroup, tiePointGridGroup) ||
+                allGridsAlignAtUpperLeftPixelCorner(affineTransform, bandGroup, tiePointGridGroup);
+    }
+
+    static boolean allGridsAlignAtUpperLeftPixelCorner(AffineTransform mapTransform,
+                                                               ProductNodeGroup<Band> bandGroup,
+                                                               ProductNodeGroup<TiePointGrid> tiePointGridGroup) {
+        return allGridsAlignAtUpperLeft(mapTransform, bandGroup, tiePointGridGroup, 0.0);
+    }
+
+    static boolean allGridsAlignAtUpperLeftPixelCenter(AffineTransform mapTransform,
+                                                               ProductNodeGroup<Band> bandGroup,
+                                                               ProductNodeGroup<TiePointGrid> tiePointGridGroup) {
+        return allGridsAlignAtUpperLeft(mapTransform, bandGroup, tiePointGridGroup, 0.5);
+    }
+
+    private static boolean allGridsAlignAtUpperLeft(AffineTransform mapTransform,
+                                                    ProductNodeGroup<Band> bandGroup,
+                                                    ProductNodeGroup<TiePointGrid> tiePointGridGroup,
+                                                    double offset) {
+        ArrayList<AffineTransform> transforms = new ArrayList<>();
+        transforms.add(mapTransform);
+        double centerX = mapTransform.getTranslateX() + offset * mapTransform.getScaleX();
+        double centerY = mapTransform.getTranslateY() + offset * mapTransform.getScaleY();
+        return allGridsAlignAtUpperLeft(transforms, centerX, centerY, bandGroup, offset) &&
+                allGridsAlignAtUpperLeft(transforms, centerX, centerY, tiePointGridGroup, offset);
+    }
+
+    //package local for testing
+    @SuppressWarnings("WeakerAccess")
+    static boolean allGridsAlignAtUpperLeft(ArrayList<AffineTransform> transforms, double centerX, double centerY,
+                                            ProductNodeGroup group, double offset) {
+        for (int i = 0; i < group.getNodeCount(); i++) {
+            RasterDataNode rasterDataNode = (RasterDataNode) group.get(i);
+            AffineTransform transform = rasterDataNode.getImageToModelTransform();
+            if (!transforms.contains(transform)) {
+                if (Math.abs(centerX - (transform.getTranslateX() + offset * transform.getScaleX())) > 1e-8 ||
+                        Math.abs(centerY - (transform.getTranslateY() + offset * transform.getScaleY())) > 1e-8) {
+                    return false;
+                }
+                transforms.add(transform);
+            }
+        }
+        return true;
+    }
+
+}

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/ResamplingOp.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/ResamplingOp.java
@@ -361,15 +361,15 @@ public class ResamplingOp extends Operator {
                 if (replacedNoData) {
                     dataBufferType = DataBuffer.TYPE_DOUBLE;
                 }
-                if ((sourceTransform.getScaleX() <= referenceImageToModelTransform.getScaleX() ||
-                        sourceTransform.getScaleY() <= referenceImageToModelTransform.getScaleY())) {
+                if ((sourceTransform.getScaleX() >= referenceImageToModelTransform.getScaleX() ||
+                        sourceTransform.getScaleY() >= referenceImageToModelTransform.getScaleY())) {
                     targetImage = createInterpolatedImage(sourceImage, sourceBand.getNoDataValue(),
                             sourceBand.getImageToModelTransform(), sourceBand.isFlagBand() || sourceBand.isIndexBand());
-                } else if ((sourceTransform.getScaleX() >= referenceImageToModelTransform.getScaleX() ||
-                        sourceTransform.getScaleY() >= referenceImageToModelTransform.getScaleY())) {
+                } else if ((sourceTransform.getScaleX() <= referenceImageToModelTransform.getScaleX() ||
+                        sourceTransform.getScaleY() <= referenceImageToModelTransform.getScaleY())) {
                     targetImage = createAggregatedImage(sourceImage, dataBufferType, sourceBand.getNoDataValue(),
                             sourceBand.isFlagBand(), referenceMultiLevelModel);
-                } else if (sourceTransform.getScaleX() > referenceImageToModelTransform.getScaleX()) {
+                } else if (sourceTransform.getScaleX() < referenceImageToModelTransform.getScaleX()) {
                     AffineTransform intermediateTransform = new AffineTransform(
                             referenceImageToModelTransform.getScaleX(), referenceImageToModelTransform.getShearX(), sourceTransform.getShearY(),
                             sourceTransform.getScaleY(), referenceImageToModelTransform.getTranslateX(), sourceTransform.getTranslateY());
@@ -380,7 +380,7 @@ public class ResamplingOp extends Operator {
                     );
                     targetImage = createInterpolatedImage(targetImage, sourceBand.getNoDataValue(),
                             intermediateTransform, sourceBand.isFlagBand() || sourceBand.isIndexBand());
-                } else if (sourceTransform.getScaleY() > referenceImageToModelTransform.getScaleY()) {
+                } else if (sourceTransform.getScaleY() < referenceImageToModelTransform.getScaleY()) {
                     AffineTransform intermediateTransform = new AffineTransform(
                             sourceTransform.getScaleX(), sourceTransform.getShearX(), referenceImageToModelTransform.getShearY(),
                             referenceImageToModelTransform.getScaleY(), sourceTransform.getTranslateX(), referenceImageToModelTransform.getTranslateY());

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/ResamplingOp.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/ResamplingOp.java
@@ -571,8 +571,8 @@ public class ResamplingOp extends Operator {
             final MathTransform imageToMapTransform = sourceProduct.getSceneGeoCoding().getImageToMapTransform();
             if (imageToMapTransform instanceof AffineTransform) {
                 AffineTransform mapTransform = (AffineTransform) imageToMapTransform;
-                referenceWidth = (int) (sourceProduct.getSceneRasterWidth() * Math.abs(mapTransform.getScaleX()) / targetResolution);
-                referenceHeight = (int) (sourceProduct.getSceneRasterHeight() * Math.abs(mapTransform.getScaleY()) / targetResolution);
+                referenceWidth = (int) Math.ceil(sourceProduct.getSceneRasterWidth() * Math.abs(mapTransform.getScaleX()) / targetResolution);
+                referenceHeight = (int) Math.ceil(sourceProduct.getSceneRasterHeight() * Math.abs(mapTransform.getScaleY()) / targetResolution);
                 referenceImageToModelTransform = new AffineTransform(targetResolution, 0, 0, -targetResolution,
                                                                      mapTransform.getTranslateX(), mapTransform.getTranslateY());
                 referenceMultiLevelModel = new DefaultMultiLevelModel(referenceImageToModelTransform, referenceWidth, referenceHeight);

--- a/snap-gpf/src/test/java/org/esa/snap/core/gpf/common/resample/AggregatedOpImageTest.java
+++ b/snap-gpf/src/test/java/org/esa/snap/core/gpf/common/resample/AggregatedOpImageTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.media.jai.ImageLayout;
+import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.NoninvertibleTransformException;
 import java.awt.image.BufferedImage;
@@ -199,6 +200,51 @@ public class AggregatedOpImageTest {
         test_first(ProductData.TYPE_UINT16);
     }
 
+    @Test
+    public void testCreateBackwardMapRect_integer_offset() throws NoninvertibleTransformException {
+        final Band sourceBand = createSourceBand(ProductData.TYPE_FLOAT64, 2);
+        final int dataBufferType = ImageManager.getDataBufferType(ProductData.TYPE_FLOAT64);
+        final ImageLayout imageLayout = createImageLayout(sourceBand);
+
+        final AggregatedOpImage image = new AggregatedOpImage(sourceBand.getSourceImage(), imageLayout,
+                sourceBand.getNoDataValue(),
+                AggregationType.Mean, dataBufferType,
+                sourceBand.getImageToModelTransform(),
+                referenceBand.getImageToModelTransform());
+
+        Rectangle destRect = new Rectangle(-1, -1, 1, 1);
+        Rectangle srcRect = image.backwardMapRect(destRect, 0);
+
+        assertNotNull(srcRect);
+        assertEquals(-1, srcRect.x);
+        assertEquals(-1, srcRect.y);
+        assertEquals(2, srcRect.width);
+        assertEquals(2, srcRect.height);
+    }
+
+    @Test
+    public void testCreateBackwardMapRect_float_offset() throws NoninvertibleTransformException {
+        final Band sourceBand = createSourceBand(ProductData.TYPE_FLOAT64, 3);
+        final int dataBufferType = ImageManager.getDataBufferType(ProductData.TYPE_FLOAT64);
+        final ImageLayout imageLayout = createImageLayout(sourceBand);
+
+        final AggregatedOpImage image = new AggregatedOpImage(sourceBand.getSourceImage(), imageLayout,
+                sourceBand.getNoDataValue(),
+                AggregationType.Mean, dataBufferType,
+                sourceBand.getImageToModelTransform(),
+                referenceBand.getImageToModelTransform());
+
+        Rectangle destRect = new Rectangle(-1, -1, 1, 1);
+        Rectangle srcRect = image.backwardMapRect(destRect, 0);
+
+        assertNotNull(srcRect);
+        assertEquals(-2, srcRect.x);
+        assertEquals(-2, srcRect.y);
+        assertEquals(3, srcRect.width);
+        assertEquals(3, srcRect.height);
+
+    }
+
     private void test_mean(int dataType) throws NoninvertibleTransformException {
         final Band sourceBand = createSourceBand(dataType);
         final int dataBufferType = ImageManager.getDataBufferType(dataType);
@@ -325,10 +371,14 @@ public class AggregatedOpImageTest {
     }
 
     private Band createSourceBand(int dataType) {
+        return createSourceBand(dataType, 2);
+    }
+
+    private Band createSourceBand(int dataType, float translate) {
         final Product sourceProduct = new Product("dummy", "dummy", 4, 4);
         final Band sourceBand = sourceProduct.addBand("sourceBand", "((X - 0.5) * 4) + (Y - 0.5)", dataType);
         sourceBand.setNoDataValue(117);
-        sourceBand.setImageToModelTransform(new AffineTransform(2, 0, 0, 2, 2, 2));
+        sourceBand.setImageToModelTransform(new AffineTransform(2, 0, 0, 2, translate, translate));
         return sourceBand;
     }
 

--- a/snap-gpf/src/test/java/org/esa/snap/core/gpf/common/resample/ResampleUtilsTest.java
+++ b/snap-gpf/src/test/java/org/esa/snap/core/gpf/common/resample/ResampleUtilsTest.java
@@ -1,0 +1,52 @@
+package org.esa.snap.core.gpf.common.resample;
+
+import org.esa.snap.core.datamodel.Band;
+import org.esa.snap.core.datamodel.ProductData;
+import org.esa.snap.core.datamodel.ProductNodeGroup;
+import org.junit.Test;
+
+import java.awt.geom.AffineTransform;
+import java.util.ArrayList;
+
+import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.*;
+
+public class ResampleUtilsTest {
+
+    @Test
+    public void testAllGridsAlignAtUpperLeft() {
+        Band band1 = new Band("x1", ProductData.TYPE_INT8, 2, 2);
+        band1.setImageToModelTransform(new AffineTransform(30.0, 0.0, 0.0, -30.0, 5000.0, 7000.0));
+        Band band2 = new Band("x2", ProductData.TYPE_INT8, 2, 2);
+        band2.setImageToModelTransform(new AffineTransform(15.0, 0.0, 0.0, -15.0, 5000.0, 7000.0));
+        Band band3 = new Band("x3", ProductData.TYPE_INT8, 2, 2);
+        band3.setImageToModelTransform(new AffineTransform(30.0, 0.0, 0.0, -30.0, 4985.0, 7015.0));
+        Band band4 = new Band("x4", ProductData.TYPE_INT8, 2, 2);
+        band4.setImageToModelTransform(new AffineTransform(20.0, 0.0, 0.0, -20.0, 4990.0, 7010.0));
+
+        ProductNodeGroup<Band> alignedAtCorner = new ProductNodeGroup<>("alignedAtCorner");
+        alignedAtCorner.add(band1);
+        alignedAtCorner.add(band2);
+
+        assertTrue(ResampleUtils.allGridsAlignAtUpperLeft(new ArrayList<>(), 5000.0, 7000.0, alignedAtCorner, 0.0));
+        assertFalse(ResampleUtils.allGridsAlignAtUpperLeft(new ArrayList<>(), 5000.0, 7000.0, alignedAtCorner, 0.5));
+        assertFalse(ResampleUtils.allGridsAlignAtUpperLeft(new ArrayList<>(), 5000.0, 7000.0, alignedAtCorner, 1.0));
+
+        ProductNodeGroup<Band> alignedAtCenter = new ProductNodeGroup<>("alignedAtCenter");
+        alignedAtCenter.add(band3);
+        alignedAtCenter.add(band4);
+
+        assertFalse(ResampleUtils.allGridsAlignAtUpperLeft(new ArrayList<>(), 5000.0, 7000.0, alignedAtCenter, 0.0));
+        assertTrue(ResampleUtils.allGridsAlignAtUpperLeft(new ArrayList<>(), 5000.0, 7000.0, alignedAtCenter, 0.5));
+        assertFalse(ResampleUtils.allGridsAlignAtUpperLeft(new ArrayList<>(), 5000.0, 7000.0, alignedAtCenter, 1.0));
+
+        ProductNodeGroup<Band> incompatible = new ProductNodeGroup<>("incompatible");
+        incompatible.add(band2);
+        incompatible.add(band3);
+
+        assertFalse(ResampleUtils.allGridsAlignAtUpperLeft(new ArrayList<>(), 5000.0, 7000.0, incompatible, 0.0));
+        assertFalse(ResampleUtils.allGridsAlignAtUpperLeft(new ArrayList<>(), 5000.0, 7000.0, incompatible, 0.5));
+        assertFalse(ResampleUtils.allGridsAlignAtUpperLeft(new ArrayList<>(), 5000.0, 7000.0, incompatible, 1.0));
+    }
+
+}


### PR DESCRIPTION
This is not only a fix for SNAP-1060 ( https://senbox.atlassian.net/browse/SNAP-1060 ), but it also includes 

- a fix for setting no-data-values during aggregation
- a check whether all grids align at the corner or the center of the upper left pixel. This is considered during resampling, so the relationship between grids is preserved and unnecessary re-computations of existing grids are prevented
- the change that the determination whether to sample up or down is not made based on image dimensions but on base of image resolution