### PR TITLE
OLCI fractional accuracy with per-pixel geo-coding

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/dataio/geocoding/InverseCoding.java
+++ b/snap-core/src/main/java/org/esa/snap/core/dataio/geocoding/InverseCoding.java
@@ -23,6 +23,8 @@ import org.esa.snap.core.datamodel.PixelPos;
 
 public interface InverseCoding {
 
+    String KEY_SUFFIX_INTERPOLATING = "_INTERPOLATING";
+
     /**
      * Returns the pixel coordinates as x/y for a given geographical position given as lat/lon.
      *

--- a/snap-core/src/main/java/org/esa/snap/core/dataio/geocoding/inverse/PixelGeoIndexInverse.java
+++ b/snap-core/src/main/java/org/esa/snap/core/dataio/geocoding/inverse/PixelGeoIndexInverse.java
@@ -33,7 +33,7 @@ import java.util.TreeMap;
 public class PixelGeoIndexInverse implements InverseCoding {
 
     public static final String KEY = "INV_PIXEL_GEO_INDEX";
-    public static final String KEY_INTERPOLATING = "INV_PIXEL_GEO_INDEX_INTERPOLATING";
+    public static final String KEY_INTERPOLATING = KEY + KEY_SUFFIX_INTERPOLATING;
 
     private final boolean fractionalAccuracy;
     private final XYInterpolator interpolator;

--- a/snap-core/src/main/java/org/esa/snap/core/dataio/geocoding/inverse/PixelQuadTreeInverse.java
+++ b/snap-core/src/main/java/org/esa/snap/core/dataio/geocoding/inverse/PixelQuadTreeInverse.java
@@ -32,7 +32,7 @@ import org.esa.snap.core.util.math.RsMathUtils;
 public class PixelQuadTreeInverse implements InverseCoding {
 
     public static final String KEY = "INV_PIXEL_QUAD_TREE";
-    public static final String KEY_INTERPOLATING = "INV_PIXEL_QUAD_TREE_INTERPOLATING";
+    public static final String KEY_INTERPOLATING = KEY + KEY_SUFFIX_INTERPOLATING;
 
     private static final double TO_DEG = 180.0 / Math.PI;
     private static final double ANGLE_THRESHOLD = 330.0;


### PR DESCRIPTION
Switch for use fractional accuracy in Sentinel-3 OLCI products with activated per-pixel geo-coding

- please double check english text