### PR TITLE
migrate to org.ejml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,11 +283,6 @@
                 <artifactId>htmlparser</artifactId>
                 <version>1.6</version>
             </dependency>
-            <dependency>
-                <groupId>com.googlecode.efficient-java-matrix-library</groupId>
-                <artifactId>core</artifactId>
-                <version>0.26</version>
-            </dependency>
 
             <!-- JDOM Library ############################################# -->
 
@@ -410,11 +405,6 @@
                     <exclusion>
                         <groupId>javax.media</groupId>
                         <artifactId>jai_imageio</artifactId>
-                    </exclusion>
-                    <!-- this lib is also used in snap-cluster-analysis and in jlinda-core -->
-                    <exclusion>
-                        <groupId>com.googlecode.efficient-java-matrix-library</groupId>
-                        <artifactId>core</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/snap-cluster-analysis/pom.xml
+++ b/snap-cluster-analysis/pom.xml
@@ -49,20 +49,15 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.ejml</groupId>
-                    <artifactId>ejml-ddense</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-gpf</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.efficient-java-matrix-library</groupId>
-            <artifactId>core</artifactId>
+            <groupId>org.ejml</groupId>
+            <artifactId>ejml-ddense</artifactId>
+            <version>0.39</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/snap-core/pom.xml
+++ b/snap-core/pom.xml
@@ -128,10 +128,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.googlecode.efficient-java-matrix-library</groupId>
-            <artifactId>core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>it.geosolutions.imageio-ext</groupId>
             <artifactId>imageio-ext-tiff</artifactId>
         </dependency>
@@ -197,7 +193,6 @@
                         <publicPackage>Jama</publicPackage>
 						<publicPackage>org.apache.*</publicPackage>
                         <publicPackage>net.coobird.thumbnailator.*</publicPackage>
-                        <publicPackage>org.ejml.*</publicPackage>
                         <publicPackage>com.bc.io</publicPackage>
                         <publicPackage>org.esa.snap.core.jexp</publicPackage>
                         <publicPackage>org.esa.snap.core.jexp.impl</publicPackage>


### PR DESCRIPTION
To avoid conflicts with ejml dependencies. All code previously using efficient-java-matrix-library can migrate to org.ejml which is the currently maintained library.