### PR TITLE
Implementing major Color Manipulation modifications done in SeaDAS 8

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorManipulationDefaults.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorManipulationDefaults.java
@@ -1,0 +1,340 @@
+package org.esa.snap.core.datamodel;
+
+import org.esa.snap.core.util.NamingConvention;
+import static org.esa.snap.core.util.NamingConvention.*;
+
+
+/**
+ * Configuration which contains many key parameters with defaults and labels for the color manipulation tool
+ *
+ * @author Daniel Knowles
+ * @date 2/1/2020
+ */
+
+public class ColorManipulationDefaults {
+
+    public static final boolean COLOR_MANIPULATION_DEBUG = false;
+
+    public static final String TOOLNAME_COLOR_MANIPULATION = NamingConvention.COLOR_MIXED_CASE + " Manipulation";
+
+
+    // Directory names
+    public static final String DIR_NAME_COLOR_SCHEMES = "color_schemes";
+    public static final String DIR_NAME_RGB_PROFILES = "rgb_profiles";
+    public static final String DIR_NAME_COLOR_PALETTES = "color_palettes";
+    public static final String DIR_NAME_AUX_DATA = "auxdata";
+
+    // Palette files
+    public static final String PALETTE_STANDARD_DEFAULT = "oceancolor_standard.cpd";
+    public static final String PALETTE_UNIVERSAL_DEFAULT = "universal_bluered.cpd";
+    public static final String PALETTE_GRAY_SCALE_DEFAULT = "gray_scale.cpd";
+    public static final String PALETTE_ANOMALIES_DEFAULT = "gradient_red_white_blue.cpd";
+    public static final String PALETTE_DEFAULT = PALETTE_GRAY_SCALE_DEFAULT;
+
+    // xml files used by the color scheme manager
+    public static final String COLOR_SCHEME_LOOKUP_FILENAME = "color_palette_scheme_lookup.xml";
+    public static final String COLOR_SCHEMES_FILENAME = "color_palette_schemes.xml";
+
+    // Indicates which color palette contained within the color scheme xml to use
+    public static final String OPTION_COLOR_STANDARD_SCHEME = "From Scheme STANDARD";
+    public static final String OPTION_COLOR_UNIVERSAL_SCHEME = "From Scheme UNIVERSAL";
+
+    // Color palette selections
+    public static final String OPTION_COLOR_GRAY_SCALE = "GRAY SCALE";
+    public static final String OPTION_COLOR_STANDARD = "STANDARD";
+    public static final String OPTION_COLOR_UNIVERSAL = "UNIVERSAL";
+    public static final String OPTION_COLOR_ANOMALIES = "ANOMALIES";
+
+    // Range options
+    public static final String OPTION_RANGE_FROM_SCHEME = "From Scheme";
+    public static final String OPTION_RANGE_FROM_DATA = "From Data";
+    public static final String OPTION_RANGE_FROM_PALETTE = "From Palette File";
+
+    // Log scaling options
+    public static final String OPTION_LOG_TRUE = "TRUE";
+    public static final String OPTION_LOG_FALSE = "FALSE";
+    public static final String OPTION_LOG_FROM_PALETTE = "From Palette File";
+    public static final String OPTION_LOG_FROM_SCHEME = "From Scheme";
+
+    // general usage values
+    public static final double DOUBLE_NULL = -Double.MAX_VALUE;
+
+
+    //--------------------------------------------------------------------------------------------------------------
+    // Color Manipulation Preferences parameters
+
+    // Preferences property prefix
+    private static final String PROPERTY_ROOT_KEY = "color.manipulation";
+
+
+    // General (Non-Scheme) Options
+
+    private static final String PROPERTY_GENERAL_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".general";
+
+    public static final String PROPERTY_GENERAL_SECTION_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_GENERAL_SECTION_LABEL = "Standard Options";
+    public static final String PROPERTY_GENERAL_SECTION_TOOLTIP = "General behavior when not using a " + COLOR_LOWER_CASE + " scheme";
+
+    public static final String PROPERTY_GENERAL_PALETTE_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".palette";
+    public static final String PROPERTY_GENERAL_PALETTE_LABEL = "Palette";
+    public static final String PROPERTY_GENERAL_PALETTE_TOOLTIP = "The color palette file to use when NOT using a " + COLOR_LOWER_CASE + " scheme";
+    public static final String PROPERTY_GENERAL_PALETTE_OPTION1 = OPTION_COLOR_GRAY_SCALE;
+    public static final String PROPERTY_GENERAL_PALETTE_OPTION2 = OPTION_COLOR_STANDARD;
+    public static final String PROPERTY_GENERAL_PALETTE_OPTION3 = OPTION_COLOR_UNIVERSAL;
+    public static final String PROPERTY_GENERAL_PALETTE_OPTION4 = OPTION_COLOR_ANOMALIES;
+    public static final String PROPERTY_GENERAL_PALETTE_DEFAULT = OPTION_COLOR_GRAY_SCALE;
+
+    public static final String PROPERTY_GENERAL_RANGE_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".range";
+    public static final String PROPERTY_GENERAL_RANGE_LABEL = "Range";
+    public static final String PROPERTY_GENERAL_RANGE_TOOLTIP = "Range options to use when NOT using a " + COLOR_LOWER_CASE + "scheme";
+    public static final String PROPERTY_GENERAL_RANGE_OPTION1 = OPTION_RANGE_FROM_DATA;
+    public static final String PROPERTY_GENERAL_RANGE_OPTION2 = OPTION_RANGE_FROM_PALETTE;
+    public static final String PROPERTY_GENERAL_RANGE_DEFAULT = OPTION_RANGE_FROM_DATA;
+
+    public static final String PROPERTY_GENERAL_LOG_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".log";
+    public static final String PROPERTY_GENERAL_LOG_LABEL = "Log Scaling";
+    public static final String PROPERTY_GENERAL_LOG_TOOLTIP = "Log scaling options to use when NOT using a " + COLOR_LOWER_CASE + " scheme";
+    public static final String PROPERTY_GENERAL_LOG_OPTION1 = OPTION_LOG_TRUE;
+    public static final String PROPERTY_GENERAL_LOG_OPTION2 = OPTION_LOG_FALSE;
+    public static final String PROPERTY_GENERAL_LOG_OPTION3 = OPTION_LOG_FROM_PALETTE;
+    public static final String PROPERTY_GENERAL_LOG_DEFAULT = OPTION_LOG_FALSE;
+
+
+
+    // Scheme option
+
+    private static final String PROPERTY_SCHEME_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".scheme";
+
+    public static final String PROPERTY_SCHEME_SECTION_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_SCHEME_SECTION_LABEL = "Scheme Options";
+    public static final String PROPERTY_SCHEME_SECTION_TOOLTIP = "<html>Behavior when using a " + COLOR_LOWER_CASE + " scheme as configured in<br>" +
+            " color_palette_schemes.xml and color_palette_scheme_lookup.xml</html>";
+
+    public static final String PROPERTY_SCHEME_AUTO_APPLY_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".auto.apply";
+    public static final String PROPERTY_SCHEME_AUTO_APPLY_LABEL = "Apply " + NamingConvention.COLOR_MIXED_CASE + " Schemes Automatically";
+    public static final String PROPERTY_SCHEME_AUTO_APPLY_TOOLTIP = "<html>Apply " + NamingConvention.COLOR_LOWER_CASE +" schemes automatically<br>" +
+            " when opening a band based on its name</html>";
+    public static final boolean PROPERTY_SCHEME_AUTO_APPLY_DEFAULT = false;
+
+    public static final String PROPERTY_SCHEME_PALETTE_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".palette";
+    public static final String PROPERTY_SCHEME_PALETTE_LABEL = "Palette";
+    public static final String PROPERTY_SCHEME_PALETTE_TOOLTIP = "The color palette file to use for the scheme";
+    public static final String PROPERTY_SCHEME_PALETTE_OPTION1 = OPTION_COLOR_STANDARD_SCHEME;
+    public static final String PROPERTY_SCHEME_PALETTE_OPTION2 = OPTION_COLOR_UNIVERSAL_SCHEME;
+    public static final String PROPERTY_SCHEME_PALETTE_OPTION3 = OPTION_COLOR_GRAY_SCALE;
+    public static final String PROPERTY_SCHEME_PALETTE_OPTION4 = OPTION_COLOR_STANDARD;
+    public static final String PROPERTY_SCHEME_PALETTE_OPTION5 = OPTION_COLOR_UNIVERSAL;
+    public static final String PROPERTY_SCHEME_PALETTE_OPTION6 = OPTION_COLOR_ANOMALIES;
+    public static final String PROPERTY_SCHEME_PALETTE_DEFAULT = OPTION_COLOR_STANDARD_SCHEME;
+
+    public static final String PROPERTY_SCHEME_RANGE_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".range";
+    public static final String PROPERTY_SCHEME_RANGE_LABEL = "Range";
+    public static final String PROPERTY_SCHEME_RANGE_TOOLTIP = "Range options (min, max) to use for the scheme";
+    public static final String PROPERTY_SCHEME_RANGE_OPTION1 = OPTION_RANGE_FROM_SCHEME;
+    public static final String PROPERTY_SCHEME_RANGE_OPTION2 = OPTION_RANGE_FROM_DATA;
+    public static final String PROPERTY_SCHEME_RANGE_OPTION3 = OPTION_RANGE_FROM_PALETTE;
+    public static final String PROPERTY_SCHEME_RANGE_DEFAULT = OPTION_RANGE_FROM_SCHEME;
+
+    public static final String PROPERTY_SCHEME_LOG_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".log";
+    public static final String PROPERTY_SCHEME_LOG_LABEL = "Log Scaling";
+    public static final String PROPERTY_SCHEME_LOG_TOOLTIP = "log scaling options to use for the scheme";
+    public static final String PROPERTY_SCHEME_LOG_OPTION1 = OPTION_LOG_FROM_SCHEME;
+    public static final String PROPERTY_SCHEME_LOG_OPTION2 = OPTION_LOG_FROM_PALETTE;
+    public static final String PROPERTY_SCHEME_LOG_OPTION3 = OPTION_LOG_TRUE;
+    public static final String PROPERTY_SCHEME_LOG_OPTION4 = OPTION_LOG_FALSE;
+    public static final String PROPERTY_SCHEME_LOG_DEFAULT = OPTION_LOG_FROM_SCHEME;
+
+
+
+    // Scheme Selector Options
+
+    private static final String PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".scheme.selector";
+
+    public static final String PROPERTY_SCHEME_SELECTOR_SECTION_KEY = PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_SCHEME_SELECTOR_SECTION_LABEL = "Scheme Selector Options";
+    public static final String PROPERTY_SCHEME_SELECTOR_SECTION_TOOLTIP = "<html>Format options for the color schemes listed<br>" +
+            " within the Scheme Selector</html>";
+
+    public static final String PROPERTY_SCHEME_VERBOSE_KEY = PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX + ".verbose";
+    public static final String PROPERTY_SCHEME_VERBOSE_LABEL = "Verbose";
+    public static final String PROPERTY_SCHEME_VERBOSE_TOOLTIP = "<html>Scheme selector will show the verbose VERBOSE_NAME field<br>" +
+            " from the color_palette_schemes.xml</html>";
+    public static final boolean PROPERTY_SCHEME_VERBOSE_DEFAULT = false;
+
+    public static final String PROPERTY_SCHEME_SHOW_DISABLED_KEY = PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX + ".show.disabled";
+    public static final String PROPERTY_SCHEME_SHOW_DISABLED_LABEL = "Show Disabled";
+    public static final String PROPERTY_SCHEME_SHOW_DISABLED_TOOLTIP = "<html>Scheme selector will display all schemes <br>" +
+            "including schemes with missing cpd files</html>";
+    public static final boolean PROPERTY_SCHEME_SHOW_DISABLED_DEFAULT = false;
+
+    public static final String PROPERTY_SCHEME_SORT_KEY = PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX + ".sort";
+    public static final String PROPERTY_SCHEME_SORT_LABEL = "Sort";
+    public static final String PROPERTY_SCHEME_SORT_TOOLTIP = "<html>Scheme selector will display all schemes alphabetically sorted<br>" +
+            " as opposed to the original xml order</html>";
+    public static final boolean PROPERTY_SCHEME_SORT_DEFAULT = true;
+
+    public static final String PROPERTY_SCHEME_CATEGORIZE_DISPLAY_KEY = PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX + ".split";
+    public static final String PROPERTY_SCHEME_CATEGORIZE_DISPLAY_LABEL = "Categorize";
+    public static final String PROPERTY_SCHEME_CATEGORIZE_DISPLAY_TOOLTIP = "<html>Scheme selector will display all schemes categorized into<br>" +
+            "primary and additional categories by the PRIMARY field<br> of the color_palette_schemes.xml</html>";
+    public static final boolean PROPERTY_SCHEME_CATEGORIZE_DISPLAY_DEFAULT = true;
+
+
+    // Sliders Editor Options
+
+    private static final String PROPERTY_SLIDER_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".slider.options";
+
+    public static final String PROPERTY_SLIDERS_SECTION_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_SLIDERS_SECTION_LABEL = "Sliders Editor Options";
+    public static final String PROPERTY_SLIDERS_SECTION_TOOLTIP = "Options within the \"Sliders\" Editor of the " + TOOLNAME_COLOR_MANIPULATION + " GUI";
+
+    public static final String PROPERTY_SLIDERS_SHOW_INFORMATION_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".extra.info";
+    public static final String PROPERTY_SLIDERS_SHOW_INFORMATION_LABEL = "Show Information";
+    public static final String PROPERTY_SLIDERS_SHOW_INFORMATION_TOOLTIP = "Display information in the histogram/slider view by default";
+    public static final boolean PROPERTY_SLIDERS_SHOW_INFORMATION_DEFAULT = true;
+
+    public static final String PROPERTY_SLIDERS_ZOOM_IN_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".zoom.in";
+    public static final String PROPERTY_SLIDERS_ZOOM_IN_LABEL = "Histogram Zoom";
+    public static final String PROPERTY_SLIDERS_ZOOM_IN_TOOLTIP = "Display histogram slider view zoomed in by default";
+    public static final boolean PROPERTY_SLIDERS_ZOOM_IN_DEFAULT = true;
+
+
+
+
+
+    // Range Percentile Default Options
+
+    private static final String PROPERTY_RANGE_PERCENTILE_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".range.percentile";
+
+    public static final String PROPERTY_RANGE_PERCENTILE_SECTION_KEY = PROPERTY_RANGE_PERCENTILE_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_RANGE_PERCENTILE_SECTION_LABEL = "Percentile Range";
+    public static final String PROPERTY_RANGE_PERCENTILE_SECTION_TOOLTIP = "Default range percentile in the " + TOOLNAME_COLOR_MANIPULATION + " GUI";
+
+    public static final String PROPERTY_RANGE_PERCENTILE_KEY = PROPERTY_RANGE_PERCENTILE_KEY_SUFFIX + ".value";
+    public static final String PROPERTY_RANGE_PERCENTILE_LABEL = "Percentile Range Default";
+    public static final String PROPERTY_RANGE_PERCENTILE_TOOLTIP = "The percentile of the data to use for determining min, max range";
+    public static final double PROPERTY_RANGE_PERCENTILE_DEFAULT = 92.0;
+
+
+
+
+
+
+    // Button Enablement Options
+
+    private static final String PROPERTY_BUTTONS_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".button.enablement";
+
+    public static final String PROPERTY_BUTTONS_SECTION_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_BUTTONS_SECTION_LABEL = "Button Enablement";
+    public static final String PROPERTY_BUTTONS_SECTION_TOOLTIP = "Button enablement options in the " + TOOLNAME_COLOR_MANIPULATION + " GUI";
+
+    public static final String PROPERTY_100_PERCENT_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".100.button";
+    public static final String PROPERTY_100_PERCENT_BUTTON_LABEL = "100% Button";
+    public static final String PROPERTY_100_PERCENT_BUTTON_TOOLTIP = "Enable 100% range button in the sliders editor";
+    public static final boolean PROPERTY_100_PERCENT_BUTTON_DEFAULT = true;
+
+    public static final String PROPERTY_95_PERCENT_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".95.button";
+    public static final String PROPERTY_95_PERCENT_BUTTON_LABEL = "95% Button";
+    public static final String PROPERTY_95_PERCENT_BUTTON_TOOLTIP = "Enable 95% range button in the sliders editor";
+    public static final boolean PROPERTY_95_PERCENT_BUTTON_DEFAULT = false;
+
+    public static final String PROPERTY_1_SIGMA_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".1.sigma.button";
+    public static final String PROPERTY_1_SIGMA_BUTTON_LABEL = "<html>1&sigma; (68.27%) Button</html>";
+    public static final String PROPERTY_1_SIGMA_BUTTON_TOOLTIP = "Enable 68.27% range button in the sliders editor";
+    public static final boolean PROPERTY_1_SIGMA_BUTTON_DEFAULT = false;
+
+    public static final String PROPERTY_2_SIGMA_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".2.sigma.button";
+    public static final String PROPERTY_2_SIGMA_BUTTON_LABEL = "<html>2&sigma; (95.45%) Button</html>";
+    public static final String PROPERTY_2_SIGMA_BUTTON_TOOLTIP = "Enable 95.45% range button in the sliders editor";
+    public static final boolean PROPERTY_2_SIGMA_BUTTON_DEFAULT = true;
+
+    public static final String PROPERTY_3_SIGMA_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".3.sigma.button";
+    public static final String PROPERTY_3_SIGMA_BUTTON_LABEL = "<html>3&sigma; (99.73%) Button</html>";
+    public static final String PROPERTY_3_SIGMA_BUTTON_TOOLTIP = "Enable 99.73% range button in the sliders editor";
+    public static final boolean PROPERTY_3_SIGMA_BUTTON_DEFAULT = true;
+
+    public static final String PROPERTY_ZOOM_VERTICAL_BUTTONS_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".zoom.vertical.buttons";
+    public static final String PROPERTY_ZOOM_VERTICAL_BUTTONS_LABEL = "Vertical Zoom Buttons";
+    public static final String PROPERTY_ZOOM_VERTICAL_BUTTONS_TOOLTIP = "Enable zoom vertical buttons in the sliders editor";
+    public static final boolean PROPERTY_ZOOM_VERTICAL_BUTTONS_DEFAULT = true;
+
+    public static final String PROPERTY_INFORMATION_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".extra.info.button";
+    public static final String PROPERTY_INFORMATION_BUTTON_LABEL = "Information Button";
+    public static final String PROPERTY_INFORMATION_BUTTON_TOOLTIP = "Enable histogram overlay information button in the sliders editor";
+    public static final boolean PROPERTY_INFORMATION_BUTTON_DEFAULT = true;
+
+
+
+
+    // Default Palettes
+
+    private static final String PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".default.palette";
+
+    public static final String PROPERTY_PALETTE_DEFAULT_SECTION_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_PALETTE_DEFAULT_SECTION_LABEL = "Default Palettes";
+    public static final String PROPERTY_PALETTE_DEFAULT_SECTION_TOOLTIP = "Palettes to use";
+
+    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".gray.scale";
+    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_LABEL = OPTION_COLOR_GRAY_SCALE;
+    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_TOOLTIP = "The palette file to use when GRAY SCALE is selected";
+    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_DEFAULT = PALETTE_GRAY_SCALE_DEFAULT;
+
+    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".standard";
+    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_LABEL = OPTION_COLOR_STANDARD;
+    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_TOOLTIP = "The palette file to use when STANDARD " + COLOR_UPPER_CASE +" is selected";
+    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_DEFAULT = PALETTE_STANDARD_DEFAULT;
+
+    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".universal";
+    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_LABEL = OPTION_COLOR_UNIVERSAL;
+    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_TOOLTIP = "<html>The color blind compliant palette file to use when <br>" +
+            "UNIVERSAL " + COLOR_UPPER_CASE + " is selected</html>";
+    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_DEFAULT = PALETTE_UNIVERSAL_DEFAULT;
+
+    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".anomalies";
+    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_LABEL = OPTION_COLOR_ANOMALIES;
+    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_TOOLTIP = "The palette file to use when ANOMALIES is selected";
+    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_DEFAULT = PALETTE_ANOMALIES_DEFAULT;
+
+
+    // RGB Options
+
+    private static final String PROPERTY_RGB_OPTIONS_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".rgb.options";
+
+    public static final String PROPERTY_RGB_OPTIONS_SECTION_KEY = PROPERTY_RGB_OPTIONS_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_RGB_OPTIONS_SECTION_LABEL = "RGB Options";
+    public static final String PROPERTY_RGB_OPTIONS_SECTION_TOOLTIP = "Options for the RGB Image";
+
+    public static final String PROPERTY_RGB_OPTIONS_MIN_KEY = PROPERTY_RGB_OPTIONS_KEY_SUFFIX + ".button.min";
+    public static final String PROPERTY_RGB_OPTIONS_MIN_LABEL = "Range Button (Min)";
+    public static final String PROPERTY_RGB_OPTIONS_MIN_TOOLTIP = "The min value to use in the RGB (A..B) range button";
+    public static final double PROPERTY_RGB_OPTIONS_MIN_DEFAULT = 0.0;
+
+    public static final String PROPERTY_RGB_OPTIONS_MAX_KEY = PROPERTY_RGB_OPTIONS_KEY_SUFFIX + "button.min";
+    public static final String PROPERTY_RGB_OPTIONS_MAX_LABEL = "Range Button (Max)";
+    public static final String PROPERTY_RGB_OPTIONS_MAX_TOOLTIP = "The max value to use in the RGB (A..B) range button";
+    public static final double PROPERTY_RGB_OPTIONS_MAX_DEFAULT = 1.0;
+
+
+
+    // Restore to defaults
+
+    private static final String PROPERTY_RESTORE_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".restore.defaults";
+
+    public static final String PROPERTY_RESTORE_SECTION_KEY = PROPERTY_RESTORE_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_RESTORE_SECTION_LABEL = "Restore";
+    public static final String PROPERTY_RESTORE_SECTION_TOOLTIP = "Restores preferences to the package defaults";
+
+    public static final String PROPERTY_RESTORE_DEFAULTS_NAME = PROPERTY_RESTORE_KEY_SUFFIX + ".apply";
+    public static final String PROPERTY_RESTORE_DEFAULTS_LABEL = "Default (" + TOOLNAME_COLOR_MANIPULATION + " Preferences)";
+    public static final String PROPERTY_RESTORE_DEFAULTS_TOOLTIP = "Restore all " + NamingConvention.COLOR_LOWER_CASE + " preferences to the original default";
+    public static final boolean PROPERTY_RESTORE_DEFAULTS_DEFAULT = false;
+
+
+
+    public static void debug(String message) {
+        if (COLOR_MANIPULATION_DEBUG) {
+            System.out.println(message);
+        }
+    }
+
+}

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorSchemeInfo.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorSchemeInfo.java
@@ -1,0 +1,210 @@
+package org.esa.snap.core.datamodel;
+
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Contains all info for a color scheme
+ * @author Daniel Knowles (NASA)
+ * @date Nov 2019
+ *
+ */
+
+public class ColorSchemeInfo {
+    private String name;
+    private String displayName;
+    private String description;
+    private String cpdFilenameStandard;
+    private String cpdFilenameColorBlind;
+    private String colorBarTitle;
+    private String colorBarLabels;
+    private double minValue;
+    private double maxValue;
+    private boolean isLogScaled;
+    private boolean enabled;
+    private boolean divider;
+    private boolean primary;
+    private File colorPaletteDir;
+    private boolean duplicateEntry = false;
+
+    private boolean useDisplayName = true;
+
+
+    public ColorSchemeInfo(String name, boolean primary, boolean divider, String displayName, String description, String cpdFilenameStandard, double minValue, double maxValue,
+                           boolean isLogScaled, boolean enabled, String cpdFilenameColorBlind, String colorBarTitle, String colorBarLabels, File colorPaletteDir) {
+        this.setName(name);
+
+        this.primary = primary;
+        this.divider = divider;
+        this.displayName = displayName;
+        this.setDescription(description);
+        this.setCpdFilenameStandard(cpdFilenameStandard);
+        this.setMinValue(minValue);
+        this.setMaxValue(maxValue);
+        this.setLogScaled(isLogScaled);
+        this.setEnabled(enabled);
+        this.cpdFilenameColorBlind = cpdFilenameColorBlind;
+        this.colorBarLabels = colorBarLabels;
+        this.colorBarTitle = colorBarTitle;
+        this.setColorPaletteDir(colorPaletteDir);
+    }
+
+
+    public boolean isDivider() {
+        return divider;
+    }
+
+    public void setUseDisplayName(boolean useDisplayName) {
+        this.useDisplayName = useDisplayName;
+    }
+
+    public boolean isUseDisplayName() {
+        return this.useDisplayName;
+    }
+
+
+    public ColorPaletteDef getColorPaletteDef(boolean useColorBlindPalette) {
+        File cpdFile = new File(colorPaletteDir, getCpdFilename(useColorBlindPalette));
+        try {
+            return ColorPaletteDef.loadColorPaletteDef(cpdFile);
+
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+
+    public String getCpdFilename(boolean isUseColorBlind) {
+        if (isUseColorBlind) {
+            return getCpdFilenameColorBlind();
+        } else {
+            return getCpdFilenameStandard();
+        }
+    }
+
+    public String getCpdFilenameStandard() {
+        return cpdFilenameStandard;
+    }
+
+    private void setCpdFilenameStandard(String cpdFilename) {
+        this.cpdFilenameStandard = cpdFilename;
+    }
+
+    public double getMinValue() {
+        return minValue;
+    }
+
+    private void setMinValue(double minValue) {
+        this.minValue = minValue;
+    }
+
+    public double getMaxValue() {
+        return maxValue;
+    }
+
+    private void setMaxValue(double maxValue) {
+        this.maxValue = maxValue;
+    }
+
+    public boolean isLogScaled() {
+        return isLogScaled;
+    }
+
+    private void setLogScaled(boolean isLogScaled) {
+        this.isLogScaled = isLogScaled;
+    }
+
+    public String toString() {
+        return toString(isUseDisplayName());
+    }
+
+    public String toString(boolean verbose) {
+        if (verbose && displayName != null && displayName.length() > 0) {
+            return displayName;
+        } else {
+            return getName();
+        }
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    private void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+
+
+    public String getCpdFilenameColorBlind() {
+        return cpdFilenameColorBlind;
+    }
+
+    public void setCpdFilenameColorBlind(String cpdFilenameColorBlind) {
+        this.cpdFilenameColorBlind = cpdFilenameColorBlind;
+    }
+
+    public String getColorBarTitle() {
+        return colorBarTitle;
+    }
+
+    public void setColorBarTitle(String colorBarTitle) {
+        this.colorBarTitle = colorBarTitle;
+    }
+
+    public String getColorBarLabels() {
+        return colorBarLabels;
+    }
+
+    public void setColorBarLabels(String colorBarLabels) {
+        this.colorBarLabels = colorBarLabels;
+    }
+
+
+    public File getColorPaletteDir() {
+        return colorPaletteDir;
+    }
+
+    public void setColorPaletteDir(File colorPaletteDir) {
+        this.colorPaletteDir = colorPaletteDir;
+    }
+
+    public boolean isDuplicateEntry() {
+        return duplicateEntry;
+    }
+
+    public void setDuplicateEntry(boolean duplicateEntry) {
+        this.duplicateEntry = duplicateEntry;
+    }
+
+    public boolean isPrimary() {
+        return primary;
+    }
+
+    public void setPrimary(boolean primary) {
+        this.primary = primary;
+    }
+}

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ImageInfo.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ImageInfo.java
@@ -17,6 +17,7 @@ package org.esa.snap.core.datamodel;
 
 import com.bc.ceres.core.Assert;
 import org.esa.snap.core.image.ImageManager;
+import org.esa.snap.core.util.math.LogLinearTransform;
 
 import java.awt.Color;
 import java.awt.Transparency;
@@ -29,8 +30,23 @@ import java.awt.image.IndexColorModel;
  * This class contains information about how a product's raster data node is displayed as an image.
  *
  * @author Norman Fomferra
+ * @author Daniel Knowles (NASA)
  * @version $Revision$ $Date$
  */
+// OCT 2019 - Knowles
+//          - Added logic to transform weighted points between logarithmic scaling and
+//            linear scaling in both directions.
+//  NOV 2019 - Knowles
+//           - Added logic to invert the direction of the color palette
+//  DEC 2019 - Knowles
+//           - Moved some of the log/liner transform methods into the class LogLinearTransform
+// JAN 2020 - Knowles
+//          - Added ColorSchemeInfo colorSchemeInfo to be able to set the color scheme selector in the ColorManipulation GUI
+// FEB 2020 - Knowles
+//          - Added ColorPaletteDef source->target transfer of the fields sourceFileMin and sourceFileMax
+//          - When tranferring points of the ColorPaletteDef, log scaling field in image info is also updated
+//          - Added zoomToHistLimits
+
 public class ImageInfo implements Cloneable {
 
     public static final Color NO_COLOR = new Color(0, 0, 0, 0);
@@ -44,6 +60,9 @@ public class ImageInfo implements Cloneable {
     public static final String HISTOGRAM_MATCHING_EQUALIZE = "equalize";
     @Deprecated
     public static final String HISTOGRAM_MATCHING_NORMALIZE = "normalize";
+
+    private static final double FORCED_CHANGE_FACTOR = 0.0001;
+
 
     /**
      * Enumerates the possible histogram matching modes.
@@ -60,6 +79,8 @@ public class ImageInfo implements Cloneable {
     private HistogramMatching histogramMatching;
     private String uncertaintyBandName;
     private boolean logScaled;
+    private ColorSchemeInfo colorSchemeInfo = null;
+    private Boolean zoomToHistLimits = null;
 
     /**
      * Enumerates the possible histogram matching modes.
@@ -313,6 +334,9 @@ public class ImageInfo implements Cloneable {
                                        boolean autoDistribute,
                                        ColorPaletteDef targetCPD) {
 
+        targetCPD.setSourceFileMin(sourceCPD.getSourceFileMin());
+        targetCPD.setSourceFileMax(sourceCPD.getSourceFileMax());
+
         if (autoDistribute || sourceCPD.isAutoDistribute()) {
             alignNumPoints(sourceCPD, targetCPD);
             double minDisplaySample = sourceCPD.getMinDisplaySample();
@@ -330,6 +354,106 @@ public class ImageInfo implements Cloneable {
             targetCPD.setPoints(sourceCPD.getPoints().clone());
         }
     }
+
+    public void setColorPaletteDefInvert(ColorPaletteDef colorPaletteDef, double min, double max) {
+        transferPointsInvert(colorPaletteDef, min, max, getColorPaletteDef());
+    }
+
+    private static void transferPointsInvert(ColorPaletteDef sourceCPD, double min, double max, ColorPaletteDef targetCPD) {
+
+        targetCPD.setSourceFileMin(min);
+        targetCPD.setSourceFileMax(max);
+
+        alignNumPoints(sourceCPD, targetCPD);
+
+
+        Color[] targetColors = new Color[sourceCPD.getNumPoints()];
+        for (int i = 0; i < sourceCPD.getNumPoints(); i++) {
+            int targetPointIndex = sourceCPD.getNumPoints() - 1 - i;
+            targetColors[i] = sourceCPD.getPointAt(targetPointIndex).getColor();
+        }
+
+        for (int i = 0; i < sourceCPD.getNumPoints(); i++) {
+            targetCPD.getPointAt(i).setLabel(sourceCPD.getPointAt(i).getLabel());
+            targetCPD.getPointAt(i).setColor(targetColors[i]);
+        }
+
+        targetCPD.setLogScaled(sourceCPD.isLogScaled());
+        targetCPD.setDiscrete(sourceCPD.isDiscrete());
+        targetCPD.setAutoDistribute(sourceCPD.isAutoDistribute());
+    }
+
+
+    public void setColorPaletteDef(ColorPaletteDef colorPaletteDef,
+                                   double minSample,
+                                   double maxSample, boolean autoDistribute, boolean isSourceLogScaled, boolean isTargetLogScaled) {
+        setLogScaled(isTargetLogScaled);
+        transferPoints(colorPaletteDef, minSample, maxSample, autoDistribute, getColorPaletteDef(), isSourceLogScaled, isTargetLogScaled);
+    }
+
+
+    private static void transferPoints(ColorPaletteDef sourceCPD,
+                                       double minTargetValue,
+                                       double maxTargetValue,
+                                       boolean autoDistribute,
+                                       ColorPaletteDef targetCPD,
+                                       boolean isSourceLogScaled,
+                                       boolean isTargetLogScaled) {
+
+        targetCPD.setSourceFileMin(sourceCPD.getSourceFileMin());
+        targetCPD.setSourceFileMax(sourceCPD.getSourceFileMax());
+
+        if (autoDistribute || sourceCPD.isAutoDistribute()) {
+            alignNumPoints(sourceCPD, targetCPD);
+            double minSourceValue = sourceCPD.getMinDisplaySample();
+            double maxSourceValue = sourceCPD.getMaxDisplaySample();
+
+            // The target CPD log status needs to be set here to be effective
+            targetCPD.setLogScaled(isTargetLogScaled);
+
+            for (int i = 0; i < sourceCPD.getNumPoints(); i++) {
+
+                if (minTargetValue != maxTargetValue && minSourceValue != maxSourceValue) {
+
+                    double linearWeight;
+                    if (isSourceLogScaled) {
+                        double currentSourceLogValue = sourceCPD.getPointAt(i).getSample();
+                        linearWeight = LogLinearTransform.getLinearWeightFromLogValue(currentSourceLogValue, minSourceValue, maxSourceValue);
+
+                    } else {
+                        double currentSourceValue = sourceCPD.getPointAt(i).getSample();
+                        linearWeight = (currentSourceValue - minSourceValue) / (maxSourceValue - minSourceValue);
+                    }
+
+                    double currentLinearTargetValue = LogLinearTransform.getLinearValue(linearWeight, minTargetValue, maxTargetValue);
+
+                    if (isTargetLogScaled) {
+                        double currentLogTargetValue = LogLinearTransform.getLogarithmicValue(currentLinearTargetValue, minTargetValue, maxTargetValue);
+                        targetCPD.getPointAt(i).setSample(currentLogTargetValue);
+                    } else {
+                        targetCPD.getPointAt(i).setSample(currentLinearTargetValue);
+                    }
+
+
+                } else {
+                    // cant do much here so just set all to min value and let user fix either palette or bad entry
+                    targetCPD.getPointAt(i).setSample(minTargetValue);
+                }
+
+                Color currentSourceColor = sourceCPD.getPointAt(i).getColor();
+                targetCPD.getPointAt(i).setColor(currentSourceColor);
+                targetCPD.getPointAt(i).setLabel(sourceCPD.getPointAt(i).getLabel());
+            }
+
+        } else {
+            targetCPD.setPoints(sourceCPD.getPoints().clone());
+            targetCPD.setLogScaled(isTargetLogScaled);
+        }
+
+    }
+
+
+
 
     private static void alignNumPoints(ColorPaletteDef sourceCPD, ColorPaletteDef targetCPD) {
         int deltaNumPoints = targetCPD.getNumPoints() - sourceCPD.getNumPoints();
@@ -349,16 +473,34 @@ public class ImageInfo implements Cloneable {
      *
      * @param mode the histogram matching string
      *
-     * @return the histogram matching. {@link ImageInfo.HistogramMatching#None} if {@code maode} is not "Equalize" or "Normalize".
+     * @return the histogram matching. {@link HistogramMatching#None} if {@code maode} is not "Equalize" or "Normalize".
      */
-    public static ImageInfo.HistogramMatching getHistogramMatching(String mode) {
-        ImageInfo.HistogramMatching histogramMatchingEnum = ImageInfo.HistogramMatching.None;
+    public static HistogramMatching getHistogramMatching(String mode) {
+        HistogramMatching histogramMatchingEnum = HistogramMatching.None;
         if ("Equalize".equalsIgnoreCase(mode)) {
-            histogramMatchingEnum = ImageInfo.HistogramMatching.Equalize;
+            histogramMatchingEnum = HistogramMatching.Equalize;
         } else if ("Normalize".equalsIgnoreCase(mode)) {
-            histogramMatchingEnum = ImageInfo.HistogramMatching.Normalize;
+            histogramMatchingEnum = HistogramMatching.Normalize;
         }
         return histogramMatchingEnum;
+    }
+
+
+    public ColorSchemeInfo getColorSchemeInfo() {
+        return colorSchemeInfo;
+    }
+
+    public void setColorSchemeInfo(ColorSchemeInfo colorSchemeInfo) {
+        this.colorSchemeInfo = colorSchemeInfo;
+    }
+
+
+    public Boolean getZoomToHistLimits() {
+        return zoomToHistLimits;
+    }
+
+    public void setZoomToHistLimits(Boolean zoomToHistLimits) {
+        this.zoomToHistLimits = zoomToHistLimits;
     }
 
 }

--- a/snap-core/src/main/java/org/esa/snap/core/util/NamingConvention.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/NamingConvention.java
@@ -1,0 +1,15 @@
+package org.esa.snap.core.util;
+
+/**
+ * Stores tool names and spellings which may differ in packages which implement SNAP
+ * @author Daniel Knowles (NASA)
+ */
+public class NamingConvention extends NamingConventionSnap {
+
+    // Uncomment the following for SeaDAS to override Snap naming convention :
+
+//    public static final String COLOR_UPPER_CASE = "COLOR";
+//    public static final String COLOR_MIXED_CASE = "Color";
+//    public static final String COLOR_LOWER_CASE = "color";
+
+}

--- a/snap-core/src/main/java/org/esa/snap/core/util/NamingConventionSnap.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/NamingConventionSnap.java
@@ -1,0 +1,12 @@
+package org.esa.snap.core.util;
+
+/**
+ * Stores tool names and spellings which may differ in packages which implement SNAP
+ * @author Daniel Knowles (NASA)
+ */
+public class NamingConventionSnap {
+
+    public static final String COLOR_UPPER_CASE = "COLOUR";
+    public static final String COLOR_MIXED_CASE = "Colour";
+    public static final String COLOR_LOWER_CASE = "colour";
+}

--- a/snap-core/src/main/java/org/esa/snap/core/util/ResourceInstaller.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/ResourceInstaller.java
@@ -87,6 +87,9 @@ public class ResourceInstaller {
         }
     }
 
+
+
+
     private void copyResources(Collection<Path> resources, ProgressMonitor pm) throws IOException {
         synchronized (ResourceInstaller.class) {
             pm.beginTask("Copying resources...", resources.size());

--- a/snap-core/src/main/java/org/esa/snap/core/util/math/Histogram.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/math/Histogram.java
@@ -32,6 +32,9 @@ import java.awt.image.RenderedImage;
  *
  * @author Norman Fomferra
  */
+// Feb 2020 - Daniel Knowles
+//          - Added method findRangeForPercent() to enable retrieval of any range between 0% and 100%
+
 public class Histogram extends Range {
 
     public static final float LEFT_AREA_SKIPPED_95 = 0.025F;
@@ -120,6 +123,30 @@ public class Histogram extends Range {
     public Range findRangeFor95Percent() {
         return findRange(LEFT_AREA_SKIPPED_95, RIGHT_AREA_SKIPPED_95);
     }
+
+
+
+
+    /**
+     * Returns the value range for any threshold of 0% to 100% where the sum of all bin values are skipped from the the lower and
+     * upper bounds of this histogram.
+     *
+     * @return the skipped value range, that include given percent of the sum of all bin values
+     */
+    public Range findRangeForPercent(double threshold) {
+        if (threshold >0 && threshold <= 100) {
+            double limits = (100 - threshold) / (100 * 2);
+            return findRange(limits, limits);
+        }
+
+        return null;
+    }
+
+
+
+
+
+
 
     /**
      * Returns the value range for the case that the given ratios of the sum of all bin values are skipped from the

--- a/snap-core/src/main/java/org/esa/snap/core/util/math/LogLinearTransform.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/math/LogLinearTransform.java
@@ -1,0 +1,174 @@
+package org.esa.snap.core.util.math;
+
+/**
+ * Math utils for transforming between log and linear.
+ *
+ * @author Daniel Knowles (NASA)
+ * @version $Revision$ $Date$
+ */
+
+
+public class LogLinearTransform {
+
+
+    private static final double FORCED_CHANGE_FACTOR = 0.0001;
+
+    public static double getLinearValueUsingLinearWeight(double linearWeight, double min, double max) {
+
+        // Prevent extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearWeight == 0) {
+            return min;
+        }
+        if (linearWeight == 1) {
+            return max;
+        }
+
+        double deltaNormalized = (max - min);
+        double linearValue = min + linearWeight * (deltaNormalized);
+
+        // Prevent UNEXPECTED interpolation/extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearWeight > 0 && linearValue < min) {
+            return min;
+        }
+        if (linearWeight < 1 && linearValue > max) {
+            return max;
+        }
+        if (linearWeight < 0 && linearValue >= min) {
+            return min - (max - min) * FORCED_CHANGE_FACTOR;
+        }
+        if (linearWeight > 1 && linearValue <= max) {
+            return max + (max - min) * FORCED_CHANGE_FACTOR;
+        }
+
+        return linearValue;
+    }
+
+    public static double getLogarithmicValueUsingLinearWeight(double weight, double min, double max) {
+
+        double linearValue = getLinearValueUsingLinearWeight(weight, min, max);
+
+        // Prevent extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearValue == min) {
+            return min;
+        }
+        if (linearValue == max) {
+            return max;
+        }
+
+        double b = Math.log(max / min) / (max - min);
+        double a = min / (Math.exp(b * min));
+        double logValue = a * Math.exp(b * linearValue);
+
+        // Prevent UNEXPECTED interpolation/extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearValue > min && logValue < min) {
+            return min;
+        }
+        if (linearValue < max && logValue > max) {
+            return max;
+        }
+        if (linearValue < min && logValue >= min) {
+            return min - (max - min) * FORCED_CHANGE_FACTOR;
+        }
+        if (linearValue > max && logValue <= max) {
+            return max + (max - min) * FORCED_CHANGE_FACTOR;
+        }
+
+        return logValue;
+    }
+
+    public static double getLogarithmicValue(double linearValue, double min, double max) {
+
+        // Prevent extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearValue == min) {
+            return min;
+        }
+        if (linearValue == max) {
+            return max;
+        }
+
+        double b = Math.log(max / min) / (max - min);
+        double a = min / (Math.exp(b * min));
+        double logValue = a * Math.exp(b * linearValue);
+
+        // Prevent UNEXPECTED interpolation/extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearValue > min && logValue < min) {
+            return min;
+        }
+        if (linearValue < max && logValue > max) {
+            return max;
+        }
+        if (linearValue < min && logValue >= min) {
+            return min - (max - min) * FORCED_CHANGE_FACTOR;
+        }
+        if (linearValue > max && logValue <= max) {
+            return max + (max - min) * FORCED_CHANGE_FACTOR;
+        }
+
+        return logValue;
+    }
+
+    public static double getLinearValue(double linearWeight, double min, double max) {
+
+        // Prevent extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearWeight == 0) {
+            return min;
+        }
+        if (linearWeight == 1) {
+            return max;
+        }
+
+        double deltaNormalized = (max - min);
+        double linearValue = min + linearWeight * (deltaNormalized);
+
+        // Prevent UNEXPECTED interpolation/extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearWeight > 0 && linearValue < min) {
+            return min;
+        }
+        if (linearWeight < 1 && linearValue > max) {
+            return max;
+        }
+        if (linearWeight < 0 && linearValue >= min) {
+            return min - (max - min) * FORCED_CHANGE_FACTOR;
+        }
+        if (linearWeight > 1 && linearValue <= max) {
+            return max + (max - min) * FORCED_CHANGE_FACTOR;
+        }
+
+        return linearValue;
+    }
+
+
+    public static double getLinearWeightFromLogValue(double logValue, double min, double max) {
+
+        // Prevent extrapolation which could occur due to machine roundoffs in the calculations
+        if (logValue == min) {
+            return 0;
+        }
+        if (logValue == max) {
+            return 1;
+        }
+
+        double b = Math.log(max / min) / (max - min);
+        double a = min / (Math.exp(b * min));
+
+//        double linearWeight = Math.log(logValue / a) / b;
+//        linearWeight = (linearWeight - min) / (max - min);
+        double linearWeight = ((Math.log(logValue / a) / b) - min) / (max - min);
+
+        // Prevent UNEXPECTED interpolation/extrapolation which could occur due to machine roundoffs in the calculations
+        if (logValue > min && linearWeight < 0) {
+            return 0;
+        }
+        if (logValue < max && linearWeight > 1) {
+            return 1;
+        }
+        if (logValue < min && linearWeight >= 0) {
+            return 0 - FORCED_CHANGE_FACTOR;
+        }
+        if (logValue > max && linearWeight <= 1) {
+            return 1 + FORCED_CHANGE_FACTOR;
+        }
+
+        return linearWeight;
+    }
+}


### PR DESCRIPTION
Major modifications to the Color Manipulation Tool. This spans both the snap-engine and snap-desktop repositories and has been merged with the master.

The key modifications/additions are:

    1. Incorporates color schemes which are auto-applied based on a band-name lookup (configurable in preferences and by editing the xml file)
    2. Imports and export cpt format files
    3.  Adds palette reversal capability
    4. Adds a robust Color Manipulation preferences page
    5. Fixes a bug in the "From Palette" button (button was named "From File")
    6. Adds in some text constants for the spelling of the word colour (enables easily reconfiguring between "Color" and "Colour" spelling)
    7. Fixes bug where the "More Options" GUI would not change it's fields between RGB, Indexed band, and SingleBand mode. Previously it would get stuck in the first mode loaded in until application restart.
    8. Fixes bugs associated with log scaling where the color bar display would get scrunched up
    9. Add log scaling attribute to the cpd palette files and it's reader. When not present the palette is treated as linear.
    10. Added some RGB profiles which automatically get installed in auxdata.
    11. Added some color palette used by NASA Ocean Color.
    12. Updated the help page and added a Color Manipulation Preferences help page.
    13. Adds configurable control for the user for the default color behavior when not using a color scheme.
    14. Fixes bugs such that color palette point values cannot be edit to be greater than the next point or less than the previous point.
    15. Prevent entering a value of 0 or less when in log scaling.
    16. Adds the log scaling in all 3 Editor modes (for convenience).
    17. Realigns buttons vertically instead of 2 columns for better space management.
    18. Color Manipulation tool is now wrapped in a scroll pane.
    19. Added a convenience range auto-adjustment button in the Sliders editor for RGB mode which sets the range to a preset range (default: min=0, max=1). This range is useful for reflectance bands. The actual values of this preset range configured in the preferences.
    20. Added additional auto-range adjustment buttons for the sliders based on 1sigma, 2sigma, and 3sigma percentages.
    21. Added ability to configure which buttons are shown in the "Sliders Editor". The 95% button if hidden now by default.
    22. Merge the horizontal zoom into a single toggle button.
    23. The preference page contains a restore to defaults setting.

Note: This branch is intentionally configured for SNAP. SeaDAS will likely make minor changes to the defaults. The majority of any configuration adjustments which may differ between SNAP and SeaDAS can be found in:
snap-engine/snap-core/src/main/java/org/esa/snap/core/datamode/ColorManipulationDefaults.java
snap-engine/snap-core/src/main/java/org/esa/snap/core/util/NamingConvention.java
snap-desktop/snap-ui/src/main/resources/auxdata/color_schemes/color_palette_schemes.xml
snap-desktop/snap-ui/src/main/resources/auxdata/color_schemes/color_palette_scheme_lookup.xml

Branch: SeaDAS-008f-master