### PR TITLE
ASTER GDEM v2 to ASTER GDEM v3

### DIFF
--- a/snap-dem/src/main/java/org/esa/snap/dem/dataio/aster/AsterFile.java
+++ b/snap-dem/src/main/java/org/esa/snap/dem/dataio/aster/AsterFile.java
@@ -53,12 +53,12 @@ public final class AsterFile extends ElevationFile {
             return true;
         } else {
             final String name = FileUtils.getFilenameWithoutExtension(localFile.getName());
-            // check for version 2
-            final String v2Name = name.replace("ASTGTM", "ASTGTM2");
-            final File v2File = new File(localFile.getParentFile(), v2Name + ".zip");
-            if (v2File.exists()) {
-                localFile = new File(localFile.getParentFile(), v2Name + "_dem.tif");
-                localZipFile = v2File;
+            // check for version 3 (see https://lpdaac.usgs.gov/products/astgtmv002/)
+            final String v3Name = name.replace("ASTGTM", "ASTGTMV003");
+            final File v3File = new File(localFile.getParentFile(), v3Name + ".zip");
+            if (v3File.exists()) {
+                localFile = new File(localFile.getParentFile(), v3Name + "_dem.tif");
+                localZipFile = v3File;
                 return true;
             } else {
                 // check if unzipped
@@ -67,9 +67,9 @@ public final class AsterFile extends ElevationFile {
                     localFile = unzipFile;
                     return true;
                 } else {
-                    final File v2UnzipFile = new File(localFile.getParentFile(), v2Name + "_dem.tif");
-                    if (v2UnzipFile.exists()) {
-                        localFile = v2UnzipFile;
+                    final File v3UnzipFile = new File(localFile.getParentFile(), v3Name + "_dem.tif");
+                    if (v3UnzipFile.exists()) {
+                        localFile = v3UnzipFile;
                         return true;
                     }
                 }
@@ -80,8 +80,8 @@ public final class AsterFile extends ElevationFile {
 
     protected InputStream getZipInputStream(File dataFile) throws IOException {
         if (!dataFile.exists()) {
-            final String v2Name = dataFile.getName().replace("ASTGTM", "ASTGTM2");
-            dataFile = new File(dataFile.getParentFile(), v2Name);
+            final String v3Name = dataFile.getName().replace("ASTGTM", "ASTGTMV003");
+            dataFile = new File(dataFile.getParentFile(), v3Name);
         }
         return super.getZipInputStream(dataFile);
     }

--- a/snap-dem/src/main/java/org/esa/snap/dem/dataio/aster/AsterFile.java
+++ b/snap-dem/src/main/java/org/esa/snap/dem/dataio/aster/AsterFile.java
@@ -54,11 +54,11 @@ public final class AsterFile extends ElevationFile {
         } else {
             final String name = FileUtils.getFilenameWithoutExtension(localFile.getName());
             // check for version 3 (see https://lpdaac.usgs.gov/products/astgtmv002/)
-            final String v3Name = name.replace("ASTGTM", "ASTGTMV003");
-            final File v3File = new File(localFile.getParentFile(), v3Name + ".zip");
-            if (v3File.exists()) {
-                localFile = new File(localFile.getParentFile(), v3Name + "_dem.tif");
-                localZipFile = v3File;
+            final String versionName = name.replace("ASTGTM", "ASTGTMV003");
+            final File versionFile = new File(localFile.getParentFile(), versionName + ".zip");
+            if (versionFile.exists()) {
+                localFile = new File(localFile.getParentFile(), versionName + "_dem.tif");
+                localZipFile = versionFile;
                 return true;
             } else {
                 // check if unzipped
@@ -67,9 +67,9 @@ public final class AsterFile extends ElevationFile {
                     localFile = unzipFile;
                     return true;
                 } else {
-                    final File v3UnzipFile = new File(localFile.getParentFile(), v3Name + "_dem.tif");
-                    if (v3UnzipFile.exists()) {
-                        localFile = v3UnzipFile;
+                    final File versionUnzipFile = new File(localFile.getParentFile(), versionName + "_dem.tif");
+                    if (versionUnzipFile.exists()) {
+                        localFile = versionUnzipFile;
                         return true;
                     }
                 }
@@ -80,8 +80,8 @@ public final class AsterFile extends ElevationFile {
 
     protected InputStream getZipInputStream(File dataFile) throws IOException {
         if (!dataFile.exists()) {
-            final String v3Name = dataFile.getName().replace("ASTGTM", "ASTGTMV003");
-            dataFile = new File(dataFile.getParentFile(), v3Name);
+            final String versionName = dataFile.getName().replace("ASTGTM", "ASTGTMV003");
+            dataFile = new File(dataFile.getParentFile(), versionName);
         }
         return super.getZipInputStream(dataFile);
     }


### PR DESCRIPTION
ASTER GDEM v2 is deemed to be deprecated (https://lpdaac.usgs.gov/products/astgtmv002/), and is wiped from all official NASA/ASTER sites, excluding some Wuhan university geoinformatics faculty FTP server (http://sendimage.whu.edu.cn/res/DEM_share/ASTER%20GDEM%20v2), but it is slow and untrusted to me.

I decided to compare v2 and v3 versions, and I found that v3 is better than v2:

1) https://i.imgur.com/1XoVe5H.png (ASTER GDEM v2 screenshot)
2) https://i.imgur.com/FunLwNT.png (ASTER GDEM v3 screenshot)
3) https://i.imgur.com/Kg1CYjk.png (Mine ROI)

Because of that fact, I've decided to make some changes in AsterFile.java.

Here is the N/E list:

N57E049
N57E050
N57E048
N57E047
N57E046
N56E050
N56E049
N56E048
N56E047
N56E046
N55E050
N55E049
N55E048
N55E047

Here is the S1 GRDH product name:

S1B_IW_GRDH_1SDV_20200803T030343_20200803T030407_022753_02B2E8_EB4C

PS: It would be fine, if user is given choice of v2 and v3 versions.
PPS: I've not found any comprehensible answer on STEP ESA forum about using v3, but encountered with this topic (https://forum.step.esa.int/t/terrain-correction-with-external-dem/19171) that indicates that users can't find a description of way to properly use v3 instead of nearly deleted v2.
PPPS: I've commited to 8.x branch because I didn't got success at Maven building of current master branch.