### PR TITLE
Geotiff reader corrections to open the stream to the tiff image later

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/image/AbstractMatrixMosaicSubsetMultiLevelSource.java
+++ b/snap-core/src/main/java/org/esa/snap/core/image/AbstractMatrixMosaicSubsetMultiLevelSource.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
  */
 public abstract class AbstractMatrixMosaicSubsetMultiLevelSource extends AbstractMosaicSubsetMultiLevelSource {
 
-    private final MosaicMatrix mosaicMatrix;
+    protected final MosaicMatrix mosaicMatrix;
 
     protected AbstractMatrixMosaicSubsetMultiLevelSource(MosaicMatrix mosaicMatrix, Rectangle imageMatrixReadBounds, Dimension tileSize, GeoCoding geoCoding) {
         this(mosaicMatrix, imageMatrixReadBounds, tileSize, Product.findImageToModelTransform(geoCoding));

--- a/snap-core/src/main/java/org/esa/snap/core/util/ImageUtils.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/ImageUtils.java
@@ -21,6 +21,7 @@ package org.esa.snap.core.util;
 import org.esa.snap.core.datamodel.CrsGeoCoding;
 import org.esa.snap.core.datamodel.ProductData;
 import org.esa.snap.core.image.ImageManager;
+import org.esa.snap.core.util.jai.JAIUtils;
 import org.esa.snap.core.util.jai.SingleBandedSampleModel;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -111,6 +112,21 @@ public class ImageUtils {
             return regionRasterSize;
         }
         return new Dimension(defaultSceneRasterWidth, defaultSceneRasterHeight);
+    }
+
+    public static Dimension computePreferredMosaicTileSize(int imageWidth, int imageHeight, int granularity) {
+        Dimension dimension = JAIUtils.computePreferredTileSize(imageWidth, imageHeight, granularity);
+        int maximumRowTileCount = 10;
+        int maximumColumnTileCount = 10;
+        int mosaicTileWidth = imageWidth / maximumColumnTileCount;
+        int mosaicTileHeight = imageHeight / maximumRowTileCount;
+        if (mosaicTileWidth < dimension.width) {
+            mosaicTileWidth = dimension.width; // increase the mosaic tile width
+        }
+        if (mosaicTileHeight < dimension.height) {
+            mosaicTileHeight = dimension.height; // increase the mosaic tile height
+        }
+        return new Dimension(mosaicTileWidth, mosaicTileHeight);
     }
 
     public static int computeTileCount(int imageSize, int tileSize) {

--- a/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffMatrixCell.java
+++ b/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffMatrixCell.java
@@ -2,38 +2,65 @@ package org.esa.snap.dataio.geotiff;
 
 import org.esa.snap.core.image.MosaicMatrix;
 
+import java.awt.image.Raster;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+
 /**
  * Created by jcoravu on 7/1/2020.
  */
-public class GeoTiffMatrixCell implements MosaicMatrix.MatrixCell {
+public class GeoTiffMatrixCell implements MosaicMatrix.MatrixCell, GeoTiffRasterRegion, Closeable {
 
     private final int cellWidth;
     private final int cellHeight;
-    private final GeoTiffImageReader geoTiffImageReader;
     private final int dataBufferType;
 
-    public GeoTiffMatrixCell(int cellWidth, int cellHeight, GeoTiffImageReader geoTiffImageReader, int dataBufferType) {
+    private Path imageParentPath;
+    private String imageRelativeFilePath;
+    private GeoTiffImageReader geoTiffImageReader;
+
+    public GeoTiffMatrixCell(int cellWidth, int cellHeight, int dataBufferType, Path imageParentPath, String imageRelativeFilePath) {
+        if (imageParentPath == null) {
+            throw new NullPointerException("The image path is null.");
+        }
         this.cellWidth = cellWidth;
         this.cellHeight = cellHeight;
-        this.geoTiffImageReader = geoTiffImageReader;
         this.dataBufferType = dataBufferType;
+        this.imageParentPath = imageParentPath;
+        this.imageRelativeFilePath = imageRelativeFilePath;
     }
 
     @Override
     public int getCellWidth() {
-        return cellWidth;
+        return this.cellWidth;
     }
 
     @Override
     public int getCellHeight() {
-        return cellHeight;
+        return this.cellHeight;
     }
 
     public int getDataBufferType() {
-        return dataBufferType;
+        return this.dataBufferType;
     }
 
-    public GeoTiffImageReader getGeoTiffImageReader() {
-        return geoTiffImageReader;
+    @Override
+    public Raster readRect(boolean isGlobalShifted180, int sourceOffsetX, int sourceOffsetY, int sourceStepX, int sourceStepY,
+                           int destOffsetX, int destOffsetY, int destWidth, int destHeight)
+                           throws Exception {
+
+        if (this.geoTiffImageReader == null) {
+            this.geoTiffImageReader = GeoTiffImageReader.buildGeoTiffImageReader(this.imageParentPath, this.imageRelativeFilePath);
+        }
+        return this.geoTiffImageReader.readRect(isGlobalShifted180, sourceOffsetX, sourceOffsetY, sourceStepX, sourceStepY, destOffsetX, destOffsetY, destWidth, destHeight);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (this.geoTiffImageReader != null) {
+            this.geoTiffImageReader.close();
+            this.geoTiffImageReader = null;
+        }
     }
 }

--- a/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffMatrixMultiLevelSource.java
+++ b/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffMatrixMultiLevelSource.java
@@ -4,10 +4,12 @@ import org.esa.snap.core.datamodel.GeoCoding;
 import org.esa.snap.core.image.AbstractMatrixMosaicSubsetMultiLevelSource;
 import org.esa.snap.core.image.MosaicMatrix;
 import org.esa.snap.core.image.UncompressedTileOpImageCallback;
+import org.esa.snap.core.util.ImageUtils;
 
 import javax.media.jai.SourcelessOpImage;
 import java.awt.*;
 import java.awt.image.RenderedImage;
+import java.io.IOException;
 
 /**
  * Created by jcoravu on 7/1/2020.
@@ -16,6 +18,11 @@ public class GeoTiffMatrixMultiLevelSource extends AbstractMatrixMosaicSubsetMul
 
     private final int bandIndex;
     private final Double noDataValue;
+
+    public GeoTiffMatrixMultiLevelSource(MosaicMatrix spotBandMatrix, Rectangle imageMatrixReadBounds, int bandIndex, GeoCoding geoCoding, Double noDataValue) {
+        this(spotBandMatrix, imageMatrixReadBounds, ImageUtils.computePreferredMosaicTileSize(imageMatrixReadBounds.width, imageMatrixReadBounds.height, 1),
+             bandIndex, geoCoding, noDataValue);
+    }
 
     public GeoTiffMatrixMultiLevelSource(MosaicMatrix spotBandMatrix, Rectangle imageMatrixReadBounds, Dimension tileSize, int bandIndex, GeoCoding geoCoding, Double noDataValue) {
         super(spotBandMatrix, imageMatrixReadBounds, tileSize, geoCoding);
@@ -26,7 +33,7 @@ public class GeoTiffMatrixMultiLevelSource extends AbstractMatrixMosaicSubsetMul
 
     @Override
     public SourcelessOpImage buildTileOpImage(Rectangle imageCellReadBounds, int level, Point tileOffset, Dimension tileSize, GeoTiffMatrixCell geoTiffMatrixCell) {
-        return new GeoTiffTileOpImage(geoTiffMatrixCell.getGeoTiffImageReader(), getModel(), geoTiffMatrixCell.getDataBufferType(),
+        return new GeoTiffTileOpImage(geoTiffMatrixCell, getModel(), geoTiffMatrixCell.getDataBufferType(),
                                       this.bandIndex, imageCellReadBounds, tileSize, tileOffset, level, false);
     }
 
@@ -38,12 +45,29 @@ public class GeoTiffMatrixMultiLevelSource extends AbstractMatrixMosaicSubsetMul
         return buildUncompressedTileImages(level, imageCellReadBounds, this.tileSize, cellTranslateLevelOffsetX, cellTranslateLevelOffsetY, this, geoTiffMatrixCell);
     }
 
-
     @Override
     protected double[] getMosaicOpBackgroundValues() {
         if (this.noDataValue == null) {
             return super.getMosaicOpBackgroundValues();
         }
         return new double[] { this.noDataValue.doubleValue() };
+    }
+
+    @Override
+    public synchronized void reset() {
+        super.reset();
+
+        for (int rowIndex = 0; rowIndex < this.mosaicMatrix.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < this.mosaicMatrix.getColumnCount(); columnIndex++) {
+                GeoTiffMatrixCell geoTiffMatrixCell = (GeoTiffMatrixCell)this.mosaicMatrix.getCellAt(rowIndex, columnIndex);
+                synchronized (geoTiffMatrixCell) {
+                    try {
+                        geoTiffMatrixCell.close();
+                    } catch (IOException e) {
+                        // do nothing
+                    }
+                }
+            }
+        }
     }
 }

--- a/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffMultiLevelSource.java
+++ b/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffMultiLevelSource.java
@@ -40,7 +40,7 @@ public class GeoTiffMultiLevelSource extends AbstractMosaicSubsetMultiLevelSourc
     protected RenderedImage createImage(int level) {
         java.util.List<RenderedImage> tileImages = buildUncompressedTileImages(level, this.imageReadBounds, this.tileSize, 0.0f, 0.0f, this, null);
         if (tileImages.size() > 0) {
-            return buildMosaicOp(level, tileImages, false);
+            return buildMosaicOp(level, tileImages, true);
         }
         return null;
     }

--- a/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffProductReader.java
+++ b/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffProductReader.java
@@ -49,9 +49,11 @@ import org.esa.snap.core.datamodel.VirtualBand;
 import org.esa.snap.core.dataop.maptransf.Datum;
 import org.esa.snap.core.image.ImageManager;
 import org.esa.snap.core.subset.PixelSubsetRegion;
+import org.esa.snap.core.util.ImageUtils;
 import org.esa.snap.core.util.geotiff.EPSGCodes;
 import org.esa.snap.core.util.geotiff.GeoTIFFCodes;
 import org.esa.snap.core.util.io.FileUtils;
+import org.esa.snap.core.util.jai.JAIUtils;
 import org.esa.snap.dataio.ImageRegistryUtils;
 import org.esa.snap.dataio.geotiff.internal.GeoKeyEntry;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
@@ -280,8 +282,8 @@ public class GeoTiffProductReader extends AbstractProductReader {
             product.getMetadataRoot().setModified(false);
         }
 
-        Dimension preferredTileSize = computePreferredTiling(isGlobalShifted180, geoTiffImageReader, product.getSceneRasterSize());
-        product.setPreferredTileSize(preferredTileSize);
+        Dimension preferredMosaicTileSize = computePreferredMosaicTileSize(isGlobalShifted180, product.getSceneRasterSize());
+        product.setPreferredTileSize(preferredMosaicTileSize);
         product.setProductReader(this);
 
         GeoCoding bandGeoCoding = buildBandGeoCoding(product.getSceneGeoCoding(), productBounds.width, productBounds.height);
@@ -308,7 +310,7 @@ public class GeoTiffProductReader extends AbstractProductReader {
                         throw new IllegalStateException("The band index " + bandIndex + " must be < " + sampleModel.getNumBands() + ". The band name is '" + band.getName() + "'.");
                     }
                     int dataBufferType = ImageManager.getDataBufferType(band.getDataType()); // sampleModel.getDataType();
-                    GeoTiffMultiLevelSource multiLevelSource = new GeoTiffMultiLevelSource(geoTiffImageReader, dataBufferType, productBounds, preferredTileSize,
+                    GeoTiffMultiLevelSource multiLevelSource = new GeoTiffMultiLevelSource(geoTiffImageReader, dataBufferType, productBounds, preferredMosaicTileSize,
                                                                                            bandIndex, band.getGeoCoding(), isGlobalShifted180, noDataValue);
                     band.setSourceImage(new DefaultMultiLevelImage(multiLevelSource));
                 }
@@ -426,11 +428,11 @@ public class GeoTiffProductReader extends AbstractProductReader {
         return product;
     }
 
-    private static Dimension computePreferredTiling(boolean isGlobalShifted180, GeoTiffImageReader geoTiffImageReader, Dimension productSize) throws IOException {
+    private static Dimension computePreferredMosaicTileSize(boolean isGlobalShifted180, Dimension productSize) {
         if (isGlobalShifted180) {
             return new Dimension(productSize.width, productSize.height);
         }
-        return geoTiffImageReader.computePreferredTiling(productSize.width, productSize.height);
+        return ImageUtils.computePreferredMosaicTileSize(productSize.width, productSize.height, 1);
     }
 
     private static ImageInfo buildIndexedImageInfo(Product product, TIFFRenderedImage baseImage, Band band) {

--- a/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffRasterRegion.java
+++ b/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffRasterRegion.java
@@ -1,0 +1,13 @@
+package org.esa.snap.dataio.geotiff;
+
+import java.awt.image.Raster;
+
+/**
+ * Created by jcoravu on 24/3/2020.
+ */
+public interface GeoTiffRasterRegion {
+
+    public Raster readRect(boolean isGlobalShifted180, int sourceOffsetX, int sourceOffsetY, int sourceStepX, int sourceStepY,
+                           int destOffsetX, int destOffsetY, int destWidth, int destHeight)
+                           throws Exception;
+}

--- a/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffTileOpImage.java
+++ b/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/GeoTiffTileOpImage.java
@@ -7,18 +7,18 @@ import javax.media.jai.PlanarImage;
 import java.awt.*;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
-import java.io.IOException;
+import java.lang.ref.WeakReference;
 
 /**
  * Created by jcoravu on 22/11/2019.
  */
 public class GeoTiffTileOpImage extends AbstractSubsetTileOpImage {
 
-    private final GeoTiffImageReader geoTiffImageReader;
+    private final GeoTiffRasterRegion geoTiffImageReader;
     private final boolean isGlobalShifted180;
     private final int bandIndex;
 
-    public GeoTiffTileOpImage(GeoTiffImageReader geoTiffImageReader, MultiLevelModel imageMultiLevelModel, int dataBufferType, int bandIndex,
+    public GeoTiffTileOpImage(GeoTiffRasterRegion geoTiffImageReader, MultiLevelModel imageMultiLevelModel, int dataBufferType, int bandIndex,
                               Rectangle imageReadBounds, Dimension tileSize, Point tileOffset, int level, boolean isGlobalShifted180) {
 
         super(imageMultiLevelModel, dataBufferType, imageReadBounds, tileSize, tileOffset, level);
@@ -35,14 +35,16 @@ public class GeoTiffTileOpImage extends AbstractSubsetTileOpImage {
             Raster normalRasterData;
             try {
                 normalRasterData = readRasterData(normalBoundsIntersection.x, normalBoundsIntersection.y, normalBoundsIntersection.width, normalBoundsIntersection.height);
-            } catch (IOException ex) {
+            } catch (Exception ex) {
                 throw new IllegalStateException("Failed to read the data for level " + getLevel() + " and rectangle " + levelDestinationRectangle + ".", ex);
             }
             writeDataOnLevelRaster(normalRasterData, normalBoundsIntersection, levelDestinationRaster, levelDestinationRectangle, this.bandIndex);
+            WeakReference<Raster> referenceRaster = new WeakReference<>(normalRasterData);
+            referenceRaster.clear();
         }
     }
 
-    private Raster readRasterData(int destOffsetX, int destOffsetY, int destWidth, int destHeight) throws IOException {
+    private Raster readRasterData(int destOffsetX, int destOffsetY, int destWidth, int destHeight) throws Exception {
         int sourceStepX = 1;
         int sourceStepY = 1;
         int sourceOffsetX = sourceStepX * destOffsetX;


### PR DESCRIPTION
The new changes are used by readers from s2tbx (worldView, EsaWorldView, Spot Multi-Volume) which contain a matrix of tiff images for each band.
For these readers the image stream is opened when showing the band image in the UI to avoid memory exception in the TIFFImageReader.
In this case when loading the product from the disk the image streams are closed after reading the initialization data.