### PR TITLE
Added copying flagBands to the ProductUtils.copyProductNodes method.

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/util/ProductUtils.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/ProductUtils.java
@@ -1198,6 +1198,7 @@ public class ProductUtils {
         ProductUtils.copyMetadata(sourceProduct, targetProduct);
         ProductUtils.copyTiePointGrids(sourceProduct, targetProduct);
         ProductUtils.copyFlagCodings(sourceProduct, targetProduct);
+        ProductUtils.copyFlagBands(sourceProduct, targetProduct, true); 
         ProductUtils.copyGeoCoding(sourceProduct, targetProduct);
         ProductUtils.copyMasks(sourceProduct, targetProduct);
         ProductUtils.copyVectorData(sourceProduct, targetProduct);


### PR DESCRIPTION
Fix SNAP-1232