### PR TITLE
using version 5.5.0 of jna library

### DIFF
--- a/lib-openjpeg/pom.xml
+++ b/lib-openjpeg/pom.xml
@@ -18,7 +18,7 @@
     <description>This modules provides the OpenJPEG codec for compressing and decompressing JPEG2000 files.</description>
 
     <properties>
-        <net.java.dev.jna.version>4.2.1</net.java.dev.jna.version>
+        <net.java.dev.jna.version>5.5.0</net.java.dev.jna.version>
     </properties>
 
     <dependencies>

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/CodestreamIndex.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/CodestreamIndex.java
@@ -59,10 +59,14 @@ public class CodestreamIndex extends Structure {
         this.tile_index = tile_index;
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends CodestreamIndex implements Structure.ByReference { }
-    public static class ByValue extends CodestreamIndex implements Structure.ByValue { }
+    public static class ByReference extends CodestreamIndex implements Structure.ByReference {
+    }
+
+    public static class ByValue extends CodestreamIndex implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/CodestreamInfo2.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/CodestreamInfo2.java
@@ -72,10 +72,14 @@ public class CodestreamInfo2 extends Structure {
         this.tile_info = tile_info;
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
-    
-    public static class ByReference extends CodestreamInfo2 implements Structure.ByReference { }
-    public static class ByValue extends CodestreamInfo2 implements Structure.ByValue { }
+
+    public static class ByReference extends CodestreamInfo2 implements Structure.ByReference {
+    }
+
+    public static class ByValue extends CodestreamInfo2 implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/CompressionCodec.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/CompressionCodec.java
@@ -69,7 +69,7 @@ public class CompressionCodec extends Structure {
     }
 
     @Override
-    protected List<?> getFieldOrder() {
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/CompressionHandler.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/CompressionHandler.java
@@ -2,7 +2,12 @@ package org.esa.snap.lib.openjpeg.dataio.struct;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.*;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.DestroyCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.EncodeCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.EndCompressCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.SetupEncoderCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.StartCompressCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.WriteTileCallback;
 
 import java.util.Arrays;
 import java.util.List;
@@ -61,10 +66,14 @@ public class CompressionHandler extends Structure {
         this.opj_setup_encoder = opj_setup_encoder;
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends CompressionHandler implements Structure.ByReference { }
-    public static class ByValue extends CompressionHandler implements Structure.ByValue { }
+    public static class ByReference extends CompressionHandler implements Structure.ByReference {
+    }
+
+    public static class ByValue extends CompressionHandler implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/CompressionParams.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/CompressionParams.java
@@ -233,14 +233,19 @@ public class CompressionParams extends Structure {
     public CompressionParams() {
         super();
     }
+
     public CompressionParams(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends CompressionParams implements Structure.ByReference { }
-    public static class ByValue extends CompressionParams implements Structure.ByValue { }
+    public static class ByReference extends CompressionParams implements Structure.ByReference {
+    }
+
+    public static class ByValue extends CompressionParams implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/DecompressCoreParams.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/DecompressCoreParams.java
@@ -101,10 +101,14 @@ public class DecompressCoreParams extends Structure {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends DecompressCoreParams implements Structure.ByReference { }
-    public static class ByValue extends DecompressCoreParams implements Structure.ByValue { }
+    public static class ByReference extends DecompressCoreParams implements Structure.ByReference {
+    }
+
+    public static class ByValue extends DecompressCoreParams implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/DecompressParams.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/DecompressParams.java
@@ -90,14 +90,19 @@ public class DecompressParams extends Structure {
         core = new DecompressCoreParams.ByReference();
         precision = new Precision.ByReference();
     }
+
     public DecompressParams(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends DecompressParams implements Structure.ByReference { }
-    public static class ByValue extends DecompressParams implements Structure.ByValue { }
+    public static class ByReference extends DecompressParams implements Structure.ByReference {
+    }
+
+    public static class ByValue extends DecompressParams implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/DecompressionCodec.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/DecompressionCodec.java
@@ -70,7 +70,7 @@ public class DecompressionCodec extends Structure {
     }
 
     @Override
-    protected List<?> getFieldOrder() {
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/DecompressionHandler.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/DecompressionHandler.java
@@ -2,7 +2,16 @@ package org.esa.snap.lib.openjpeg.dataio.struct;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.*;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.DecodeCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.DecodeTileDataCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.DestroyCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.EndDecompressCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.GetDecodedTileCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.ReadHeaderCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.ReadTileHeaderCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.SetDecodeAreaCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.SetDecodedResolutionFactorCallback;
+import org.esa.snap.lib.openjpeg.dataio.library.Callbacks.SetupDecoderCallback;
 
 import java.util.Arrays;
 import java.util.List;
@@ -92,7 +101,7 @@ public class DecompressionHandler extends Structure {
     }
 
     @Override
-    protected List<?> getFieldOrder() {
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/Image.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/Image.java
@@ -75,10 +75,14 @@ public class Image extends Structure {
         this.icc_profile_len = icc_profile_len;
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
-    
-    public static class ByReference extends Image implements Structure.ByReference { }
-    public static class ByValue extends Image implements Structure.ByValue { }
+
+    public static class ByReference extends Image implements Structure.ByReference {
+    }
+
+    public static class ByValue extends Image implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/ImageComponent.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/ImageComponent.java
@@ -73,14 +73,19 @@ public class ImageComponent extends Structure {
         super();
         data = new IntByReference();
     }
+
     public ImageComponent(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends ImageComponent implements Structure.ByReference { }
-    public static class ByValue extends ImageComponent implements Structure.ByValue { }
+    public static class ByReference extends ImageComponent implements Structure.ByReference {
+    }
+
+    public static class ByValue extends ImageComponent implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/ImageComponentParams.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/ImageComponentParams.java
@@ -73,10 +73,14 @@ public class ImageComponentParams extends Structure {
         this.sgnd = sgnd;
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends ImageComponentParams implements Structure.ByReference { }
-    public static class ByValue extends ImageComponentParams implements Structure.ByValue { }
+    public static class ByReference extends ImageComponentParams implements Structure.ByReference {
+    }
+
+    public static class ByValue extends ImageComponentParams implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/MarkerInfo.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/MarkerInfo.java
@@ -35,14 +35,19 @@ public class MarkerInfo extends Structure {
         this.pos = pos;
         this.len = len;
     }
+
     public MarkerInfo(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends MarkerInfo implements Structure.ByReference { }
-    public static class ByValue extends MarkerInfo implements Structure.ByValue { }
+    public static class ByReference extends MarkerInfo implements Structure.ByReference {
+    }
+
+    public static class ByValue extends MarkerInfo implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/PacketInfo.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/PacketInfo.java
@@ -47,14 +47,19 @@ public class PacketInfo extends Structure {
         this.end_pos = end_pos;
         this.disto = disto;
     }
+
     public PacketInfo(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends PacketInfo implements Structure.ByReference { }
-    public static class ByValue extends PacketInfo implements Structure.ByValue { }
+    public static class ByReference extends PacketInfo implements Structure.ByReference {
+    }
+
+    public static class ByValue extends PacketInfo implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/PoC.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/PoC.java
@@ -198,14 +198,19 @@ public class PoC extends Structure {
     public PoC() {
         super();
     }
+
     public PoC(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends PoC implements Structure.ByReference { }
-    public static class ByValue extends PoC implements Structure.ByValue { }
+    public static class ByReference extends PoC implements Structure.ByReference {
+    }
+
+    public static class ByValue extends PoC implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/Precision.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/Precision.java
@@ -27,14 +27,19 @@ public class Precision extends Structure {
         this.prec = prec;
         this.mode = mode;
     }
+
     public Precision(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends Precision implements Structure.ByReference { }
-    public static class ByValue extends Precision implements Structure.ByValue { }
+    public static class ByReference extends Precision implements Structure.ByReference {
+    }
+
+    public static class ByValue extends Precision implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/SegmentedFileInfo.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/SegmentedFileInfo.java
@@ -36,16 +36,17 @@ public class SegmentedFileInfo extends Structure {
     public SegmentedFileInfo() {
         super();
     }
+
     /**
-     * @param infile C type : char[4096]<br>
-     * @param p_file C type : FilePointer*<br>
-     * @param dataLength C type : OPJ_SIZE_T<br>
-     * @param dataRead C type : OPJ_SIZE_T<br>
+     * @param infile                 C type : char[4096]<br>
+     * @param p_file                 C type : FilePointer*<br>
+     * @param dataLength             C type : OPJ_SIZE_T<br>
+     * @param dataRead               C type : OPJ_SIZE_T<br>
      * @param p_segmentPositionsList C type : OPJ_OFF_T*<br>
-     * @param p_segmentLengths C type : OPJ_SIZE_T*<br>
-     * @param curPos C type : OPJ_OFF_T
+     * @param p_segmentLengths       C type : OPJ_SIZE_T*<br>
+     * @param curPos                 C type : OPJ_OFF_T
      */
-    public SegmentedFileInfo(byte infile[], FilePointer p_file, NativeSize dataLength, NativeSize dataRead, int numSegmentsMinusOne, LongByReference p_segmentPositionsList, NativeSizeByReference p_segmentLengths, long curPos, int curSegment) {
+    public SegmentedFileInfo(byte[] infile, FilePointer p_file, NativeSize dataLength, NativeSize dataRead, int numSegmentsMinusOne, LongByReference p_segmentPositionsList, NativeSizeByReference p_segmentLengths, long curPos, int curSegment) {
         super();
         if ((infile.length != this.infile.length))
             throw new IllegalArgumentException("Wrong array size !");
@@ -59,14 +60,19 @@ public class SegmentedFileInfo extends Structure {
         this.curPos = curPos;
         this.curSegment = curSegment;
     }
+
     public SegmentedFileInfo(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends SegmentedFileInfo implements Structure.ByReference { }
-    public static class ByValue extends SegmentedFileInfo implements Structure.ByValue { }
+    public static class ByReference extends SegmentedFileInfo implements Structure.ByReference {
+    }
+
+    public static class ByValue extends SegmentedFileInfo implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/Stream.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/Stream.java
@@ -86,18 +86,23 @@ public class Stream extends Structure {
      * C type : OPJ_UINT32
      */
     public int m_status;
-    
+
     public Stream() {
         super();
     }
+
     public Stream(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
-    
-    public static class ByReference extends Stream implements Structure.ByReference { }
-    public static class ByValue extends Stream implements Structure.ByValue { }
+
+    public static class ByReference extends Stream implements Structure.ByReference {
+    }
+
+    public static class ByValue extends Stream implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/TCCPInfo.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/TCCPInfo.java
@@ -86,14 +86,19 @@ public class TCCPInfo extends Structure {
     public TCCPInfo() {
         super();
     }
+
     public TCCPInfo(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends TCCPInfo implements Structure.ByReference { }
-    public static class ByValue extends TCCPInfo implements Structure.ByValue { }
+    public static class ByReference extends TCCPInfo implements Structure.ByReference {
+    }
+
+    public static class ByValue extends TCCPInfo implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/TPIndex.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/TPIndex.java
@@ -42,14 +42,19 @@ public class TPIndex extends Structure {
         this.end_header = end_header;
         this.end_pos = end_pos;
     }
+
     public TPIndex(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends TPIndex implements Structure.ByReference { }
-    public static class ByValue extends TPIndex implements Structure.ByValue { }
+    public static class ByReference extends TPIndex implements Structure.ByReference {
+    }
+
+    public static class ByValue extends TPIndex implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/TileIndex.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/TileIndex.java
@@ -66,14 +66,19 @@ public class TileIndex extends Structure {
     public TileIndex() {
         super();
     }
+
     public TileIndex(Pointer peer) {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    @Override
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 
-    public static class ByReference extends TileIndex implements Structure.ByReference { }
-    public static class ByValue extends TileIndex implements Structure.ByValue { }
+    public static class ByReference extends TileIndex implements Structure.ByReference {
+    }
+
+    public static class ByValue extends TileIndex implements Structure.ByValue {
+    }
 }

--- a/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/TileInfo2.java
+++ b/lib-openjpeg/src/main/java/org/esa/snap/lib/openjpeg/dataio/struct/TileInfo2.java
@@ -68,7 +68,7 @@ public class TileInfo2 extends Structure {
         super(peer);
     }
 
-    protected List<?> getFieldOrder() {
+    protected List<String> getFieldOrder() {
         return fieldNames;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -247,29 +247,19 @@
                 <version>${netcdf.version}</version>
             </dependency>
 
-            <!-- from toniof-netcdf-change_validation branch, not sure whether it is required
-            <dependency>
-                <groupId>edu.ucar</groupId>
-                <artifactId>cdm-core</artifactId>
-                <version>5.2.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>edu.ucar</groupId>
-                <artifactId>netcdf4</artifactId>
-                <version>5.2.0</version>
-            </dependency>
-
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
-                <version>5.4.0</version>
+                <version>5.5.0</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna-platform</artifactId>
-                <version>5.4.0</version>
+                <version>5.5.0</version>
             </dependency>
+
+            <!-- from toniof-netcdf-change_validation branch, not sure whether it is required
+
 
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/snap-netcdf/pom.xml
+++ b/snap-netcdf/pom.xml
@@ -53,26 +53,18 @@
             <artifactId>snap-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>edu.ucar</groupId>
             <artifactId>netcdfAll</artifactId>
         </dependency>
-
-        <!-- from toniof-netcdf-change_validation branch, not sure whether it is required
-        <dependency>
-            <groupId>edu.ucar</groupId>
-            <artifactId>cdm-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>edu.ucar</groupId>
-            <artifactId>netcdf4</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-        </dependency>
-        -->
         
         <!--
         We have to include the following UGLY dependencies so that they are put into the NBM module's ext folder.


### PR DESCRIPTION
The OpenJpeg Module still used an old version of the jna library. This caused classloading issues when using gpt on the command line because interfaces have changed. So I updated the version and updated some classes because of the interface change.
Would be great if you could quickly review. 