### PR TITLE
SEADAS-001a (PropertyPane: use JScrollPanel instead of JPanel)

### DIFF
--- a/ceres-ui/src/main/java/com/bc/ceres/swing/binding/PropertyPane.java
+++ b/ceres-ui/src/main/java/com/bc/ceres/swing/binding/PropertyPane.java
@@ -35,7 +35,17 @@ import static com.bc.ceres.swing.TableLayout.*;
  * is set, it will be used as label, otherwise a label is derived from the {@code name} property.
  * <p>Properties, whose attribute "enabled" is set to {@code false}, will be shown in disabled state.
  * Properties, whose attribute "visible" is set to {@code false}, will not be shown at all.
+ *
+ * @author Brockmann Consult
+ * @author Daniel Knowles
+ * @version $Revision$ $Date$
+ * @
  */
+// JAN2018 - Daniel Knowles - Added method to return property pane as a JScrollPane
+
+
+
+
 public class PropertyPane {
 
     private final BindingContext bindingContext;
@@ -102,6 +112,31 @@ public class PropertyPane {
         panel.add(new JPanel());
         return panel;
     }
+
+
+
+
+
+
+
+    /*
+     * Returns a JScrollPane version of the property pane
+     * Note: This method was added to fix an issue where a layer editor view with too many properties wouldn't fit onto
+     *       some monitor screens.
+     * @author Daniel Knowles
+     * @since Jan 2019
+     */
+
+    public JScrollPane createJScrollPanel() {
+
+        JPanel panel = createPanel();
+        panel.setMinimumSize(panel.getPreferredSize());
+        final JScrollPane scrollPane = new JScrollPane(panel);
+
+        return scrollPane;
+    }
+
+
 
     private boolean isInvisible(PropertyDescriptor descriptor) {
         return Boolean.FALSE.equals(descriptor.getAttribute("visible")) || descriptor.isDeprecated();


### PR DESCRIPTION
This adds a method to get the PropertyPane return panel as a JScrollPanel instead of a JPanel.  This is important as some of the future tools modifications such as Graticule and Color Bar Layer contain too many parameters to fit in a standard non-scrolling window.