### PR TITLE
Export xml bind

### DIFF
--- a/ceres-jai/pom.xml
+++ b/ceres-jai/pom.xml
@@ -91,6 +91,7 @@
                     <publicPackages>
                         <publicPackage>javax.media.jai.*</publicPackage>
                         <publicPackage>javax.imageio.*</publicPackage>
+                        <publicPackage>javax.xml.bind.*</publicPackage>
                         <publicPackage>com.sun.media.*</publicPackage>
                         <publicPackage>sun.awt.image.codec.*</publicPackage>
                         <publicPackage>com.sun.image.codec.jpeg.*</publicPackage>

--- a/snap-remote-products-repository/pom.xml
+++ b/snap-remote-products-repository/pom.xml
@@ -102,7 +102,6 @@
                         <publicPackage>org.esa.snap.remote.products.repository.*</publicPackage>
                         <publicPackage>org.apache.http.auth.*</publicPackage>
                         <publicPackage>org.codehaus.stax2.*</publicPackage>
-                        <publicPackage>javax.xml.bind.*</publicPackage>
                     </publicPackages>
                 </configuration>
             </plugin>


### PR DESCRIPTION
I got this error when running a build s2tbx-commons.
[INFO] Private classes referenced in module: [javax.xml.bind.ValidationEventHandler, javax.xml.bind.JAXBIntrospector, javax.xml.bind.annotation.XmlSeeAlso, javax.xml.bind.PropertyException, javax.xml.bind.attachment.AttachmentMarshaller, 
... 
javax.xml.bind.annotation.XmlElement, javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter]
[ERROR] Project depends on packages not accessible at runtime in module org.esa.snap:ceres-jai:jar:8.0.0-SNAPSHOT

With the changes in this PR it seems to be fixed.