### PR TITLE
Fix for clipping and rounding issues

### DIFF
--- a/snap-gpf/src/test/java/org/esa/snap/core/gpf/internal/TileImplTest.java
+++ b/snap-gpf/src/test/java/org/esa/snap/core/gpf/internal/TileImplTest.java
@@ -277,8 +277,174 @@ public class TileImplTest {
         samples = tile.getSamplesDouble();
         assertNotNull(samples);
         assertEquals(N, samples.length);
-        assertEquals(10.0, samples[0], 1.0e-10);
-        assertEquals(10.0, samples[N - 1], 1.0e-10);
+        assertEquals(12.5, samples[0], 0.0);
+        assertEquals(12.5, samples[N - 1], 0.0);
+    }
+
+    @Test
+    public void testSetSamples_Double_INT8() {
+        final double factor = 0.015;
+        final Tile tile = createScaledTile(ProductData.TYPE_INT8, factor);
+
+        tile.setSample(0, 0, 1.0);
+        assertEquals(1.0, tile.getSampleDouble(0,0), 0.015 / 2.0);
+
+        tile.setSample(0, 0, -1.0);
+        assertEquals(-1.0, tile.getSampleDouble(0,0), 0.015 / 2.0);
+
+        final double upperBound = 127.0;
+        final double tooBig = upperBound * (factor + 0.001);
+        tile.setSample(0, 0, tooBig);
+        assertEquals(upperBound * factor, tile.getSampleDouble(0,0), 0.0);
+
+        final double negativeTooBig = -tooBig;
+        final double lowerBound = -upperBound - 1.0;
+        tile.setSample(0, 0, negativeTooBig);
+        assertEquals(lowerBound * factor, tile.getSampleDouble(0,0), 0.0);
+    }
+
+    @Test
+    public void testSetSamples_Double_INT16() {
+        final double factor = 0.015;
+        final Tile tile = createScaledTile(ProductData.TYPE_INT16, factor);
+
+        tile.setSample(0, 0, 1.0);
+        assertEquals(1.0, tile.getSampleDouble(0,0), 0.015 / 2.0);
+
+        tile.setSample(0, 0, -1.0);
+        assertEquals(-1.0, tile.getSampleDouble(0,0), 0.015 / 2.0);
+
+        final double upperBound = 32767.0;
+        final double tooBig = upperBound * (factor + 0.001);
+        tile.setSample(0, 0, tooBig);
+        assertEquals(upperBound * factor, tile.getSampleDouble(0,0), 0.0);
+
+        final double lowerBound = -upperBound - 1.0;
+        tile.setSample(0, 0, -tooBig);
+        assertEquals(lowerBound * factor, tile.getSampleDouble(0,0), 0.0);
+    }
+
+    @Test
+    public void testSetSamples_Double_UINT8() {
+        final double factor = 0.015;
+        final Tile tile = createScaledTile(ProductData.TYPE_UINT8, factor);
+
+        tile.setSample(0, 0, 1.0);
+        assertEquals(1.0, tile.getSampleDouble(0,0), 0.015 / 2.0);
+
+        tile.setSample(0, 0, 0.0);
+        assertEquals(0.0, tile.getSampleDouble(0,0), 0.0);
+
+        final double upperBound = 255.0;
+        final double tooBig = upperBound * (factor + 0.001);
+        tile.setSample(0, 0, tooBig);
+        assertEquals(upperBound * factor, tile.getSampleDouble(0,0), 0.0);
+
+        tile.setSample(0, 0, -1.0);
+        assertEquals(0.0, tile.getSampleDouble(0,0), 0.0);
+    }
+
+    @Test
+    public void testSetSamples_Double_UINT16() {
+        final double factor = 0.015;
+        final Tile tile = createScaledTile(ProductData.TYPE_UINT16, factor);
+
+        tile.setSample(0, 0, 1.0);
+        assertEquals(1.0, tile.getSampleDouble(0,0), 0.015 / 2.0);
+
+        tile.setSample(0, 0, 0.0);
+        assertEquals(0.0, tile.getSampleDouble(0,0), 0.0);
+
+        final double upperBound = 65535.0;
+        final double tooBig = upperBound * (factor + 0.001);
+        tile.setSample(0, 0, tooBig);
+        assertEquals(upperBound * factor, tile.getSampleDouble(0,0), 0.0);
+
+        tile.setSample(0, 0, -1.0);
+        assertEquals(0.0, tile.getSampleDouble(0,0), 0.0);
+    }
+
+    @Test
+    public void testSetSamples_Float_INT8() {
+        final double factor = 0.015;
+        final Tile tile = createScaledTile(ProductData.TYPE_INT8, factor);
+
+        tile.setSample(0, 0, 1.0f);
+        assertEquals(1.0, tile.getSampleFloat(0,0), 0.015 / 2.0);
+
+        tile.setSample(0, 0, -1.0f);
+        assertEquals(-1.0, tile.getSampleFloat(0,0), 0.015 / 2.0);
+
+        final double upperBound = 127.0;
+        final double tooBig = upperBound * (factor + 0.001);
+        tile.setSample(0, 0, (float) tooBig);
+        assertEquals((float) (upperBound * factor), tile.getSampleFloat(0,0), 0.0);
+
+        final double negativeTooBig = -tooBig;
+        final double lowerBound = -upperBound - 1.0;
+        tile.setSample(0, 0, (float) negativeTooBig);
+        assertEquals((float) (lowerBound * factor), tile.getSampleFloat(0,0), 0.0);
+    }
+
+    @Test
+    public void testSetSamples_Float_INT16() {
+        final double factor = 0.015;
+        final Tile tile = createScaledTile(ProductData.TYPE_INT16, factor);
+
+        tile.setSample(0, 0, 1.0f);
+        assertEquals(1.0, tile.getSampleFloat(0,0), 0.015 / 2.0);
+
+        tile.setSample(0, 0, -1.0f);
+        assertEquals(-1.0, tile.getSampleFloat(0,0), 0.015 / 2.0);
+
+        final double upperBound = 32767.0;
+        final double tooBig = upperBound * (factor + 0.001);
+        tile.setSample(0, 0, (float) tooBig);
+        assertEquals((float) (upperBound * factor), tile.getSampleFloat(0,0), 0.0);
+
+        final double lowerBound = -upperBound - 1.0;
+        tile.setSample(0, 0, (float) -tooBig);
+        assertEquals((float) (lowerBound * factor), tile.getSampleFloat(0,0), 0.0);
+    }
+
+    @Test
+    public void testSetSamples_Float_UINT8() {
+        final double factor = 0.015;
+        final Tile tile = createScaledTile(ProductData.TYPE_UINT8, factor);
+
+        tile.setSample(0, 0, 1.0f);
+        assertEquals(1.0, tile.getSampleFloat(0,0), 0.015 / 2.0);
+
+        tile.setSample(0, 0, 0.0f);
+        assertEquals(0.0, tile.getSampleFloat(0,0), 0.0);
+
+        final double upperBound = 255.0;
+        final double tooBig = upperBound * (factor + 0.001);
+        tile.setSample(0, 0, (float) tooBig);
+        assertEquals((float) (upperBound * factor), tile.getSampleFloat(0,0), 0.0);
+
+        tile.setSample(0, 0, -1.0f);
+        assertEquals(0.0, tile.getSampleFloat(0,0), 0.0);
+    }
+
+    @Test
+    public void testSetSamples_Float_UINT16() {
+        final double factor = 0.015;
+        final Tile tile = createScaledTile(ProductData.TYPE_UINT16, factor);
+
+        tile.setSample(0, 0, 1.0f);
+        assertEquals(1.0, tile.getSampleFloat(0,0), 0.015 / 2.0);
+
+        tile.setSample(0, 0, 0.0f);
+        assertEquals(0.0, tile.getSampleFloat(0,0), 0.0);
+
+        final double upperBound = 65535.0;
+        final double tooBig = upperBound * (factor + 0.001);
+        tile.setSample(0, 0, (float) tooBig);
+        assertEquals((float) (upperBound * factor), tile.getSampleFloat(0,0), 0.0);
+
+        tile.setSample(0, 0, -1.0f);
+        assertEquals(0.0, tile.getSampleFloat(0,0), 0.0);
     }
 
     static Tile createRawTile(int type) {


### PR DESCRIPTION
This pull request fixes (some) clipping and rounding issues due to (in my opinion) wrong implementations of `setSample(int x, int y, double / float / int sample)` in `TileImpl`. The original implementation did not

- Clip the argument (or inverse-scaled argument) to the value range of the underlying data type as stated in the API documentation
- Round floating point values to the nearest integer value

The first point leads to unpredictible behaviour (may be predictable for a Java software developer, but not for a scientist who wants to code an operator). The second points leads to a systematic bias when written data are read again. 

For example, as a consequence of these issues, the collocation operator produces extremely high (and wrong) signals from almost zero signal for `short` data types when higher than bilinear interpolation (like bicubic interpolation) is requested.

Please review my changes.