### PR TITLE
fix

### DIFF
--- a/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/metadata/profiles/hdfeos/HdfEosGeocodingPart.java
+++ b/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/metadata/profiles/hdfeos/HdfEosGeocodingPart.java
@@ -97,13 +97,9 @@ public class HdfEosGeocodingPart extends ProfilePartIO {
                 final MathTransformFactory transformFactory = ReferencingFactoryFinder.getMathTransformFactory(null);
                 ParameterValueGroup parameters;
                 try {
-                    parameters = transformFactory.getDefaultParameters("OGC:Sinusoidal");
-                } catch (NoSuchIdentifierException ignore) {
-                    try {
-                        parameters = transformFactory.getDefaultParameters("Sinusoidal");
-                    } catch (NoSuchIdentifierException ignore2) {
-                        return;
-                    }
+                    parameters = transformFactory.getDefaultParameters("Sinusoidal");
+                } catch (NoSuchIdentifierException ignore2) {
+                    return;
                 }
                 double semi_major;
                 double semi_minor;

--- a/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/metadata/profiles/hdfeos/HdfEosGeocodingPart.java
+++ b/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/metadata/profiles/hdfeos/HdfEosGeocodingPart.java
@@ -35,7 +35,7 @@ import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.MathTransformFactory;
 import org.opengis.referencing.operation.TransformException;
 
-import java.awt.Rectangle;
+import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.io.IOException;
 import java.util.List;
@@ -99,7 +99,11 @@ public class HdfEosGeocodingPart extends ProfilePartIO {
                 try {
                     parameters = transformFactory.getDefaultParameters("OGC:Sinusoidal");
                 } catch (NoSuchIdentifierException ignore) {
-                    return;
+                    try {
+                        parameters = transformFactory.getDefaultParameters("Sinusoidal");
+                    } catch (NoSuchIdentifierException ignore2) {
+                        return;
+                    }
                 }
                 double semi_major;
                 double semi_minor;

--- a/snap-netcdf/src/test/java/org/esa/snap/dataio/netcdf/metadata/profiles/hdfeos/HdfEosGeocodingPartTest.java
+++ b/snap-netcdf/src/test/java/org/esa/snap/dataio/netcdf/metadata/profiles/hdfeos/HdfEosGeocodingPartTest.java
@@ -1,0 +1,18 @@
+package org.esa.snap.dataio.netcdf.metadata.profiles.hdfeos;
+
+import org.esa.snap.core.datamodel.Product;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertNotNull;
+
+public class HdfEosGeocodingPartTest {
+
+    @Test
+    public void testAttachGeoCoding() {
+        Product product = new Product("dummy", "type", 4800, 4800);
+        double[] pp = {6371007.181, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        HdfEosGeocodingPart.attachGeoCoding(product, -3335851.559, 6671703.118, -2223901.039333, 5559752.598333, "GCTP_SNSOID", pp);
+        assertNotNull(product.getSceneGeoCoding());
+    }
+
+}


### PR DESCRIPTION
The line
parameters = transformFactory.getDefaultParameters("OGC:Sinusoidal");
throws an exception, but I think we should keep it for backwards compatibility.