### PR TITLE
Snap 999 geocoding border

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -759,6 +759,7 @@
                     <version>1.19</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.5.1</version>
                     <configuration>

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/FXYGeoCoding.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/FXYGeoCoding.java
@@ -150,7 +150,10 @@ public class FXYGeoCoding extends AbstractGeoCoding {
     @Override
     public GeoPos getGeoPos(final PixelPos pixelPos, GeoPos geoPos) {
         if (geoPos == null) {
-            geoPos = new GeoPos(0.0f, 0.0f);
+            // TODO: 20.02.2020 SE fixed -- Marked GETGEOPOS why?
+//            geoPos = new GeoPos(0.0f, 0.0f);
+            // TODO: 20.02.2020 SE fixed -- Marked GETGEOPOS ... instead that way?
+            geoPos = new GeoPos();
         }
         final double x = _pixelOffsetX + _pixelSizeX * pixelPos.x;
         final double y = _pixelOffsetY + _pixelSizeY * pixelPos.y;

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/GeoPos.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/GeoPos.java
@@ -49,6 +49,8 @@ public class GeoPos {
      * Constructs a new geo-position with latitude and longitude set to zero.
      */
     public GeoPos() {
+        // TODO: 20.02.2020 SE fixed -- Marked GETGEOPOS setInvalid instead?
+        setInvalid();
     }
 
     /**

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/GeoPos.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/GeoPos.java
@@ -49,8 +49,6 @@ public class GeoPos {
      * Constructs a new geo-position with latitude and longitude set to zero.
      */
     public GeoPos() {
-        // TODO: 20.02.2020 SE fixed -- Marked GETGEOPOS setInvalid instead?
-        setInvalid();
     }
 
     /**

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/PixelGeoCoding.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/PixelGeoCoding.java
@@ -817,8 +817,8 @@ public class PixelGeoCoding extends AbstractGeoCoding implements BasicPixelGeoCo
             final double pipoY = pixelPos.getY();
 
             // TODO: 20.02.2020 SE fixed -- Marked GETGEOPOS abort condition
-            int x0 = (int) Math.floor(pipoX) - pipoX == rasterWidth ? 1 : 0;
-            int y0 = (int) Math.floor(pipoY) - pipoY == rasterHeight ? 1 : 0;
+            int x0 = (int) Math.floor(pipoX) - (pipoX == rasterWidth ? 1 : 0);
+            int y0 = (int) Math.floor(pipoY) - (pipoY == rasterHeight ? 1 : 0);
             if (x0 >= 0 && x0 < rasterWidth && y0 >= 0 && y0 < rasterHeight) {
                 if (fractionAccuracy) { // implies tiling mode
                     if (x0 > 0 && pipoX - x0 < 0.5f || x0 == rasterWidth - 1) {

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/PixelGeoCoding2.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/PixelGeoCoding2.java
@@ -243,9 +243,10 @@ class PixelGeoCoding2 extends AbstractGeoCoding implements BasicPixelGeoCoding {
         }
         geoPos.setInvalid();
         if (pixelPos.isValid()) {
+            // TODO: 20.02.2020 SE fixed -- Marked GETGEOPOS abort condition
             if (pixelPosIsInsideRasterWH(pixelPos)) {
-                int x0 = (int) Math.floor(pixelPos.getX());
-                int y0 = (int) Math.floor(pixelPos.getY());
+                int x0 = (int) Math.floor(pixelPos.getX()) - pixelPos.x == rasterW ? 1 : 0;
+                int y0 = (int) Math.floor(pixelPos.getY()) - pixelPos.y == rasterH ? 1 : 0;
 
                 if (fractionAccuracy && !isInPixelCenter(pixelPos)) {
                     if (x0 > 0 && pixelPos.x - x0 < 0.5 || x0 == rasterW - 1) {
@@ -285,7 +286,8 @@ class PixelGeoCoding2 extends AbstractGeoCoding implements BasicPixelGeoCoding {
     private boolean pixelPosIsInsideRasterWH(PixelPos pixelPos) {
         final double x = pixelPos.x;
         final double y = pixelPos.y;
-        return x >= 0 && x < rasterW && y >= 0 && y < rasterH;
+        // TODO: 20.02.2020 SE fixed -- Marked GETGEOPOS abort condition
+        return x >= 0 && x <= rasterW && y >= 0 && y <= rasterH;
     }
 
     public int getRasterWidth() {

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/PixelGeoCoding2.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/PixelGeoCoding2.java
@@ -553,8 +553,8 @@ class PixelGeoCoding2 extends AbstractGeoCoding implements BasicPixelGeoCoding {
 
         @Override
         public void getGeoPosDouble(int x0, int y0, double wx, double wy, GeoPos geoPos) {
-            geoPos.lon = interpolate(x0, y0, wx, wy, lonData, LAT);
-            geoPos.lat = interpolate(x0, y0, wx, wy, latData, LON);
+            geoPos.lon = interpolate(x0, y0, wx, wy, lonData, LON);
+            geoPos.lat = interpolate(x0, y0, wx, wy, latData, LAT);
         }
 
         private double interpolate(int x0, int y0, double wx, double wy, double[] data, int latLon) {

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/PixelGeoCoding2.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/PixelGeoCoding2.java
@@ -245,8 +245,8 @@ class PixelGeoCoding2 extends AbstractGeoCoding implements BasicPixelGeoCoding {
         if (pixelPos.isValid()) {
             // TODO: 20.02.2020 SE fixed -- Marked GETGEOPOS abort condition
             if (pixelPosIsInsideRasterWH(pixelPos)) {
-                int x0 = (int) Math.floor(pixelPos.getX()) - pixelPos.x == rasterW ? 1 : 0;
-                int y0 = (int) Math.floor(pixelPos.getY()) - pixelPos.y == rasterH ? 1 : 0;
+                int x0 = (int) Math.floor(pixelPos.getX()) - (pixelPos.x == rasterW ? 1 : 0);
+                int y0 = (int) Math.floor(pixelPos.getY()) - (pixelPos.y == rasterH ? 1 : 0);
 
                 if (fractionAccuracy && !isInPixelCenter(pixelPos)) {
                     if (x0 > 0 && pixelPos.x - x0 < 0.5 || x0 == rasterW - 1) {

--- a/snap-core/src/test/java/org/esa/snap/core/util/GeoUtilsTest.java
+++ b/snap-core/src/test/java/org/esa/snap/core/util/GeoUtilsTest.java
@@ -521,8 +521,8 @@ public class GeoUtilsTest {
                 return geoPos;
             }
 
-            final int x = (int) Math.floor(pipoX) - pipoX == width ? 1 : 0;
-            final int y = (int) Math.floor(pipoY) - pipoY == height ? 1 : 0;
+            final int x = (int) Math.floor(pipoX) - (pipoX == width ? 1 : 0);
+            final int y = (int) Math.floor(pipoY) - (pipoY == height ? 1 : 0);
 
             final int index = y * width + x;
             geoPos.lon = longitudes[index];

--- a/snap-core/src/test/java/org/esa/snap/core/util/GeoUtilsTest.java
+++ b/snap-core/src/test/java/org/esa/snap/core/util/GeoUtilsTest.java
@@ -18,7 +18,7 @@ public class GeoUtilsTest {
     public void testCreatePixelBoundaryFromRect_usePixelCenter_false() {
         final boolean usePixelCenter = false;
         final PixelPos[] rectBoundary = GeoUtils.createPixelBoundaryFromRect(new Rectangle(2, 3, 15, 20), 7,
-                usePixelCenter);
+                                                                             usePixelCenter);
         assertEquals(12, rectBoundary.length);
         assertEquals(new PixelPos(2, 3), rectBoundary[0]);
         assertEquals(new PixelPos(9, 3), rectBoundary[1]);
@@ -364,7 +364,7 @@ public class GeoUtilsTest {
     public void testCreateGeoBoundaryPaths() {
         final Product slstrProduct = createSLSTR();
 
-        final GeneralPath[] geoBoundary = GeoUtils.createGeoBoundaryPaths(slstrProduct, null,5, false);
+        final GeneralPath[] geoBoundary = GeoUtils.createGeoBoundaryPaths(slstrProduct, null, 5, false);
         assertEquals(1, geoBoundary.length);
 
         assertEquals(1, geoBoundary[0].getWindingRule());
@@ -407,7 +407,7 @@ public class GeoUtilsTest {
     public void testCreateGeoBoundaryPaths_default_on_center() {
         final Product slstrProduct = createSLSTR();
 
-        final GeneralPath[] geoBoundary = GeoUtils.createGeoBoundaryPaths(slstrProduct, null,5);
+        final GeneralPath[] geoBoundary = GeoUtils.createGeoBoundaryPaths(slstrProduct, null, 5);
         assertEquals(1, geoBoundary.length);
 
         assertEquals(1, geoBoundary[0].getWindingRule());
@@ -514,11 +514,15 @@ public class GeoUtilsTest {
             }
             geoPos.setInvalid();
 
-            final int x = (int) Math.floor(pixelPos.x);
-            final int y = (int) Math.floor(pixelPos.y);
-            if (x < 0 || x >= width || y < 0 || y >= height) {
+            final double pipoX = pixelPos.x;
+            final double pipoY = pixelPos.y;
+            // TODO: 20.02.2020 SE fixed -- Marked GETGEOPOS abort condition
+            if (pipoX < 0 || pipoX > width || pipoY < 0 || pipoY > height) {
                 return geoPos;
             }
+
+            final int x = (int) Math.floor(pipoX) - pipoX == width ? 1 : 0;
+            final int y = (int) Math.floor(pipoY) - pipoY == height ? 1 : 0;
 
             final int index = y * width + x;
             geoPos.lon = longitudes[index];


### PR DESCRIPTION
Defines that the maximum pixel position in width and the maximum pixel position in height, as well as 0 in x and y pixel position, is a valid part of the product.
With these changes, tie point based geo-coding or other pixel-based geo-codings behave the same way like math based geo-codings such as UTM.
This harmonized behavior is necessary to calculate valid envelopes for product reprojection with geotools.
