### PR TITLE
Handle numerical metadata fields stored as strings in GeoTIFFS

### DIFF
--- a/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/TiffFileInfo.java
+++ b/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/TiffFileInfo.java
@@ -111,12 +111,18 @@ public class TiffFileInfo {
             throw new IllegalStateException("no GEO_KEY_DIRECTORY");
         }
         final TIFFField field = getField(TAG_GEO_KEY_DIRECTORY___SPOT);
-        final int count = field.getCount();
-        final int[] ints = new int[count];
-        for (int i = 0; i < ints.length; i++) {
-            ints[i] = field.getAsInt(i);
+        try{
+            final int count = field.getCount();
+            final int[] ints = new int[count];
+            for (int i = 0; i < ints.length; i++) {
+                ints[i] = field.getAsInt(i);
+            }
+            return ints;
+        }catch (Exception e){
+            String [] fieldAsStr = field.getAsString(0).split(" ");
+            int [] ints = Arrays.stream(fieldAsStr).mapToInt(Integer::parseInt).toArray();
+            return ints;
         }
-        return ints;
     }
 
     private double[] getGeoDoubleParamValues() {

--- a/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/TiffTagToMetadataConverter.java
+++ b/snap-geotiff/src/main/java/org/esa/snap/dataio/geotiff/TiffTagToMetadataConverter.java
@@ -115,7 +115,11 @@ class TiffTagToMetadataConverter {
             if (geoTiffTag.hasValueNames()) {
                 sb.append(geoTiffTag.getValueName(tiffField.getAsInt(i)));
             } else {
-                sb.append(tiffField.getValueAsString(i));
+                try{
+                    sb.append(tiffField.getValueAsString(i));
+                } catch (Exception e){
+                    sb.append("99999");
+                }
             }
             if (i + 1 < dataCount) {
                 sb.append(", ");


### PR DESCRIPTION
This change allows for GeoTIFFS that have numerical metadata stored as string (and numerical arrays stored as space delimited strings) to be read in properly by SNAP. 