### PR TITLE
Fixing category discrepancies

### DIFF
--- a/ceres-core/src/main/java/com/bc/ceres/nbmgen/NbCodeGenTool.java
+++ b/ceres-core/src/main/java/com/bc/ceres/nbmgen/NbCodeGenTool.java
@@ -190,7 +190,7 @@ public class NbCodeGenTool implements CeresModuleProject.Processor {
             parentToPath.put("Graphs", "Menu/Graphs");  // ???
             parentToPath.put("help", "Menu/Help");  // ???
             parentToPath.put("processing", "Menu/Processing");  // ???
-            parentToPath.put("processing.preProcessing", "Menu/Processing/Pre-Processing");  // ???
+            parentToPath.put("processing.preProcessing", "Menu/Processing/Preprocessing");  // ???
             parentToPath.put("processing.thematicLand", "Menu/Processing/Thematic Land Processing");  // ???
             parentToPath.put("processing.thematicWater", "Menu/Processing/Thematic Water Processing");  // ???
             parentToPath.put("processing.imageAnalysis", "Menu/Processing/Image Analysis");  // ???

--- a/snap-binning/src/main/java/org/esa/snap/binning/operator/BinningOp.java
+++ b/snap-binning/src/main/java/org/esa/snap/binning/operator/BinningOp.java
@@ -103,7 +103,7 @@ todo - address the following BinningOp requirements (nf, 2012-03-09)
  */
 @SuppressWarnings("UnusedDeclaration")
 @OperatorMetadata(alias = "Binning",
-        category = "Raster/Geometric",
+        category = "Raster/Geometric Operations",
         version = "1.0",
         authors = "Norman Fomferra, Marco Zühlke, Thomas Storm",
         copyright = "(c) 2014 by Brockmann Consult GmbH",

--- a/snap-collocation/src/main/java/org/esa/snap/collocation/CollocateOp.java
+++ b/snap-collocation/src/main/java/org/esa/snap/collocation/CollocateOp.java
@@ -64,7 +64,7 @@ import static java.text.MessageFormat.*;
  * @since BEAM 4.1
  */
 @OperatorMetadata(alias = "Collocate",
-        category = "Raster/Geometric",
+        category = "Raster/Geometric Operations",
         version = "1.2",
         authors = "Ralf Quast, Norman Fomferra",
         copyright = "(c) 2007-2011 by Brockmann Consult",

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/MosaicOp.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/MosaicOp.java
@@ -75,7 +75,7 @@ import java.util.Map;
  * @since BEAM 4.7
  */
 @OperatorMetadata(alias = "Mosaic",
-                  category = "Raster/Geometric",
+                  category = "Raster/Geometric Operations",
                   version = "1.0",
                   authors = "Marco Peters, Ralf Quast, Marco Zühlke",
                   copyright = "(c) 2009 by Brockmann Consult",

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/SubsetOp.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/SubsetOp.java
@@ -74,7 +74,7 @@ import static java.lang.Math.*;
  * @since BEAM 4.9
  */
 @OperatorMetadata(alias = "Subset",
-        category = "Raster/Geometric",
+        category = "Raster",
         authors = "Marco Zuehlke, Norman Fomferra, Marco Peters",
         version = "1.2",
         copyright = "(c) 2011 by Brockmann Consult",

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/reproject/ReprojectionOp.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/reproject/ReprojectionOp.java
@@ -133,7 +133,7 @@ import java.util.HashMap;
  * @since BEAM 4.7
  */
 @OperatorMetadata(alias = "Reproject",
-        category = "Raster/Geometric",
+        category = "Raster/Geometric Operations",
         version = "1.0",
         authors = "Marco Zühlke, Marco Peters, Ralf Quast, Norman Fomferra",
         copyright = "(c) 2009 by Brockmann Consult",

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/ResamplingOp.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/resample/ResamplingOp.java
@@ -64,7 +64,7 @@ import java.util.logging.Logger;
  * @author Tonio Fincke
  */
 @OperatorMetadata(alias = "Resample",
-        category = "Raster/Geometric",
+        category = "Raster/Geometric Operations",
         version = "2.0",
         authors = "Tonio Fincke",
         copyright = "(c) 2016 by Brockmann Consult",


### PR DESCRIPTION
I am trying to uniform the Graph Builder menus with the main window menus, to do so the category in the operator descriptor must be the same as the one in the main menu. 