### PR TITLE
[SNAP-1183] Export of transect pixels does not show correct values

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/TransectProfileData.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/TransectProfileData.java
@@ -40,7 +40,7 @@ public class TransectProfileData {
     public static final GeoPos NO_GEO_POS = new GeoPos(Float.NaN, Float.NaN);
     private final Point2D[] shapeVertices;
     private final int[] shapeVertexIndexes;
-    private final Point2D[] pixelPositions; // todo - ts02Apr2012 - better use integer point class
+    private final Point2D[] pixelPositions;
     private final GeoPos[] geoPositions;
     private final float[] sampleValues;
     private final float[] sampleSigmas;
@@ -164,6 +164,10 @@ public class TransectProfileData {
         }
     }
 
+    public Config getConfig() {
+        return config;
+    }
+
     public int getNumPixels() {
         return pixelPositions.length;
     }
@@ -204,14 +208,14 @@ public class TransectProfileData {
         return sampleMax;
     }
 
-    static class Config {
+    public static class Config {
 
-        RasterDataNode raster;
-        Shape path;
-        int boxSize;
-        boolean useRoiMask;
-        Mask roiMask;
-        boolean connectVertices;
+        public RasterDataNode raster;
+        public Shape path;
+        public int boxSize;
+        public boolean useRoiMask;
+        public Mask roiMask;
+        public boolean connectVertices;
     }
 
 }

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/TransectProfileDataBuilder.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/TransectProfileDataBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Brockmann Consult GmbH (info@brockmann-consult.de)
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -9,7 +9,7 @@
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
@@ -39,8 +39,6 @@ public class TransectProfileDataBuilder {
 
     final TransectProfileData.Config config;
 
-    private VectorDataNode pointData;
-
     public TransectProfileDataBuilder() {
         config = new TransectProfileData.Config();
         setDefaults();
@@ -48,10 +46,6 @@ public class TransectProfileDataBuilder {
 
     public TransectProfileData build() throws IOException {
         validate();
-
-        if (config.path == null) {
-            config.path = createPath(pointData);
-        }
 
         return new TransectProfileData(config);
     }
@@ -68,7 +62,7 @@ public class TransectProfileDataBuilder {
     }
 
     public TransectProfileDataBuilder pointData(VectorDataNode pointData) {
-        this.pointData = pointData;
+        config.path = createPath(pointData);
         return this;
     }
 
@@ -99,13 +93,13 @@ public class TransectProfileDataBuilder {
 
     private void validate() {
         Assert.state(config.raster != null, "raster == null");
-        Assert.state(config.path != null || pointData != null, "path != null || pointData != null");
-        Assert.state(config.path == null && pointData != null
-                     || config.path != null && pointData == null,
-                     "path == null && pointData != null || path != null && pointData == null");
+        Assert.state(config.path != null, "path == null ");
     }
 
     private static Path2D createPath(VectorDataNode pointData) {
+        if (pointData == null) {
+            return null;
+        }
         Path2D.Double path = new Path2D.Double();
         SimpleFeature[] simpleFeatures = pointData.getFeatureCollection().toArray(new SimpleFeature[0]);
         for (int i = 0; i < simpleFeatures.length; i++) {

--- a/snap-core/src/test/java/org/esa/snap/core/datamodel/TransectProfileDataBuilderTest.java
+++ b/snap-core/src/test/java/org/esa/snap/core/datamodel/TransectProfileDataBuilderTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Brockmann Consult GmbH (info@brockmann-consult.de)
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -9,7 +9,7 @@
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see http://www.gnu.org/licenses/
  */
@@ -17,16 +17,27 @@
 package org.esa.snap.core.datamodel;
 
 import com.bc.ceres.core.ProgressMonitor;
+import it.geosolutions.jaiext.jts.CoordinateSequence2D;
 import org.esa.snap.core.dataio.AbstractProductReader;
-import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.feature.DefaultFeatureCollection;
 import org.junit.Before;
 import org.junit.Test;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.opengis.feature.simple.SimpleFeatureType;
 
 import java.awt.Rectangle;
 import java.awt.Shape;
-import java.io.IOException;
+import java.awt.geom.PathIterator;
+import java.awt.geom.Point2D;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Thomas Storm
@@ -52,9 +63,9 @@ public class TransectProfileDataBuilderTest {
         assertEquals(1, data.config.boxSize);
         assertSame(dummyBand, data.config.raster);
         assertSame(dummyPath, data.config.path);
-        assertEquals(true, data.config.connectVertices);
-        assertEquals(null, data.config.roiMask);
-        assertEquals(false, data.config.useRoiMask);
+        assertTrue(data.config.connectVertices);
+        assertNull(data.config.roiMask);
+        assertFalse(data.config.useRoiMask);
     }
 
     @Test
@@ -63,7 +74,7 @@ public class TransectProfileDataBuilderTest {
         Mask dummyMask = createDummyMask();
 
         builder.raster(dummyBand);
-        builder.pointData(createDummyVDN());
+        builder.pointData(createDummyPoints(new Point2D[]{new Point2D.Double(0, 0), new Point2D.Double(5, 8), new Point2D.Double(19, 4)}));
         builder.boxSize(5);
         builder.roiMask(dummyMask);
         builder.useRoiMask(true);
@@ -73,10 +84,22 @@ public class TransectProfileDataBuilderTest {
 
         assertSame(dummyBand, data.config.raster);
         assertNotNull(data.config.path);
+        final PathIterator pathIterator = data.config.path.getPathIterator(null);
+        final double[] pointData = new double[6];
+        pathIterator.currentSegment(pointData);
+        assertArrayEquals(new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, pointData, 1.0e-6);
+        pathIterator.next();
+        pathIterator.currentSegment(pointData);
+        assertArrayEquals(new double[]{5.0, 8.0, 0.0, 0.0, 0.0, 0.0}, pointData, 1.0e-6);
+        pathIterator.next();
+        pathIterator.currentSegment(pointData);
+        assertArrayEquals(new double[]{19.0, 4.0, 0.0, 0.0, 0.0, 0.0}, pointData, 1.0e-6);
+        pathIterator.next();
+        assertTrue(pathIterator.isDone());
         assertEquals(5, data.config.boxSize);
         assertSame(dummyMask, data.config.roiMask);
-        assertEquals(true, data.config.useRoiMask);
-        assertEquals(false, data.config.connectVertices);
+        assertTrue(data.config.useRoiMask);
+        assertFalse(data.config.connectVertices);
     }
 
     @Test
@@ -97,8 +120,8 @@ public class TransectProfileDataBuilderTest {
         assertNotNull(data.config.path);
         assertEquals(13, data.config.boxSize);
         assertSame(dummyMask, data.config.roiMask);
-        assertEquals(true, data.config.useRoiMask);
-        assertEquals(false, data.config.connectVertices);
+        assertTrue(data.config.useRoiMask);
+        assertFalse(data.config.connectVertices);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -125,10 +148,18 @@ public class TransectProfileDataBuilderTest {
         return mask;
     }
 
-    private VectorDataNode createDummyVDN() {
-        SimpleFeatureTypeBuilder typeBuilder = new SimpleFeatureTypeBuilder();
-        typeBuilder.setName("typeName");
-        return new VectorDataNode("name", typeBuilder.buildFeatureType());
+    private VectorDataNode createDummyPoints(Point2D[] points) {
+        final SimpleFeatureType superType = PlainFeatureFactory.createPlainFeatureType("testPoint", Point.class, null);
+        final VectorDataNode vdn = new VectorDataNode("dummyPoints", superType);
+        final DefaultFeatureCollection featureCollection = vdn.getFeatureCollection();
+        final GeometryFactory geomFactory = new GeometryFactory();
+        for (int i = 0; i < points.length; i++) {
+            Point2D point = points[i];
+            final CoordinateSequence2D coordinates = new CoordinateSequence2D(point.getX(), point.getY());
+            featureCollection.add(PlainFeatureFactory.createPlainFeature(superType, String.valueOf(i), new Point(coordinates, geomFactory), null));
+
+        }
+        return vdn;
     }
 
     private RasterDataNode createDummyBandWithoutProduct() {
@@ -139,12 +170,14 @@ public class TransectProfileDataBuilderTest {
         final Product product = new Product("pname", "type", 10, 10);
         product.setProductReader(new AbstractProductReader(null) {
             @Override
-            protected Product readProductNodesImpl() throws IOException {
+            protected Product readProductNodesImpl() {
                 return product;
             }
 
             @Override
-            protected void readBandRasterDataImpl(int sourceOffsetX, int sourceOffsetY, int sourceWidth, int sourceHeight, int sourceStepX, int sourceStepY, Band destBand, int destOffsetX, int destOffsetY, int destWidth, int destHeight, ProductData destBuffer, ProgressMonitor pm) throws IOException {
+            protected void readBandRasterDataImpl(int sourceOffsetX, int sourceOffsetY, int sourceWidth, int sourceHeight,
+                                                  int sourceStepX, int sourceStepY, Band destBand, int destOffsetX, int destOffsetY, int destWidth, int destHeight,
+                                                  ProductData destBuffer, ProgressMonitor pm) {
             }
         });
         return product.addBand("name", ProductData.TYPE_FLOAT32);


### PR DESCRIPTION
The “Invalid Pixel“ was inserted into the export because the pixel under the current mouse position was checked accidentally. If the cursor was at an invalid position, then the “Invalid Pixel“ was written and not the value.
Also did some refactorings.