### PR TITLE
SNAP-1405: download s2 from aws fix

### DIFF
--- a/snap-remote-products-repository/pom.xml
+++ b/snap-remote-products-repository/pom.xml
@@ -19,7 +19,7 @@
     <description>The Remote Products Repository allows downloading the products from a list of repositories.</description>
 
     <properties>
-        <tao.version>1.0.4.1</tao.version>
+        <tao.version>1.0.4.2</tao.version>
     </properties>
 
     <dependencies>

--- a/snap-remote-products-repository/src/main/java/org/esa/snap/remote/products/repository/download/DownloadProductStatusListener.java
+++ b/snap-remote-products-repository/src/main/java/org/esa/snap/remote/products/repository/download/DownloadProductStatusListener.java
@@ -47,6 +47,11 @@ class DownloadProductStatusListener implements ProductStatusListener {
         this.downloadMessages.add(message);
     }
 
+    @Override
+    public void downloadQueued(EOProduct eoProduct, String message) {
+        //no action for now
+    }
+
     public List<String> getDownloadMessages() {
         return this.downloadMessages;
     }


### PR DESCRIPTION
Update TAO version after fix issue with downloading S2 products from AWS remote repository.
JIRA: [SNAP-1405](https://senbox.atlassian.net/browse/SNAP-1405)