### PR TITLE
GDAL reader: optimisation for reading using blocks

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/image/AbstractSubsetTileOpImage.java
+++ b/snap-core/src/main/java/org/esa/snap/core/image/AbstractSubsetTileOpImage.java
@@ -24,7 +24,7 @@ public abstract class AbstractSubsetTileOpImage extends SingleBandedOpImage {
                 tileOffsetFromReadBounds, ResolutionLevel.create(imageMultiLevelModel, level));
     }
 
-    private AbstractSubsetTileOpImage(int dataBufferType, Rectangle imageReadBounds, Dimension tileSize, Dimension subTileSize,
+    protected AbstractSubsetTileOpImage(int dataBufferType, Rectangle imageReadBounds, Dimension tileSize, Dimension subTileSize,
                                       Point tileOffsetFromReadBounds, ResolutionLevel resolutionLevel) {
 
         super(dataBufferType, null, tileSize.width, tileSize.height, subTileSize, null, resolutionLevel);


### PR DESCRIPTION
Update lib-gdal for:
- eliminate dependencies between modules which uses GDAL Reader/Writer and lib-gdal module, by ensuring that GDAL libraries was initialized before using any GDAL Reader/Writer.
- report warning when unable to delete old GDAL drivers, instead of reporting error.
- fix issue with wrong name for method getIndexColorModel from ColorTable class driver.
- update solution with fetching process output for checking GDAL version command, by timing the process run time for prevent locking out SNAP when the process not responding.
Update GDAL Reader for:
- fix issues with reading GDAL products using blocks instead of rasters (issues with reading subsets not fully fixed at this time - temporary skip some tests).