### PR TITLE
SIITBX-459 Workaround deadlock on graphprocessor

### DIFF
--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/graph/GraphProcessor.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/graph/GraphProcessor.java
@@ -168,7 +168,17 @@ public class GraphProcessor {
             return Long.compare(area1, area2);
         });
 
-//        System.out.println("graphContext = " + graphContext.getGraph().getId());
+// //        System.out.println("graphContext = " + graphContext.getGraph().getId());
+//             Long area1 = (long) (d1.width) * (long) (d1.height);
+//             Long area2 = (long) (d2.width) * (long) (d2.height);
+//             return area1.compareTo(area2);
+//         });
+
+        int numPmTicks = graphContext.getGraph().getNodeCount();
+        for (Dimension dimension : dimList) {
+            numPmTicks += dimension.width * dimension.height * tileDimMap.get(dimension).size();
+        }
+
         ImagingListener imagingListener = JAI.getDefaultInstance().getImagingListener();
         JAI.getDefaultInstance().setImagingListener(new GPFImagingListener());
 
@@ -187,11 +197,6 @@ public class GraphProcessor {
             }
         }
 
-        int numPmTicks = graphContext.getGraph().getNodeCount();
-        for (Dimension dimension : dimList) {
-            numPmTicks += dimension.width * dimension.height * tileDimMap.get(dimension).size();
-        }
-
         try {
             pm.beginTask("Executing operators...", numPmTicks);
             for (NodeContext outputNodeContext : outputNodeContexts) {
@@ -205,20 +210,20 @@ public class GraphProcessor {
                 final int numXTiles = dimension.width;
                 final int numYTiles = dimension.height;
                 Dimension tileSize = nodeContextList.get(0).getTargetProduct().getPreferredTileSize();
-                if (canComputeTileStack) {
-                    for (int tileY = 0; tileY < numYTiles; tileY++) {
-                        for (int tileX = 0; tileX < numXTiles; tileX++) {
-                            if (pm.isCanceled()) {
-                                return graphContext.getOutputProducts();
-                            }
-                            Rectangle tileRectangle = new Rectangle(tileX * tileSize.width,
-                                                                    tileY * tileSize.height,
-                                                                    tileSize.width,
-                                                                    tileSize.height);
-                            fireTileStarted(graphContext, tileRectangle);
-                            for (NodeContext nodeContext : nodeContextList) {
-                                Product targetProduct = nodeContext.getTargetProduct();
-
+                for (int tileY = 0; tileY < numYTiles; tileY++) {
+                    for (int tileX = 0; tileX < numXTiles; tileX++) {
+                        if (pm.isCanceled()) {
+                            // todo - check: throw exception here? (nf, 2010.10.21)
+                            return graphContext.getOutputProducts();
+                        }
+                        Rectangle tileRectangle = new Rectangle(tileX * tileSize.width,
+                                tileY * tileSize.height,
+                                tileSize.width,
+                                tileSize.height);
+                        fireTileStarted(graphContext, tileRectangle);
+                        for (NodeContext nodeContext : nodeContextList) {
+                            Product targetProduct = nodeContext.getTargetProduct();
+                            if (canComputeTileStack) {
                                 // (1) Pull tile from first OperatorImage we find. This will trigger pulling
                                 // tiles of all other OperatorImage computed stack-wise.
                                 //
@@ -243,31 +248,11 @@ public class GraphProcessor {
                                         }
                                     }
                                 }
-                            }
-                            fireTileStopped(graphContext, tileRectangle);
-                            pm.worked(1);
-                        }
-                    }
-                } else {
-                    for (NodeContext nodeContext : nodeContextList) {
-                        Product targetProduct = nodeContext.getTargetProduct();
-                        boolean monitorProgress = true;
-                        for (Band band : targetProduct.getBands()) {
-                            PlanarImage image = nodeContext.getTargetImage(band);
-                            for (int tileY = 0; tileY < numYTiles; tileY++) {
-                                for (int tileX = 0; tileX < numXTiles; tileX++) {
-                                    if (pm.isCanceled()) {
-                                        return graphContext.getOutputProducts();
-                                    }
-
-                                    Rectangle tileRectangle = new Rectangle(tileX * tileSize.width,
-                                                                            tileY * tileSize.height,
-                                                                            tileSize.width,
-                                                                            tileSize.height);
-                                    fireTileStarted(graphContext, tileRectangle);
-
-                                    // Simply pull tile from source images of regular bands.
-                                    //
+                            } else {
+                                // Simply pull tile from source images of regular bands.
+                                //
+                                for (Band band : targetProduct.getBands()) {
+                                    PlanarImage image = nodeContext.getTargetImage(band);
                                     if (image != null) {
                                         forceTileComputation(image, tileX, tileY, semaphore, tileScheduler, listeners,
                                                              parallelism);
@@ -275,17 +260,12 @@ public class GraphProcessor {
                                         forceTileComputation(band.getSourceImage(), tileX, tileY, semaphore,
                                                              tileScheduler, listeners, parallelism);
                                     }
-                                    fireTileStopped(graphContext, tileRectangle);
-                                    if (monitorProgress) {
-                                        pm.worked(1);
-                                        // as a consequence of inverting the loop, progressMonitor ticks must only be increased
-                                        // once per product processed. This crude boolean logic ensures that. Nevertheless,
-                                        // this class needs refactoring! tb 2021-05-21
-                                        monitorProgress = false;
-                                    }
                                 }
                             }
+
+                            pm.worked(1);
                         }
+                        fireTileStopped(graphContext, tileRectangle);
                     }
                 }
             }


### PR DESCRIPTION
We purpose a workaround by removing graphprocessor optimization waiting a better solution.
The deadlock appear with the graphprocessor optimization (https://github.com/senbox-org/snap-engine/commit/5af4f66910ad8fa03399c40df37acba9e8977cc2). We guess the deadlock come from the S2reader structure (The addition in snap 9 are not involved. Test without new S2 features has been made and the crash still remain).
