### PR TITLE
Fixes for reading Sentinel-1 products from AWS

### DIFF
--- a/ceres-binding/src/main/java/com/bc/ceres/binding/ConverterRegistry.java
+++ b/ceres-binding/src/main/java/com/bc/ceres/binding/ConverterRegistry.java
@@ -41,8 +41,10 @@ import java.awt.Font;
 import java.awt.geom.AffineTransform;
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -55,9 +57,11 @@ import java.util.regex.Pattern;
 public class ConverterRegistry {
 
     private Map<Class<?>, Converter<?>> converters;
+    private List<PathConverter> pathConverters;
 
     private ConverterRegistry() {
         converters = new HashMap<>(33);
+        pathConverters = new ArrayList<PathConverter>();
 
         // Primitive types
         setConverter(Boolean.TYPE, new BooleanConverter());
@@ -140,6 +144,32 @@ public class ConverterRegistry {
         return (Converter<T>) converter;
     }
     
+    /**
+     * Registers a {@code PathConverter} to allow the conversion of user-defined
+     * textual representations of {@code Path} to object instances.
+     * 
+     * @param converter The converter.
+     */
+    public void registerPathConverter(PathConverter converter) {
+        pathConverters.add(converter);
+    }
+
+    /**
+     * Returns the {@code PathConverter} that matches the given textual 
+     * representation of a {@code Path}.
+     * 
+     * @param text
+     * @return The Path converter, May be {@code null}.
+     */
+    public PathConverter getPathConverter(String text) {
+        for (PathConverter converter : pathConverters) {
+            if (converter.matches(text)) {
+                return converter;
+            }
+        }
+        return null;
+    }
+
     // Initialization on demand holder idiom
     private static class Holder {
         private static final ConverterRegistry instance = new ConverterRegistry();

--- a/ceres-binding/src/main/java/com/bc/ceres/binding/PathConverter.java
+++ b/ceres-binding/src/main/java/com/bc/ceres/binding/PathConverter.java
@@ -1,0 +1,29 @@
+package com.bc.ceres.binding;
+
+import java.nio.file.Path;
+
+/**
+ * A {@code PathConverter} provides a strategy to convert from plain text
+ * to a {@code Path} object instance.
+ *
+ * @author Alvaro Huarte
+ */
+public interface PathConverter {
+    /**
+     * Tells whether or not this instance supports the given textual 
+     * representation of a {@code Path}.
+     * 
+     * @param text The textual representation of the Path.
+     * @return True if this instance supports the textual representation.
+     */
+    boolean matches(String text);
+
+    /**
+     * Converts a Path from its plain text representation to 
+     * a {@code Path} object instance.
+     *
+     * @param text The textual representation of the Path.
+     * @return The converted Path.
+     */
+    Path parse(String text);
+}

--- a/ceres-core/src/main/java/com/bc/ceres/core/VirtualDir.java
+++ b/ceres-core/src/main/java/com/bc/ceres/core/VirtualDir.java
@@ -235,7 +235,7 @@ public abstract class VirtualDir {
             if (path.endsWith(".gz")) {
                 return new GZIPInputStream(new BufferedInputStream(new FileInputStream(getFile(path))));
             }
-            return new BufferedInputStream(new FileInputStream(getFile(path)));
+            return new BufferedInputStream(Files.newInputStream(getFile(path).toPath()));
         }
 
         @Override
@@ -255,7 +255,7 @@ public abstract class VirtualDir {
 
         @Override
         public boolean exists(String path) {
-            File child = new File(dir, path);
+            File child = dir.toPath().resolve(path).toFile();
             return child.exists();
         }
 

--- a/snap-core/src/main/java/org/esa/snap/core/dataio/rgb/ImageProductReader.java
+++ b/snap-core/src/main/java/org/esa/snap/core/dataio/rgb/ImageProductReader.java
@@ -16,6 +16,7 @@
 package org.esa.snap.core.dataio.rgb;
 
 import com.bc.ceres.core.ProgressMonitor;
+import com.sun.media.jai.codec.SeekableStream;
 import org.esa.snap.core.dataio.AbstractProductReader;
 import org.esa.snap.core.datamodel.Band;
 import org.esa.snap.core.datamodel.Product;
@@ -38,6 +39,8 @@ import java.awt.image.ColorModel;
 import java.awt.image.SampleModel;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import javax.media.jai.operator.StreamDescriptor;
 
 /**
  * @author Norman Fomferra
@@ -69,7 +72,16 @@ public class ImageProductReader extends AbstractProductReader {
     @Override
     protected Product readProductNodesImpl() throws IOException {
         File file = ImageProductReaderPlugIn.getFile(getInput());
-        sourceImage = FileLoadDescriptor.create(file.getPath(), null, true, null);
+        File temp = new File(file.getAbsolutePath());
+        
+        // Does this image come from a virtual file?
+        if (!temp.exists()) {
+            SeekableStream inputStream = SeekableStream.wrapInputStream(Files.newInputStream(file.toPath()), true);
+            sourceImage = StreamDescriptor.create(inputStream, null, null);
+        }
+        else {
+            sourceImage = FileLoadDescriptor.create(file.getPath(), null, true, null);
+        }
         ColorModel colorModel = sourceImage.getColorModel();
         ColorSpace colorSpace = colorModel.getColorSpace();
 

--- a/snap-virtual-file-system/pom.xml
+++ b/snap-virtual-file-system/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>ceres-jai</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.esa.snap</groupId>
+            <artifactId>ceres-binding</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>

--- a/snap-virtual-file-system/src/main/java/org/esa/snap/vfs/activator/VFSPlugInActivator.java
+++ b/snap-virtual-file-system/src/main/java/org/esa/snap/vfs/activator/VFSPlugInActivator.java
@@ -1,7 +1,10 @@
 package org.esa.snap.vfs.activator;
 
+import com.bc.ceres.binding.ConverterRegistry;
+
 import org.esa.snap.runtime.Activator;
 import org.esa.snap.vfs.VFS;
+import org.esa.snap.vfs.converters.VFSPathConverter;
 import org.esa.snap.vfs.preferences.model.VFSRemoteFileRepositoriesController;
 import org.esa.snap.vfs.preferences.model.VFSRemoteFileRepository;
 
@@ -36,6 +39,7 @@ public class VFSPlugInActivator implements Activator {
             Path configFile = VFSRemoteFileRepositoriesController.getDefaultConfigFilePath();
             List<VFSRemoteFileRepository> vfsRepositories = VFSRemoteFileRepositoriesController.getVFSRemoteFileRepositories(configFile);
             VFS.getInstance().initRemoteInstalledProviders(vfsRepositories);
+            ConverterRegistry.getInstance().registerPathConverter(new VFSPathConverter());
         } catch (Exception exception) {
             logger.log(Level.SEVERE, "Unable to start the VFS Plugin. Reason: " + exception.getMessage(), exception);
         }

--- a/snap-virtual-file-system/src/main/java/org/esa/snap/vfs/converters/VFSPathConverter.java
+++ b/snap-virtual-file-system/src/main/java/org/esa/snap/vfs/converters/VFSPathConverter.java
@@ -1,0 +1,27 @@
+package org.esa.snap.vfs.converters;
+
+import com.bc.ceres.binding.PathConverter;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+
+import org.esa.snap.vfs.VFS;
+
+/**
+ * Implements a {@code PathConverter} for VFS.
+ *
+ * @author Alvaro Huarte
+ */
+public class VFSPathConverter implements PathConverter {
+
+    @Override
+    public boolean matches(String text) {
+        Path path = VFS.getInstance().get(text);
+        return path != null && !path.getFileSystem().getClass().equals(FileSystems.getDefault().getClass());
+    }
+
+    @Override
+    public Path parse(String text) {
+        return VFS.getInstance().get(text);
+    }
+}


### PR DESCRIPTION
This commit does some changes to allow to SNAP to load Sentinel-1 products from the [S1 AWS bucket](https://sentinel-s1-l1c.s3.amazonaws.com).

There is a commit related in [s1tbx ](https://github.com/senbox-org/s1tbx/pull/64) repo to properly work.
It is based from 7.x branch.

You could execute an ESA GPT graph in an EC2 instance using the S1 AWS bucket as input, but without any downloading if you use the "eu-central-1" (Frankfurt) region:
```
gpt \
  ./settings/gpt/s1_to_avh+ivh-geotiff.xml \
  -Pinput1=AWS_S1L1C_vfs:/GRD/2019/6/6/IW/DV/S1B_IW_…_5C_6ECF/manifest.safe \
  -Poutput1=./output/tests/result-S1.tif
```