### PR TITLE
SNAP 1057 multi-size product exception

### DIFF
--- a/snap-raster/src/main/java/org/esa/snap/raster/gpf/masks/CreateLandMaskOp.java
+++ b/snap-raster/src/main/java/org/esa/snap/raster/gpf/masks/CreateLandMaskOp.java
@@ -98,6 +98,12 @@ public class CreateLandMaskOp extends Operator {
             if (shorelineExtension == null) {
                 shorelineExtension = 0;
             }
+            boolean isMultiSizeProducts = sourceProduct.isMultiSize();
+            if(isMultiSizeProducts) {
+                throw new OperatorException("The multi-size source product is not supported."
+                +"Please, use resampling processor before. Or use the default graph 'Raster/Land Sea Mask For Multi-size Source.xml'"
+                +"in the graph builder.");
+            }
 
         } catch (Throwable e) {
             OperatorUtils.catchOperatorException(getId(), e);


### PR DESCRIPTION
Add multi-size source product exception in case of operator is used without the UI.

For the desktop UI, other exception appear during selection of a multi-size source product.
