### PR TITLE
Color Manipulation parameters added to snap.properties file

### DIFF
--- a/etc/snap.properties
+++ b/etc/snap.properties
@@ -53,3 +53,36 @@ snap.color-palette.unit.tree_cover_percent=tree_cover_percent.cpd
 snap.gpf.unsupported.CoarseFine-Coregistration = "Operator CoarseFine-Coregistration replaced by Cross-Correlation"
 snap.gpf.unsupported.GCP-Selection = "Operator GCP-Selection replaced by Cross-Correlation"
 snap.gpf.unsupported.LinearToFromdB = "Operator LinearTodB renamed to LinearToFromdB"
+
+
+# Color Manipulation Preferences (shown here with SNAP Defaults)
+#   Commented out because these not needed but useful in showing what the keys and associated SNAP defaults are
+#   for the case of branding or other initial configurations.
+# snap.color.manipulation.palette.default.gray.scale=gray_scale.cpd
+# snap.color.manipulation.palette.default.standard=oceancolor_standard.cpd
+# snap.color.manipulation.palette.default.universal=universal_bluered.cpd
+# snap.color.manipulation.palette.default.anomalies=gradient_red_white_blue.cpd
+# snap.color.manipulation.scheme.default.enable=false
+# snap.color.manipulation.scheme.default.palette=GRAY-SCALE
+# snap.color.manipulation.scheme.default.range=From Data
+# snap.color.manipulation.scheme.default.log=FALSE
+# snap.color.manipulation.scheme.band.lookup.auto.apply=false
+# snap.color.manipulation.scheme.band.lookup.palette=From Scheme STANDARD
+# snap.color.manipulation.scheme.band.lookup.range=From Scheme
+# snap.color.manipulation.scheme.band.lookup.log=From Scheme
+# snap.color.manipulation.percentile.value=92.0
+# snap.color.manipulation.percentile.1.sigma.enable.button=false
+# snap.color.manipulation.percentile.2.sigma.enable.button=true
+# snap.color.manipulation.percentile.3.sigma.enable.button=true
+# snap.color.manipulation.percentile.95.percent.enable.button=false
+# snap.color.manipulation.percentile.100.percent.enable.button=true
+# snap.color.manipulation.scheme.selector.verbose=false
+# snap.color.manipulation.scheme.selector.sort=true
+# snap.color.manipulation.scheme.selector.split=true
+# snap.color.manipulation.scheme.selector.show.disabled=false
+# snap.color.manipulation.sliders.zoom.in=true
+# snap.color.manipulation.sliders.extra.info=true
+# snap.color.manipulation.sliders.zoom.vertical.enable.buttons=true
+# snap.color.manipulation.sliders.extra.info.enable.button=true
+# snap.color.manipulation.rgb.button.min=0.0
+# snap.color.manipulation.rgb.button.max=1.0

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorManipulationDefaults.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorManipulationDefaults.java
@@ -1,6 +1,7 @@
 package org.esa.snap.core.datamodel;
 
 import org.esa.snap.core.util.NamingConvention;
+
 import static org.esa.snap.core.util.NamingConvention.*;
 
 
@@ -67,8 +68,6 @@ public class ColorManipulationDefaults {
     private static final String PROPERTY_ROOT_KEY = "color.manipulation";
 
 
-
-
     // Palettes (Default)
 
     private static final String PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".palette.default";
@@ -80,24 +79,23 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".gray.scale";
     public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_LABEL = OPTION_COLOR_GRAY_SCALE;
     public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_TOOLTIP = "The palette file to use when GRAY-SCALE is selected";
-    public static  String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_DEFAULT = PALETTE_GRAY_SCALE_DEFAULT;
+    public static String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_DEFAULT = PALETTE_GRAY_SCALE_DEFAULT;
 
     public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".standard";
     public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_LABEL = OPTION_COLOR_STANDARD;
-    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_TOOLTIP = "The palette file to use when STANDARD " + COLOR_UPPER_CASE +" is selected";
-    public static  String PROPERTY_PALETTE_DEFAULT_STANDARD_DEFAULT = PALETTE_STANDARD_DEFAULT;
+    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_TOOLTIP = "The palette file to use when STANDARD " + COLOR_UPPER_CASE + " is selected";
+    public static String PROPERTY_PALETTE_DEFAULT_STANDARD_DEFAULT = PALETTE_STANDARD_DEFAULT;
 
     public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".universal";
     public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_LABEL = OPTION_COLOR_UNIVERSAL;
     public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_TOOLTIP = "<html>The color blind compliant palette file to use when <br>" +
             "UNIVERSAL " + COLOR_UPPER_CASE + " is selected</html>";
-    public static  String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_DEFAULT = PALETTE_UNIVERSAL_DEFAULT;
+    public static String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_DEFAULT = PALETTE_UNIVERSAL_DEFAULT;
 
     public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".anomalies";
     public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_LABEL = OPTION_COLOR_ANOMALIES;
     public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_TOOLTIP = "The palette file to use when ANOMALIES is selected";
-    public static  String PROPERTY_PALETTE_DEFAULT_ANOMALIES_DEFAULT = PALETTE_ANOMALIES_DEFAULT;
-
+    public static String PROPERTY_PALETTE_DEFAULT_ANOMALIES_DEFAULT = PALETTE_ANOMALIES_DEFAULT;
 
 
     // Scheme (Default)
@@ -130,7 +128,7 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_GENERAL_RANGE_TOOLTIP = "Range options to use when NOT using a " + COLOR_LOWER_CASE + "scheme";
     public static final String PROPERTY_GENERAL_RANGE_OPTION1 = OPTION_RANGE_FROM_DATA;
     public static final String PROPERTY_GENERAL_RANGE_OPTION2 = OPTION_RANGE_FROM_PALETTE;
-    public static  String PROPERTY_GENERAL_RANGE_DEFAULT = OPTION_RANGE_FROM_DATA;
+    public static String PROPERTY_GENERAL_RANGE_DEFAULT = OPTION_RANGE_FROM_DATA;
 
     public static final String PROPERTY_GENERAL_LOG_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".log";
     public static final String PROPERTY_GENERAL_LOG_LABEL = "Log Scaling";
@@ -138,12 +136,7 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_GENERAL_LOG_OPTION1 = OPTION_LOG_TRUE;
     public static final String PROPERTY_GENERAL_LOG_OPTION2 = OPTION_LOG_FALSE;
     public static final String PROPERTY_GENERAL_LOG_OPTION3 = OPTION_LOG_FROM_PALETTE;
-    public static  String PROPERTY_GENERAL_LOG_DEFAULT = OPTION_LOG_FALSE;
-
-
-
-
-
+    public static String PROPERTY_GENERAL_LOG_DEFAULT = OPTION_LOG_FALSE;
 
 
     // Scheme (Band Lookup))
@@ -157,9 +150,9 @@ public class ColorManipulationDefaults {
 
     public static final String PROPERTY_SCHEME_AUTO_APPLY_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".auto.apply";
     public static final String PROPERTY_SCHEME_AUTO_APPLY_LABEL = "Auto-apply";
-    public static final String PROPERTY_SCHEME_AUTO_APPLY_TOOLTIP = "<html>Apply " + NamingConvention.COLOR_LOWER_CASE +" schemes automatically<br>" +
+    public static final String PROPERTY_SCHEME_AUTO_APPLY_TOOLTIP = "<html>Apply " + NamingConvention.COLOR_LOWER_CASE + " schemes automatically<br>" +
             " when opening a band based on its name</html>";
-    public static  boolean PROPERTY_SCHEME_AUTO_APPLY_DEFAULT = false;
+    public static boolean PROPERTY_SCHEME_AUTO_APPLY_DEFAULT = false;
 
 
     public static final String PROPERTY_SCHEME_PALETTE_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".palette";
@@ -179,7 +172,7 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_SCHEME_RANGE_OPTION1 = OPTION_RANGE_FROM_SCHEME;
     public static final String PROPERTY_SCHEME_RANGE_OPTION2 = OPTION_RANGE_FROM_DATA;
     public static final String PROPERTY_SCHEME_RANGE_OPTION3 = OPTION_RANGE_FROM_PALETTE;
-    public static  String PROPERTY_SCHEME_RANGE_DEFAULT = OPTION_RANGE_FROM_SCHEME;
+    public static String PROPERTY_SCHEME_RANGE_DEFAULT = OPTION_RANGE_FROM_SCHEME;
 
     public static final String PROPERTY_SCHEME_LOG_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".log";
     public static final String PROPERTY_SCHEME_LOG_LABEL = "Log Scaling";
@@ -188,9 +181,7 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_SCHEME_LOG_OPTION2 = OPTION_LOG_FROM_PALETTE;
     public static final String PROPERTY_SCHEME_LOG_OPTION3 = OPTION_LOG_TRUE;
     public static final String PROPERTY_SCHEME_LOG_OPTION4 = OPTION_LOG_FALSE;
-    public static  String PROPERTY_SCHEME_LOG_DEFAULT = OPTION_LOG_FROM_SCHEME;
-
-
+    public static String PROPERTY_SCHEME_LOG_DEFAULT = OPTION_LOG_FROM_SCHEME;
 
 
     // Range Percentile Default Options
@@ -205,38 +196,33 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_RANGE_PERCENTILE_LABEL = "Percentile Default";
     public static final String PROPERTY_RANGE_PERCENTILE_TOOLTIP = "The percentile of the data to use for determining min, max range when clicking the using the " +
             "band statistics 'From Data'";
-    public static  double PROPERTY_RANGE_PERCENTILE_DEFAULT = 92.0;
+    public static double PROPERTY_RANGE_PERCENTILE_DEFAULT = 92.0;
 
 
     public static final String PROPERTY_100_PERCENT_BUTTON_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".100.percent.enable.button";
     public static final String PROPERTY_100_PERCENT_BUTTON_LABEL = "100% Button";
     public static final String PROPERTY_100_PERCENT_BUTTON_TOOLTIP = "Enable 100% range button in the sliders editor";
-    public static  boolean PROPERTY_100_PERCENT_BUTTON_DEFAULT = true;
+    public static boolean PROPERTY_100_PERCENT_BUTTON_DEFAULT = true;
 
     public static final String PROPERTY_95_PERCENT_BUTTON_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".95.percent.enable.button";
     public static final String PROPERTY_95_PERCENT_BUTTON_LABEL = "95% Button";
     public static final String PROPERTY_95_PERCENT_BUTTON_TOOLTIP = "Enable 95% range button in the sliders editor";
-    public static  boolean PROPERTY_95_PERCENT_BUTTON_DEFAULT = false;
+    public static boolean PROPERTY_95_PERCENT_BUTTON_DEFAULT = false;
 
     public static final String PROPERTY_1_SIGMA_BUTTON_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".1.sigma.enable.button";
     public static final String PROPERTY_1_SIGMA_BUTTON_LABEL = "<html>1&sigma; (68.27%) Button</html>";
     public static final String PROPERTY_1_SIGMA_BUTTON_TOOLTIP = "Enable 68.27% range button in the sliders editor";
-    public static  boolean PROPERTY_1_SIGMA_BUTTON_DEFAULT = false;
+    public static boolean PROPERTY_1_SIGMA_BUTTON_DEFAULT = false;
 
     public static final String PROPERTY_2_SIGMA_BUTTON_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".2.sigma.enable.button";
     public static final String PROPERTY_2_SIGMA_BUTTON_LABEL = "<html>2&sigma; (95.45%) Button</html>";
     public static final String PROPERTY_2_SIGMA_BUTTON_TOOLTIP = "Enable 95.45% range button in the sliders editor";
-    public static  boolean PROPERTY_2_SIGMA_BUTTON_DEFAULT = true;
+    public static boolean PROPERTY_2_SIGMA_BUTTON_DEFAULT = true;
 
     public static final String PROPERTY_3_SIGMA_BUTTON_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".3.sigma.enable.button";
     public static final String PROPERTY_3_SIGMA_BUTTON_LABEL = "<html>3&sigma; (99.73%) Button</html>";
     public static final String PROPERTY_3_SIGMA_BUTTON_TOOLTIP = "Enable 99.73% range button in the sliders editor";
-    public static  boolean PROPERTY_3_SIGMA_BUTTON_DEFAULT = true;
-
-
-
-
-
+    public static boolean PROPERTY_3_SIGMA_BUTTON_DEFAULT = true;
 
 
     // Scheme Selector Options
@@ -258,20 +244,19 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_SCHEME_SHOW_DISABLED_LABEL = "Show Disabled";
     public static final String PROPERTY_SCHEME_SHOW_DISABLED_TOOLTIP = "<html>Scheme selector will display all schemes <br>" +
             "including schemes with missing cpd files</html>";
-    public static  boolean PROPERTY_SCHEME_SHOW_DISABLED_DEFAULT = false;
+    public static boolean PROPERTY_SCHEME_SHOW_DISABLED_DEFAULT = false;
 
     public static final String PROPERTY_SCHEME_SORT_KEY = PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX + ".sort";
     public static final String PROPERTY_SCHEME_SORT_LABEL = "Sort";
     public static final String PROPERTY_SCHEME_SORT_TOOLTIP = "<html>Scheme selector will display all schemes alphabetically sorted<br>" +
             " as opposed to the original xml order</html>";
-    public static  boolean PROPERTY_SCHEME_SORT_DEFAULT = true;
+    public static boolean PROPERTY_SCHEME_SORT_DEFAULT = true;
 
     public static final String PROPERTY_SCHEME_CATEGORIZE_DISPLAY_KEY = PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX + ".split";
     public static final String PROPERTY_SCHEME_CATEGORIZE_DISPLAY_LABEL = "Categorize";
     public static final String PROPERTY_SCHEME_CATEGORIZE_DISPLAY_TOOLTIP = "<html>Scheme selector will display all schemes categorized into<br>" +
             "primary and additional categories by the PRIMARY field<br> of the color_palette_schemes.xml</html>";
-    public static  boolean PROPERTY_SCHEME_CATEGORIZE_DISPLAY_DEFAULT = true;
-
+    public static boolean PROPERTY_SCHEME_CATEGORIZE_DISPLAY_DEFAULT = true;
 
 
     // Sliders Editor Options
@@ -285,25 +270,23 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_SLIDERS_SHOW_INFORMATION_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".extra.info";
     public static final String PROPERTY_SLIDERS_SHOW_INFORMATION_LABEL = "Show Information";
     public static final String PROPERTY_SLIDERS_SHOW_INFORMATION_TOOLTIP = "Display information in the histogram/slider view by default";
-    public static  boolean PROPERTY_SLIDERS_SHOW_INFORMATION_DEFAULT = true;
+    public static boolean PROPERTY_SLIDERS_SHOW_INFORMATION_DEFAULT = true;
 
     public static final String PROPERTY_SLIDERS_ZOOM_IN_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".zoom.in";
     public static final String PROPERTY_SLIDERS_ZOOM_IN_LABEL = "Histogram Zoom";
     public static final String PROPERTY_SLIDERS_ZOOM_IN_TOOLTIP = "Display histogram slider view zoomed in by default";
-    public static  boolean PROPERTY_SLIDERS_ZOOM_IN_DEFAULT = true;
+    public static boolean PROPERTY_SLIDERS_ZOOM_IN_DEFAULT = true;
 
 
     public static final String PROPERTY_ZOOM_VERTICAL_BUTTONS_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".zoom.vertical.enable.buttons";
     public static final String PROPERTY_ZOOM_VERTICAL_BUTTONS_LABEL = "Vertical Zoom Buttons";
     public static final String PROPERTY_ZOOM_VERTICAL_BUTTONS_TOOLTIP = "Enable zoom vertical buttons in the sliders editor";
-    public static  boolean PROPERTY_ZOOM_VERTICAL_BUTTONS_DEFAULT = true;
+    public static boolean PROPERTY_ZOOM_VERTICAL_BUTTONS_DEFAULT = true;
 
     public static final String PROPERTY_INFORMATION_BUTTON_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".extra.info.enable.button";
     public static final String PROPERTY_INFORMATION_BUTTON_LABEL = "Information Button";
     public static final String PROPERTY_INFORMATION_BUTTON_TOOLTIP = "Enable histogram overlay information button in the sliders editor";
-    public static  boolean PROPERTY_INFORMATION_BUTTON_DEFAULT = true;
-
-
+    public static boolean PROPERTY_INFORMATION_BUTTON_DEFAULT = true;
 
 
     // RGB Options
@@ -317,13 +300,12 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_RGB_OPTIONS_MIN_KEY = PROPERTY_RGB_OPTIONS_KEY_SUFFIX + ".button.min";
     public static final String PROPERTY_RGB_OPTIONS_MIN_LABEL = "Range Button (Min)";
     public static final String PROPERTY_RGB_OPTIONS_MIN_TOOLTIP = "The min value to use in the RGB (A..B) range button";
-    public static  double PROPERTY_RGB_OPTIONS_MIN_DEFAULT = 0.0;
+    public static double PROPERTY_RGB_OPTIONS_MIN_DEFAULT = 0.0;
 
     public static final String PROPERTY_RGB_OPTIONS_MAX_KEY = PROPERTY_RGB_OPTIONS_KEY_SUFFIX + ".button.max";
     public static final String PROPERTY_RGB_OPTIONS_MAX_LABEL = "Range Button (Max)";
     public static final String PROPERTY_RGB_OPTIONS_MAX_TOOLTIP = "The max value to use in the RGB (A..B) range button";
-    public static  double PROPERTY_RGB_OPTIONS_MAX_DEFAULT = 1.0;
-
+    public static double PROPERTY_RGB_OPTIONS_MAX_DEFAULT = 1.0;
 
 
     // Restore to defaults

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorManipulationDefaults.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorManipulationDefaults.java
@@ -1,6 +1,7 @@
 package org.esa.snap.core.datamodel;
 
 import org.esa.snap.core.util.NamingConvention;
+
 import static org.esa.snap.core.util.NamingConvention.*;
 
 
@@ -40,7 +41,7 @@ public class ColorManipulationDefaults {
     public static final String OPTION_COLOR_UNIVERSAL_SCHEME = "From Scheme UNIVERSAL";
 
     // Color palette selections
-    public static final String OPTION_COLOR_GRAY_SCALE = "GRAY SCALE";
+    public static final String OPTION_COLOR_GRAY_SCALE = "GRAY-SCALE";
     public static final String OPTION_COLOR_STANDARD = "STANDARD";
     public static final String OPTION_COLOR_UNIVERSAL = "UNIVERSAL";
     public static final String OPTION_COLOR_ANOMALIES = "ANOMALIES";
@@ -67,20 +68,53 @@ public class ColorManipulationDefaults {
     private static final String PROPERTY_ROOT_KEY = "color.manipulation";
 
 
-    // General (Non-Scheme) Options
 
-    private static final String PROPERTY_GENERAL_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".general";
+
+    // Palettes (Default)
+
+    private static final String PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".palette.default";
+
+    public static final String PROPERTY_PALETTE_DEFAULT_SECTION_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_PALETTE_DEFAULT_SECTION_LABEL = "Palettes (Default)";
+    public static final String PROPERTY_PALETTE_DEFAULT_SECTION_TOOLTIP = "Palettes to use with associated variables name";
+
+    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".gray.scale";
+    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_LABEL = OPTION_COLOR_GRAY_SCALE;
+    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_TOOLTIP = "The palette file to use when GRAY-SCALE is selected";
+    public static  String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_DEFAULT = PALETTE_GRAY_SCALE_DEFAULT;
+
+    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".standard";
+    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_LABEL = OPTION_COLOR_STANDARD;
+    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_TOOLTIP = "The palette file to use when STANDARD " + COLOR_UPPER_CASE +" is selected";
+    public static  String PROPERTY_PALETTE_DEFAULT_STANDARD_DEFAULT = PALETTE_STANDARD_DEFAULT;
+
+    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".universal";
+    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_LABEL = OPTION_COLOR_UNIVERSAL;
+    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_TOOLTIP = "<html>The color blind compliant palette file to use when <br>" +
+            "UNIVERSAL " + COLOR_UPPER_CASE + " is selected</html>";
+    public static  String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_DEFAULT = PALETTE_UNIVERSAL_DEFAULT;
+
+    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".anomalies";
+    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_LABEL = OPTION_COLOR_ANOMALIES;
+    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_TOOLTIP = "The palette file to use when ANOMALIES is selected";
+    public static  String PROPERTY_PALETTE_DEFAULT_ANOMALIES_DEFAULT = PALETTE_ANOMALIES_DEFAULT;
+
+
+
+    // Scheme (Default)
+
+    private static final String PROPERTY_GENERAL_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".scheme.default";
 
     public static final String PROPERTY_GENERAL_SECTION_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".section";
-    public static final String PROPERTY_GENERAL_SECTION_LABEL = "Standard Options";
+    public static final String PROPERTY_GENERAL_SECTION_LABEL = "Scheme (Default)";
     public static final String PROPERTY_GENERAL_SECTION_TOOLTIP = "General behavior when not using a " + COLOR_LOWER_CASE + " scheme";
 
 
-    public static final String PROPERTY_GENERAL_CUSTOM_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".custom";
-    public static final String PROPERTY_GENERAL_CUSTOM_LABEL = "Use Standard Options as Default";
-    public static final String PROPERTY_GENERAL_CUSTOM_TOOLTIP = "<html>Use Standard Options as default<br>" +
+    public static final String PROPERTY_GENERAL_CUSTOM_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".enable";
+    public static final String PROPERTY_GENERAL_CUSTOM_LABEL = "Enable";
+    public static final String PROPERTY_GENERAL_CUSTOM_TOOLTIP = "<html>Ude following scheme parameters as default<br>" +
             " when opening a band<br>otherwise use settings from the file reader.</html>";
-    public static final boolean PROPERTY_GENERAL_CUSTOM_DEFAULT = false;
+    public static boolean PROPERTY_GENERAL_CUSTOM_DEFAULT = false;
 
 
     public static final String PROPERTY_GENERAL_PALETTE_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".palette";
@@ -90,14 +124,14 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_GENERAL_PALETTE_OPTION2 = OPTION_COLOR_STANDARD;
     public static final String PROPERTY_GENERAL_PALETTE_OPTION3 = OPTION_COLOR_UNIVERSAL;
     public static final String PROPERTY_GENERAL_PALETTE_OPTION4 = OPTION_COLOR_ANOMALIES;
-    public static final String PROPERTY_GENERAL_PALETTE_DEFAULT = OPTION_COLOR_GRAY_SCALE;
+    public static String PROPERTY_GENERAL_PALETTE_DEFAULT = OPTION_COLOR_GRAY_SCALE;
 
     public static final String PROPERTY_GENERAL_RANGE_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".range";
     public static final String PROPERTY_GENERAL_RANGE_LABEL = "Range";
     public static final String PROPERTY_GENERAL_RANGE_TOOLTIP = "Range options to use when NOT using a " + COLOR_LOWER_CASE + "scheme";
     public static final String PROPERTY_GENERAL_RANGE_OPTION1 = OPTION_RANGE_FROM_DATA;
     public static final String PROPERTY_GENERAL_RANGE_OPTION2 = OPTION_RANGE_FROM_PALETTE;
-    public static final String PROPERTY_GENERAL_RANGE_DEFAULT = OPTION_RANGE_FROM_DATA;
+    public static  String PROPERTY_GENERAL_RANGE_DEFAULT = OPTION_RANGE_FROM_DATA;
 
     public static final String PROPERTY_GENERAL_LOG_KEY = PROPERTY_GENERAL_KEY_SUFFIX + ".log";
     public static final String PROPERTY_GENERAL_LOG_LABEL = "Log Scaling";
@@ -105,7 +139,7 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_GENERAL_LOG_OPTION1 = OPTION_LOG_TRUE;
     public static final String PROPERTY_GENERAL_LOG_OPTION2 = OPTION_LOG_FALSE;
     public static final String PROPERTY_GENERAL_LOG_OPTION3 = OPTION_LOG_FROM_PALETTE;
-    public static final String PROPERTY_GENERAL_LOG_DEFAULT = OPTION_LOG_FALSE;
+    public static  String PROPERTY_GENERAL_LOG_DEFAULT = OPTION_LOG_FALSE;
 
 
 
@@ -113,24 +147,20 @@ public class ColorManipulationDefaults {
 
 
 
-    // Scheme option
+    // Scheme (Band Lookup))
 
-    private static final String PROPERTY_SCHEME_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".scheme";
+    private static final String PROPERTY_SCHEME_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".scheme.band.lookup";
 
     public static final String PROPERTY_SCHEME_SECTION_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".section";
-    public static final String PROPERTY_SCHEME_SECTION_LABEL = "Scheme Options";
+    public static final String PROPERTY_SCHEME_SECTION_LABEL = "Scheme (Band Lookup)";
     public static final String PROPERTY_SCHEME_SECTION_TOOLTIP = "<html>Behavior when using a " + COLOR_LOWER_CASE + " scheme as configured in<br>" +
             " color_palette_schemes.xml and color_palette_scheme_lookup.xml</html>";
 
     public static final String PROPERTY_SCHEME_AUTO_APPLY_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".auto.apply";
-    public static final String PROPERTY_SCHEME_AUTO_APPLY_LABEL = "Apply " + NamingConvention.COLOR_MIXED_CASE + " Schemes Automatically";
+    public static final String PROPERTY_SCHEME_AUTO_APPLY_LABEL = "Auto-apply";
     public static final String PROPERTY_SCHEME_AUTO_APPLY_TOOLTIP = "<html>Apply " + NamingConvention.COLOR_LOWER_CASE +" schemes automatically<br>" +
             " when opening a band based on its name</html>";
-    public static final boolean PROPERTY_SCHEME_AUTO_APPLY_DEFAULT = false;
-
-
-
-
+    public static  boolean PROPERTY_SCHEME_AUTO_APPLY_DEFAULT = false;
 
 
     public static final String PROPERTY_SCHEME_PALETTE_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".palette";
@@ -142,7 +172,7 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_SCHEME_PALETTE_OPTION4 = OPTION_COLOR_STANDARD;
     public static final String PROPERTY_SCHEME_PALETTE_OPTION5 = OPTION_COLOR_UNIVERSAL;
     public static final String PROPERTY_SCHEME_PALETTE_OPTION6 = OPTION_COLOR_ANOMALIES;
-    public static final String PROPERTY_SCHEME_PALETTE_DEFAULT = OPTION_COLOR_STANDARD_SCHEME;
+    public static String PROPERTY_SCHEME_PALETTE_DEFAULT = OPTION_COLOR_STANDARD_SCHEME;
 
     public static final String PROPERTY_SCHEME_RANGE_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".range";
     public static final String PROPERTY_SCHEME_RANGE_LABEL = "Range";
@@ -150,7 +180,7 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_SCHEME_RANGE_OPTION1 = OPTION_RANGE_FROM_SCHEME;
     public static final String PROPERTY_SCHEME_RANGE_OPTION2 = OPTION_RANGE_FROM_DATA;
     public static final String PROPERTY_SCHEME_RANGE_OPTION3 = OPTION_RANGE_FROM_PALETTE;
-    public static final String PROPERTY_SCHEME_RANGE_DEFAULT = OPTION_RANGE_FROM_SCHEME;
+    public static  String PROPERTY_SCHEME_RANGE_DEFAULT = OPTION_RANGE_FROM_SCHEME;
 
     public static final String PROPERTY_SCHEME_LOG_KEY = PROPERTY_SCHEME_KEY_SUFFIX + ".log";
     public static final String PROPERTY_SCHEME_LOG_LABEL = "Log Scaling";
@@ -159,7 +189,54 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_SCHEME_LOG_OPTION2 = OPTION_LOG_FROM_PALETTE;
     public static final String PROPERTY_SCHEME_LOG_OPTION3 = OPTION_LOG_TRUE;
     public static final String PROPERTY_SCHEME_LOG_OPTION4 = OPTION_LOG_FALSE;
-    public static final String PROPERTY_SCHEME_LOG_DEFAULT = OPTION_LOG_FROM_SCHEME;
+    public static  String PROPERTY_SCHEME_LOG_DEFAULT = OPTION_LOG_FROM_SCHEME;
+
+
+
+
+    // Range Percentile Default Options
+
+    private static final String PROPERTY_PERCENTILE_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".percentile";
+
+    public static final String PROPERTY_RANGE_PERCENTILE_SECTION_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_RANGE_PERCENTILE_SECTION_LABEL = "Percentile Options";
+    public static final String PROPERTY_RANGE_PERCENTILE_SECTION_TOOLTIP = "Default range percentile in the " + TOOLNAME_COLOR_MANIPULATION + " GUI";
+
+    public static final String PROPERTY_RANGE_PERCENTILE_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".value";
+    public static final String PROPERTY_RANGE_PERCENTILE_LABEL = "Percentile Default";
+    public static final String PROPERTY_RANGE_PERCENTILE_TOOLTIP = "The percentile of the data to use for determining min, max range when clicking the using the " +
+            "band statistics 'From Data'";
+    public static  double PROPERTY_RANGE_PERCENTILE_DEFAULT = 92.0;
+
+
+    public static final String PROPERTY_100_PERCENT_BUTTON_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".100.percent.enable.button";
+    public static final String PROPERTY_100_PERCENT_BUTTON_LABEL = "100% Button";
+    public static final String PROPERTY_100_PERCENT_BUTTON_TOOLTIP = "Enable 100% range button in the sliders editor";
+    public static  boolean PROPERTY_100_PERCENT_BUTTON_DEFAULT = true;
+
+    public static final String PROPERTY_95_PERCENT_BUTTON_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".95.percent.enable.button";
+    public static final String PROPERTY_95_PERCENT_BUTTON_LABEL = "95% Button";
+    public static final String PROPERTY_95_PERCENT_BUTTON_TOOLTIP = "Enable 95% range button in the sliders editor";
+    public static  boolean PROPERTY_95_PERCENT_BUTTON_DEFAULT = false;
+
+    public static final String PROPERTY_1_SIGMA_BUTTON_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".1.sigma.enable.button";
+    public static final String PROPERTY_1_SIGMA_BUTTON_LABEL = "<html>1&sigma; (68.27%) Button</html>";
+    public static final String PROPERTY_1_SIGMA_BUTTON_TOOLTIP = "Enable 68.27% range button in the sliders editor";
+    public static  boolean PROPERTY_1_SIGMA_BUTTON_DEFAULT = false;
+
+    public static final String PROPERTY_2_SIGMA_BUTTON_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".2.sigma.enable.button";
+    public static final String PROPERTY_2_SIGMA_BUTTON_LABEL = "<html>2&sigma; (95.45%) Button</html>";
+    public static final String PROPERTY_2_SIGMA_BUTTON_TOOLTIP = "Enable 95.45% range button in the sliders editor";
+    public static  boolean PROPERTY_2_SIGMA_BUTTON_DEFAULT = true;
+
+    public static final String PROPERTY_3_SIGMA_BUTTON_KEY = PROPERTY_PERCENTILE_KEY_SUFFIX + ".3.sigma.enable.button";
+    public static final String PROPERTY_3_SIGMA_BUTTON_LABEL = "<html>3&sigma; (99.73%) Button</html>";
+    public static final String PROPERTY_3_SIGMA_BUTTON_TOOLTIP = "Enable 99.73% range button in the sliders editor";
+    public static  boolean PROPERTY_3_SIGMA_BUTTON_DEFAULT = true;
+
+
+
+
 
 
 
@@ -176,30 +253,31 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_SCHEME_VERBOSE_LABEL = "Verbose";
     public static final String PROPERTY_SCHEME_VERBOSE_TOOLTIP = "<html>Scheme selector will show the verbose VERBOSE_NAME field<br>" +
             " from the color_palette_schemes.xml</html>";
-    public static final boolean PROPERTY_SCHEME_VERBOSE_DEFAULT = false;
+    public static boolean PROPERTY_SCHEME_VERBOSE_DEFAULT = false;
 
     public static final String PROPERTY_SCHEME_SHOW_DISABLED_KEY = PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX + ".show.disabled";
     public static final String PROPERTY_SCHEME_SHOW_DISABLED_LABEL = "Show Disabled";
     public static final String PROPERTY_SCHEME_SHOW_DISABLED_TOOLTIP = "<html>Scheme selector will display all schemes <br>" +
             "including schemes with missing cpd files</html>";
-    public static final boolean PROPERTY_SCHEME_SHOW_DISABLED_DEFAULT = false;
+    public static  boolean PROPERTY_SCHEME_SHOW_DISABLED_DEFAULT = false;
 
     public static final String PROPERTY_SCHEME_SORT_KEY = PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX + ".sort";
     public static final String PROPERTY_SCHEME_SORT_LABEL = "Sort";
     public static final String PROPERTY_SCHEME_SORT_TOOLTIP = "<html>Scheme selector will display all schemes alphabetically sorted<br>" +
             " as opposed to the original xml order</html>";
-    public static final boolean PROPERTY_SCHEME_SORT_DEFAULT = true;
+    public static  boolean PROPERTY_SCHEME_SORT_DEFAULT = true;
 
     public static final String PROPERTY_SCHEME_CATEGORIZE_DISPLAY_KEY = PROPERTY_SCHEME_SELECTOR_KEY_SUFFIX + ".split";
     public static final String PROPERTY_SCHEME_CATEGORIZE_DISPLAY_LABEL = "Categorize";
     public static final String PROPERTY_SCHEME_CATEGORIZE_DISPLAY_TOOLTIP = "<html>Scheme selector will display all schemes categorized into<br>" +
             "primary and additional categories by the PRIMARY field<br> of the color_palette_schemes.xml</html>";
-    public static final boolean PROPERTY_SCHEME_CATEGORIZE_DISPLAY_DEFAULT = true;
+    public static  boolean PROPERTY_SCHEME_CATEGORIZE_DISPLAY_DEFAULT = true;
+
 
 
     // Sliders Editor Options
 
-    private static final String PROPERTY_SLIDER_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".slider.options";
+    private static final String PROPERTY_SLIDER_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".sliders";
 
     public static final String PROPERTY_SLIDERS_SECTION_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".section";
     public static final String PROPERTY_SLIDERS_SECTION_LABEL = "Sliders Editor Options";
@@ -208,114 +286,30 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_SLIDERS_SHOW_INFORMATION_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".extra.info";
     public static final String PROPERTY_SLIDERS_SHOW_INFORMATION_LABEL = "Show Information";
     public static final String PROPERTY_SLIDERS_SHOW_INFORMATION_TOOLTIP = "Display information in the histogram/slider view by default";
-    public static final boolean PROPERTY_SLIDERS_SHOW_INFORMATION_DEFAULT = true;
+    public static  boolean PROPERTY_SLIDERS_SHOW_INFORMATION_DEFAULT = true;
 
     public static final String PROPERTY_SLIDERS_ZOOM_IN_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".zoom.in";
     public static final String PROPERTY_SLIDERS_ZOOM_IN_LABEL = "Histogram Zoom";
     public static final String PROPERTY_SLIDERS_ZOOM_IN_TOOLTIP = "Display histogram slider view zoomed in by default";
-    public static final boolean PROPERTY_SLIDERS_ZOOM_IN_DEFAULT = true;
+    public static  boolean PROPERTY_SLIDERS_ZOOM_IN_DEFAULT = true;
 
 
-
-
-
-    // Range Percentile Default Options
-
-    private static final String PROPERTY_RANGE_PERCENTILE_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".range.percentile";
-
-    public static final String PROPERTY_RANGE_PERCENTILE_SECTION_KEY = PROPERTY_RANGE_PERCENTILE_KEY_SUFFIX + ".section";
-    public static final String PROPERTY_RANGE_PERCENTILE_SECTION_LABEL = "Percentile Range";
-    public static final String PROPERTY_RANGE_PERCENTILE_SECTION_TOOLTIP = "Default range percentile in the " + TOOLNAME_COLOR_MANIPULATION + " GUI";
-
-    public static final String PROPERTY_RANGE_PERCENTILE_KEY = PROPERTY_RANGE_PERCENTILE_KEY_SUFFIX + ".value";
-    public static final String PROPERTY_RANGE_PERCENTILE_LABEL = "Percentile Range Default";
-    public static final String PROPERTY_RANGE_PERCENTILE_TOOLTIP = "The percentile of the data to use for determining min, max range";
-    public static final double PROPERTY_RANGE_PERCENTILE_DEFAULT = 92.0;
-
-
-
-
-
-
-    // Button Enablement Options
-
-    private static final String PROPERTY_BUTTONS_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".button.enablement";
-
-    public static final String PROPERTY_BUTTONS_SECTION_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".section";
-    public static final String PROPERTY_BUTTONS_SECTION_LABEL = "Button Enablement";
-    public static final String PROPERTY_BUTTONS_SECTION_TOOLTIP = "Button enablement options in the " + TOOLNAME_COLOR_MANIPULATION + " GUI";
-
-    public static final String PROPERTY_100_PERCENT_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".100.button";
-    public static final String PROPERTY_100_PERCENT_BUTTON_LABEL = "100% Button";
-    public static final String PROPERTY_100_PERCENT_BUTTON_TOOLTIP = "Enable 100% range button in the sliders editor";
-    public static final boolean PROPERTY_100_PERCENT_BUTTON_DEFAULT = true;
-
-    public static final String PROPERTY_95_PERCENT_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".95.button";
-    public static final String PROPERTY_95_PERCENT_BUTTON_LABEL = "95% Button";
-    public static final String PROPERTY_95_PERCENT_BUTTON_TOOLTIP = "Enable 95% range button in the sliders editor";
-    public static final boolean PROPERTY_95_PERCENT_BUTTON_DEFAULT = false;
-
-    public static final String PROPERTY_1_SIGMA_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".1.sigma.button";
-    public static final String PROPERTY_1_SIGMA_BUTTON_LABEL = "<html>1&sigma; (68.27%) Button</html>";
-    public static final String PROPERTY_1_SIGMA_BUTTON_TOOLTIP = "Enable 68.27% range button in the sliders editor";
-    public static final boolean PROPERTY_1_SIGMA_BUTTON_DEFAULT = false;
-
-    public static final String PROPERTY_2_SIGMA_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".2.sigma.button";
-    public static final String PROPERTY_2_SIGMA_BUTTON_LABEL = "<html>2&sigma; (95.45%) Button</html>";
-    public static final String PROPERTY_2_SIGMA_BUTTON_TOOLTIP = "Enable 95.45% range button in the sliders editor";
-    public static final boolean PROPERTY_2_SIGMA_BUTTON_DEFAULT = true;
-
-    public static final String PROPERTY_3_SIGMA_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".3.sigma.button";
-    public static final String PROPERTY_3_SIGMA_BUTTON_LABEL = "<html>3&sigma; (99.73%) Button</html>";
-    public static final String PROPERTY_3_SIGMA_BUTTON_TOOLTIP = "Enable 99.73% range button in the sliders editor";
-    public static final boolean PROPERTY_3_SIGMA_BUTTON_DEFAULT = true;
-
-    public static final String PROPERTY_ZOOM_VERTICAL_BUTTONS_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".zoom.vertical.buttons";
+    public static final String PROPERTY_ZOOM_VERTICAL_BUTTONS_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".zoom.vertical.enable.buttons";
     public static final String PROPERTY_ZOOM_VERTICAL_BUTTONS_LABEL = "Vertical Zoom Buttons";
     public static final String PROPERTY_ZOOM_VERTICAL_BUTTONS_TOOLTIP = "Enable zoom vertical buttons in the sliders editor";
-    public static final boolean PROPERTY_ZOOM_VERTICAL_BUTTONS_DEFAULT = true;
+    public static  boolean PROPERTY_ZOOM_VERTICAL_BUTTONS_DEFAULT = true;
 
-    public static final String PROPERTY_INFORMATION_BUTTON_KEY = PROPERTY_BUTTONS_KEY_SUFFIX + ".extra.info.button";
+    public static final String PROPERTY_INFORMATION_BUTTON_KEY = PROPERTY_SLIDER_KEY_SUFFIX + ".extra.info.enable.button";
     public static final String PROPERTY_INFORMATION_BUTTON_LABEL = "Information Button";
     public static final String PROPERTY_INFORMATION_BUTTON_TOOLTIP = "Enable histogram overlay information button in the sliders editor";
-    public static final boolean PROPERTY_INFORMATION_BUTTON_DEFAULT = true;
+    public static  boolean PROPERTY_INFORMATION_BUTTON_DEFAULT = true;
 
 
-
-
-    // Default Palettes
-
-    private static final String PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".default.palette";
-
-    public static final String PROPERTY_PALETTE_DEFAULT_SECTION_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".section";
-    public static final String PROPERTY_PALETTE_DEFAULT_SECTION_LABEL = "Default Palettes";
-    public static final String PROPERTY_PALETTE_DEFAULT_SECTION_TOOLTIP = "Palettes to use with associated variables name";
-
-    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".gray.scale";
-    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_LABEL = OPTION_COLOR_GRAY_SCALE;
-    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_TOOLTIP = "The palette file to use when GRAY SCALE is selected";
-    public static final String PROPERTY_PALETTE_DEFAULT_GRAY_SCALE_DEFAULT = PALETTE_GRAY_SCALE_DEFAULT;
-
-    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".standard";
-    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_LABEL = OPTION_COLOR_STANDARD;
-    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_TOOLTIP = "The palette file to use when STANDARD " + COLOR_UPPER_CASE +" is selected";
-    public static final String PROPERTY_PALETTE_DEFAULT_STANDARD_DEFAULT = PALETTE_STANDARD_DEFAULT;
-
-    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".universal";
-    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_LABEL = OPTION_COLOR_UNIVERSAL;
-    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_TOOLTIP = "<html>The color blind compliant palette file to use when <br>" +
-            "UNIVERSAL " + COLOR_UPPER_CASE + " is selected</html>";
-    public static final String PROPERTY_PALETTE_DEFAULT_UNIVERSAL_DEFAULT = PALETTE_UNIVERSAL_DEFAULT;
-
-    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_KEY = PROPERTY_PALETTE_DEFAULT_KEY_SUFFIX + ".anomalies";
-    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_LABEL = OPTION_COLOR_ANOMALIES;
-    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_TOOLTIP = "The palette file to use when ANOMALIES is selected";
-    public static final String PROPERTY_PALETTE_DEFAULT_ANOMALIES_DEFAULT = PALETTE_ANOMALIES_DEFAULT;
 
 
     // RGB Options
 
-    private static final String PROPERTY_RGB_OPTIONS_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".rgb.options";
+    private static final String PROPERTY_RGB_OPTIONS_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".rgb";
 
     public static final String PROPERTY_RGB_OPTIONS_SECTION_KEY = PROPERTY_RGB_OPTIONS_KEY_SUFFIX + ".section";
     public static final String PROPERTY_RGB_OPTIONS_SECTION_LABEL = "RGB Options";
@@ -324,12 +318,12 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_RGB_OPTIONS_MIN_KEY = PROPERTY_RGB_OPTIONS_KEY_SUFFIX + ".button.min";
     public static final String PROPERTY_RGB_OPTIONS_MIN_LABEL = "Range Button (Min)";
     public static final String PROPERTY_RGB_OPTIONS_MIN_TOOLTIP = "The min value to use in the RGB (A..B) range button";
-    public static final double PROPERTY_RGB_OPTIONS_MIN_DEFAULT = 0.0;
+    public static  double PROPERTY_RGB_OPTIONS_MIN_DEFAULT = 0.0;
 
-    public static final String PROPERTY_RGB_OPTIONS_MAX_KEY = PROPERTY_RGB_OPTIONS_KEY_SUFFIX + "button.min";
+    public static final String PROPERTY_RGB_OPTIONS_MAX_KEY = PROPERTY_RGB_OPTIONS_KEY_SUFFIX + ".button.max";
     public static final String PROPERTY_RGB_OPTIONS_MAX_LABEL = "Range Button (Max)";
     public static final String PROPERTY_RGB_OPTIONS_MAX_TOOLTIP = "The max value to use in the RGB (A..B) range button";
-    public static final double PROPERTY_RGB_OPTIONS_MAX_DEFAULT = 1.0;
+    public static  double PROPERTY_RGB_OPTIONS_MAX_DEFAULT = 1.0;
 
 
 
@@ -345,7 +339,6 @@ public class ColorManipulationDefaults {
     public static final String PROPERTY_RESTORE_DEFAULTS_LABEL = "Default (" + TOOLNAME_COLOR_MANIPULATION + " Preferences)";
     public static final String PROPERTY_RESTORE_DEFAULTS_TOOLTIP = "Restore all " + NamingConvention.COLOR_LOWER_CASE + " preferences to the original default";
     public static final boolean PROPERTY_RESTORE_DEFAULTS_DEFAULT = false;
-
 
 
     public static void debug(String message) {

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorManipulationDefaults.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorManipulationDefaults.java
@@ -1,7 +1,6 @@
 package org.esa.snap.core.datamodel;
 
 import org.esa.snap.core.util.NamingConvention;
-
 import static org.esa.snap.core.util.NamingConvention.*;
 
 


### PR DESCRIPTION
*Note: this pull request involves both snap-engine and snap-desktop, so both pull requests are needed to resolve dependencies.

Enhanced the branding and preference configuration by adding Color Manipulation preference capabilities to the snap.properties file.  Adding these parameters enhances the branding capability of SNAP and reduces hard coded differences between the branded package and SNAP.  It also adds a convenient preferences setting for users in general.

Modified the wording of Color Manipulation Preferences GUI to better clarify the meaning of certain parameters.

Modified the help pages accordingly.

For the snap.properties file, the following is a list of all color manipulation default parameter keys along with the SNAP default values.  These parameters are not needed to be explicitly set in the SNAP package's snap.properties file because SNAP already has them had coded internally.  

# snap.color.manipulation.palette.default.gray.scale=gray_scale.cpd
# snap.color.manipulation.palette.default.standard=oceancolor_standard.cpd
# snap.color.manipulation.palette.default.universal=universal_bluered.cpd
# snap.color.manipulation.palette.default.anomalies=gradient_red_white_blue.cpd
# snap.color.manipulation.scheme.default.enable=false
# snap.color.manipulation.scheme.default.palette=GRAY-SCALE
# snap.color.manipulation.scheme.default.range=From Data
# snap.color.manipulation.scheme.default.log=FALSE
# snap.color.manipulation.scheme.band.lookup.auto.apply=false
# snap.color.manipulation.scheme.band.lookup.palette=From Scheme STANDARD
# snap.color.manipulation.scheme.band.lookup.range=From Scheme
# snap.color.manipulation.scheme.band.lookup.log=From Scheme
# snap.color.manipulation.percentile.value=92.0
# snap.color.manipulation.percentile.1.sigma.enable.button=false
# snap.color.manipulation.percentile.2.sigma.enable.button=true
# snap.color.manipulation.percentile.3.sigma.enable.button=true
# snap.color.manipulation.percentile.95.percent.enable.button=false
# snap.color.manipulation.percentile.100.percent.enable.button=true
# snap.color.manipulation.scheme.selector.verbose=false
# snap.color.manipulation.scheme.selector.sort=true
# snap.color.manipulation.scheme.selector.split=true
# snap.color.manipulation.scheme.selector.show.disabled=false
# snap.color.manipulation.sliders.zoom.in=true
# snap.color.manipulation.sliders.extra.info=true
# snap.color.manipulation.sliders.zoom.vertical.enable.buttons=true
# snap.color.manipulation.sliders.extra.info.enable.button=true
# snap.color.manipulation.rgb.button.min=0.0
# snap.color.manipulation.rgb.button.max=1.0