### PR TITLE
remove ejml v0.34 from classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,14 @@
                 <artifactId>htmlparser</artifactId>
                 <version>1.6</version>
             </dependency>
+            <dependency>
+                <!-- this lib is also used in snap-cluster-analysis and in jlinda-core
+                     better have an explicit dependency than rely on the transitive dependency
+                -->
+                <groupId>org.ejml</groupId>
+                <artifactId>ejml-ddense</artifactId>
+                <version>0.39</version>
+            </dependency>
 
             <!-- JDOM Library ############################################# -->
 
@@ -405,6 +413,13 @@
                     <exclusion>
                         <groupId>javax.media</groupId>
                         <artifactId>jai_imageio</artifactId>
+                    </exclusion>
+                    <!-- this lib is also used in snap-cluster-analysis and in jlinda-core
+                         better have an explicit dependency than rely on the transitive dependency
+                    -->
+                    <exclusion>
+                        <groupId>org.ejml</groupId>
+                        <artifactId>ejml-ddense</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/snap-cluster-analysis/pom.xml
+++ b/snap-cluster-analysis/pom.xml
@@ -54,11 +54,10 @@
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-gpf</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.ejml</groupId>
-            <artifactId>ejml-ddense</artifactId>
-            <version>0.39</version>
-        </dependency>
+        <!--        <dependency>-->
+        <!--            <groupId>org.ejml</groupId>-->
+        <!--            <artifactId>ejml-ddense</artifactId>-->
+        <!--        </dependency>-->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/snap-core/pom.xml
+++ b/snap-core/pom.xml
@@ -128,6 +128,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.ejml</groupId>
+            <artifactId>ejml-ddense</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>it.geosolutions.imageio-ext</groupId>
             <artifactId>imageio-ext-tiff</artifactId>
         </dependency>
@@ -193,6 +198,7 @@
                         <publicPackage>Jama</publicPackage>
 						<publicPackage>org.apache.*</publicPackage>
                         <publicPackage>net.coobird.thumbnailator.*</publicPackage>
+                        <publicPackage>org.ejml.*</publicPackage>
                         <publicPackage>com.bc.io</publicPackage>
                         <publicPackage>org.esa.snap.core.jexp</publicPackage>
                         <publicPackage>org.esa.snap.core.jexp.impl</publicPackage>

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/Operator.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/Operator.java
@@ -177,8 +177,6 @@ public abstract class Operator {
         pm.done();
     }
 
-    // todo - remove ProgressMonitor parameter, it has never been used and wastes processing time (nf - 17.12.2010)
-
     /**
      * Called by the framework in order to compute a tile for the given target band.
      * <p>The default implementation throws a runtime exception with the message "not implemented".
@@ -193,8 +191,6 @@ public abstract class Operator {
         throw new RuntimeException(
                 MessageFormat.format("{0}: ''computeTile()'' method not implemented", getClass().getSimpleName()));
     }
-
-    // todo - remove ProgressMonitor parameter, it has never been used and wastes processing time (nf - 17.12.2010)
 
     /**
      * Called by the framework in order to compute the stack of tiles for the given target bands.


### PR DESCRIPTION
This should remove ejml library v0.34 from the classpath which is pulled in as transitive dependency from gt-referencing.
There is also a PR for s1tbx.
Luis, can you try if this still works for s1tbx?