### PR TITLE
SEADAS: Statistics Tool (9.x)

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/Stx.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/Stx.java
@@ -47,12 +47,15 @@ public class Stx {
     private final double mean;
     private final double standardDeviation;
     private final double median;
+    private final double medianRaster;
+    private final boolean includesMedianRaster;
     private final int resolutionLevel;
     private final boolean logHistogram;
     private final boolean intHistogram;
     private final Histogram histogram;
 
     private final Scaling histogramScaling;
+    private  int rawTotal = -1; // optional field for adding on a total which includes no-data pixels
 
     private final double coefficientOfVariation;
     private final double enl;
@@ -75,6 +78,13 @@ public class Stx {
                double coeffOfVariation, double enl,
                boolean logHistogram, boolean intHistogram, Histogram histogram, int resolutionLevel) {
 
+        this(minimum, maximum, mean, 0.0, 0.0, 0.0, 0.0, false, logHistogram, intHistogram, histogram, resolutionLevel);
+
+    }
+
+    public Stx(double minimum, double maximum, double mean, double standardDeviation,
+               double coeffOfVariation, double enl, double medianRaster, boolean includesMedianRaster,
+               boolean logHistogram, boolean intHistogram, Histogram histogram, int resolutionLevel) {
         Assert.argument(!Double.isNaN(minimum), "minimum must not be NaN");
         Assert.argument(!Double.isInfinite(minimum), "minimum must not be infinity");
         Assert.argument(!Double.isNaN(maximum), "maximum must not be NaN");
@@ -99,6 +109,8 @@ public class Stx {
         this.intHistogram = intHistogram;
         this.histogram = histogram;
         this.resolutionLevel = resolutionLevel;
+        this.medianRaster = medianRaster;
+        this.includesMedianRaster = includesMedianRaster;
         this.coefficientOfVariation = coeffOfVariation;
         this.enl = enl;
     }
@@ -129,6 +141,13 @@ public class Stx {
      */
     public double getMedian() {
         return median;
+    }
+
+    /**
+     * @return The median value (raster based).
+     */
+    public double getMedianRaster() {
+        return medianRaster;
     }
 
     /**
@@ -301,4 +320,20 @@ public class Stx {
             return FastMath.exp(LN10 * value);
         }
     }
+
+    /**
+     * @return The minimum value.
+     */
+    public int getRawTotal() {
+        return rawTotal;
+    }
+
+    /**
+     * @return The minimum value.
+     */
+    public void setRawTotal(int rawTotal) {
+        this.rawTotal = rawTotal;
+    }
+
+
 }

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/SummaryStxOp.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/SummaryStxOp.java
@@ -19,6 +19,8 @@ package org.esa.snap.core.datamodel;
 import org.esa.snap.core.util.math.DoubleList;
 
 import javax.media.jai.UnpackedImageData;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import static java.lang.Double.*;
 
@@ -37,6 +39,9 @@ final public class SummaryStxOp extends StxOp {
     private double maximum;
     private double mean;
     private double meanSqr;
+    private ArrayList<Double> sampleData;
+    private boolean calculateMedian = false;
+
     private long sampleCount;
 
     private double valueSum;
@@ -47,10 +52,12 @@ final public class SummaryStxOp extends StxOp {
         super("Summary");
         this.minimum = POSITIVE_INFINITY;
         this.maximum = NEGATIVE_INFINITY;
-        this.sampleCount = 0;
-        this.valueSum = 0;
-        this.sqrSum = 0;
-        this.power4Sum = 0;
+    }
+
+    public SummaryStxOp(boolean calculateMedian) {
+        this();
+        this.calculateMedian = calculateMedian;
+        sampleData = new ArrayList<Double>();
     }
 
     public double getMinimum() {
@@ -65,6 +72,30 @@ final public class SummaryStxOp extends StxOp {
 
     public double getMean() {
         return sampleCount > 0 ? mean : NaN;
+    }
+
+    public double getMedian() {
+        if (sampleCount > 0 && sampleData != null && calculateMedian) {
+            double[] sampleArray = new double[sampleData.size()];
+            for (int i = 0; i < sampleData.size(); i++) {
+                sampleArray[i] = (double) sampleData.get(i);
+            }
+
+            Arrays.sort(sampleArray);
+            double median;
+            if (sampleArray.length % 2 == 0)
+
+                median = ((double) sampleArray[sampleArray.length / 2] + (double) sampleArray[sampleArray.length / 2 - 1]) / 2;
+            else
+
+                median = (double) sampleArray[sampleArray.length / 2];
+
+            return median;
+
+        } else {
+            return NaN;
+        }
+
     }
 
     public double getStandardDeviation() {
@@ -157,21 +188,24 @@ final public class SummaryStxOp extends StxOp {
                     value = values.getDouble(dataPixelOffset);
                     if(!Double.isInfinite(value) && !Double.isNaN(value)) {
 
-                    tileSampleCount++;
-                    if (value < tileMinimum) {
-                        tileMinimum = value;
-                    }
-                    if (value > tileMaximum) {
-                        tileMaximum = value;
-                    }
-                    delta = value - tileMean;
-                    tileMean += delta / tileSampleCount;
-                    tileMeanSqr += delta * (value - tileMean);
+                        tileSampleCount++;
+                        if (value < tileMinimum) {
+                            tileMinimum = value;
+                        }
+                        if (value > tileMaximum) {
+                            tileMaximum = value;
+                        }
+                        delta = value - tileMean;
+                        tileMean += delta / tileSampleCount;
+                        tileMeanSqr += delta * (value - tileMean);
 
-                    tmpValueSum += value;
-                    final double value2 = value * value;
-                    tmpSqrSum += value2;
-                    tmpPower4Sum += value2*value2;
+                        tmpValueSum += value;
+                        final double value2 = value * value;
+                        tmpSqrSum += value2;
+                        tmpPower4Sum += value2*value2;
+                        if (calculateMedian && sampleData != null) {
+                            sampleData.add(value);
+                        }
                     }
                 }
                 dataPixelOffset += dataPixelStride;

--- a/snap-core/src/main/java/org/esa/snap/core/util/ProductUtils.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/ProductUtils.java
@@ -57,6 +57,20 @@ import java.util.Map;
  */
 public class ProductUtils {
 
+    private static String GLOBAL_ATTRIBUTES_KEY = "Global_Attributes";
+    public static String METADATA_PROJECTION_KEY = "map_projection";
+    public static String[] METADATA_POSSIBLE_PROJECTION_KEYS = {METADATA_PROJECTION_KEY, "projection", "crs"};
+    public static String[] METADATA_POSSIBLE_SENSOR_KEYS = {"sensor_name", "instrument", "sensor"};
+    public static String[] METADATA_POSSIBLE_PLATFORM_KEYS = {"platform"};
+    public static String[] METADATA_POSSIBLE_PROCESSING_VERSION_KEYS = {"processing_version"};
+    public static String[] METADATA_POSSIBLE_DAY_NIGHT_KEYS = {"day_night_flag", "day_night"};
+    public static String[] METADATA_POSSIBLE_ORBIT_KEYS = {"orbit_number", "orbit"};
+    public static String[] METADATA_POSSIBLE_START_ORBIT_KEYS = {"start_orbit_number", "end_orbit"};
+    public static String[] METADATA_POSSIBLE_END_ORBIT_KEYS = {"end_orbit_number", "end_orbit"};
+
+    public static String METADATA_RESOLUTION_KEY = "spatial_resolution";
+    public static String[] METADATA_POSSIBLE_RESOLUTION_KEYS = {METADATA_RESOLUTION_KEY, "resolution"};
+
     private static final int[] RGB_BAND_OFFSETS = new int[]{
             2, 1, 0
     };
@@ -1075,6 +1089,301 @@ public class ProductUtils {
             }
         }
     }
+
+    public static void markAsDerivedFromMetaDataField(Product product, String attribute) {
+        // Created by Daniel Knowles
+
+        String tag = "Derived from (";
+
+        if (attribute != null && attribute.length() > 0 && product != null && product.getMetadataRoot() != null && product.getMetadataRoot().getElement(GLOBAL_ATTRIBUTES_KEY) != null) {
+            MetadataElement metadataElement = product.getMetadataRoot().getElement(GLOBAL_ATTRIBUTES_KEY);
+
+            String value = "";
+
+            MetadataAttribute metadataAttribute = metadataElement.getAttribute(attribute);
+
+            if (metadataAttribute != null) {
+                value = metadataAttribute.getData().toString();
+
+                if (value != null && value.length() > 0 && !value.startsWith(tag)) {
+                    value = tag + value + ")";
+                    setMetaDataField(product, attribute, value);
+                }
+            }
+        }
+
+    }
+
+
+    public static void markProductMetaDataFieldAsDerivedFrom(Product product) {
+        // Created by Daniel Knowles
+
+        markAsDerivedFromMetaDataField(product, "product_name");
+        markAsDerivedFromMetaDataField(product, "title");
+        markAsDerivedFromMetaDataField(product, "processing_level");
+
+        String tag = "Derived from (";
+
+        if (product != null) {
+            String productType = product.getProductType();
+
+            if (productType != null && productType.length() > 0 && !productType.startsWith(tag)) {
+                productType = tag + productType + ")";
+                product.setProductType(productType);
+            }
+        }
+
+    }
+
+
+    public static void prependHistoryMetaDataField(Product product, String latestHistoryEvent) {
+        // Created by Daniel Knowles
+
+        String HISTORY_KEY = "history";
+        String history = latestHistoryEvent;
+
+        if (product != null && product.getMetadataRoot() != null && product.getMetadataRoot().getElement(GLOBAL_ATTRIBUTES_KEY) != null) {
+
+            MetadataElement metadataElement = product.getMetadataRoot().getElement(GLOBAL_ATTRIBUTES_KEY);
+
+            if (metadataElement.getAttribute(HISTORY_KEY) != null) {
+                String previousHistory = metadataElement.getAttribute(HISTORY_KEY).getData().toString();
+
+                if (previousHistory.length() > 0) {
+                    history = latestHistoryEvent + " :: " + previousHistory;
+                }
+            }
+
+            setMetaDataField(product, HISTORY_KEY, history);
+        }
+    }
+
+
+    public static void setResolutionMetaDataField(Product product, boolean markAsDerivedFrom) {
+        // Created by Daniel Knowles
+
+        setMetaDataFieldFromPossible(product, METADATA_RESOLUTION_KEY, METADATA_POSSIBLE_RESOLUTION_KEYS);
+
+        if (markAsDerivedFrom) {
+            markAsDerivedFromMetaDataField(product, METADATA_RESOLUTION_KEY);
+        }
+    }
+
+
+    public static void setMetaDataFieldFromPossible(Product product, String attribute, String[] possibleAttributes) {
+        // Created by Daniel Knowles
+        // if attribute does not exist then set to first value found from the possibleAttributes
+
+        if (product != null && product.getMetadataRoot() != null) {
+            MetadataElement metadataElement = product.getMetadataRoot().getElement(GLOBAL_ATTRIBUTES_KEY);
+
+            if (metadataElement != null) {
+                MetadataAttribute metadataAttribute = metadataElement.getAttribute(attribute);
+
+                if (metadataAttribute == null) {
+                    for (String key : possibleAttributes) {
+                        String[] keyVariations = StringUtils.getStringCaseVariations(key);
+                        for (String keyVariation : keyVariations) {
+                            if (metadataElement.getAttribute(keyVariation) != null) {
+                                String value = metadataElement.getAttribute(keyVariation).getData().toString();
+                                setMetaDataField(product, attribute, value);
+                                break;
+                            }
+                        }
+                    }
+
+                    for (String key : possibleAttributes) {
+                        String[] keyVariations = StringUtils.getStringCaseVariations(key);
+                        for (String keyVariation : keyVariations) {
+                            if (keyVariation != null && !keyVariation.toLowerCase().equals(attribute.toLowerCase())) {
+                                deleteMetaDataField(product, keyVariation);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+    public static void setMapProjectionMetaDataFields(Product product) {
+        // Created by Daniel Knowles
+
+        String MAP_PROJECTION_KEY = "map_projection";
+        String CRS_KEY = "crs";
+        String UNDEFINED_VALUE = "undefined";
+        String[] keysToDelete = {"projection", "mapprojection", "coordinatesystem", "coordinatereferencesystem", "coordinate_system", "geocoding", "geo_coding"};
+
+
+        if (product != null && product.getMetadataRoot() != null && product.getMetadataRoot().getElement(GLOBAL_ATTRIBUTES_KEY) != null) {
+
+            deleteMetaDataFields(product, keysToDelete);
+
+            String mapProjectionString = UNDEFINED_VALUE;
+            String crsString = UNDEFINED_VALUE;
+
+            if (product.getSceneGeoCoding() != null && product.getSceneGeoCoding().getMapCRS() != null) {
+                if (product.getSceneGeoCoding().getMapCRS().getName() != null) {
+                    mapProjectionString = product.getSceneGeoCoding().getMapCRS().getName().toString();
+                }
+                if (product.getSceneGeoCoding().getMapCRS().toString() != null) {
+                    crsString = product.getSceneGeoCoding().getMapCRS().toString().replaceAll("\n", "").replaceAll(" ", "");
+                }
+            }
+
+            setMetaDataField(product, MAP_PROJECTION_KEY, mapProjectionString);
+            setMetaDataField(product, CRS_KEY, crsString);
+        }
+    }
+
+
+    public static void deleteMetaDataFields(Product product, String[] fields) {
+        // Created by Daniel Knowles
+
+        MetadataElement metadataElement = product.getMetadataRoot().getElement(GLOBAL_ATTRIBUTES_KEY);
+
+        for (String key : fields) {
+            MetadataAttribute metadataAttribute = metadataElement.getAttribute(key);
+            if (metadataAttribute != null) {
+                metadataAttribute.setReadOnly(false);
+                metadataElement.removeAttribute(metadataAttribute);
+            }
+        }
+    }
+
+
+    public static void deleteMetaDataField(Product product, String field) {
+        // Created by Daniel Knowles
+
+        String[] fields = {field};
+        deleteMetaDataFields(product, fields);
+    }
+
+
+    public static void setMetaDataField(Product product, String field, String value) {
+        // Created by Daniel Knowles
+
+        String UNDEFINED_VALUE = "undefined";
+
+        if (product != null && product.getMetadataRoot() != null && product.getMetadataRoot().getElement(GLOBAL_ATTRIBUTES_KEY) != null) {
+
+            MetadataElement metadataElement = product.getMetadataRoot().getElement(GLOBAL_ATTRIBUTES_KEY);
+
+            MetadataAttribute metadataAttribute = metadataElement.getAttribute(field);
+            if (metadataAttribute != null) {
+                metadataAttribute.setReadOnly(false);
+                metadataAttribute.setModified(true);
+            }
+
+            // this wont do anything if attribute is not a String type
+            try {
+                if (value != null) {
+                    metadataElement.setAttributeString(field, value);
+                } else {
+                    metadataElement.setAttributeString(field, UNDEFINED_VALUE);
+                }
+            } catch (Exception e) {
+
+            }
+
+            if (metadataAttribute != null) {
+                metadataAttribute.setReadOnly(true);
+            }
+        }
+    }
+
+
+
+
+    public static String getMetaData(Product product, String[] keys) {
+        // Created by Daniel Knowles
+        String metaData = "";
+
+        for (String key : keys) {
+            metaData = getMetaData(product, key, false);
+
+            if (metaData.length() > 0) {
+                return metaData;
+            }
+        }
+
+        return metaData;
+    }
+
+    public static String getMetaData(Product product, String key) {
+        // Created by Daniel Knowles
+        String metaData = "";
+
+        if (key != null && key.length() > 0) {
+            try {
+                metaData = product.getMetadataRoot().getElement("Global_Attributes").getAttribute(key).getData().getElemString();
+            } catch (Exception ignore) {
+            }
+        }
+
+        return metaData;
+    }
+
+
+
+
+    public static String getMetaData(Product product, String key, boolean exact) {
+        // Created by Daniel Knowles
+        if (key == null) {
+            return null;
+        }
+
+        if (exact) {
+            return getMetaData(product, key);
+        } else {
+            String metaData = "";
+            String[] keyVariations = StringUtils.getStringCaseVariations(key);
+            for (String keyVariation : keyVariations) {
+                metaData = getMetaData(product, keyVariation);
+                if (metaData != null && metaData.length() > 0) {
+                    return metaData;
+                }
+            }
+
+            return metaData;
+        }
+    }
+
+
+
+
+
+
+
+
+
+
+    public static String getMetaDataOrbit(Product product) {
+        // Created by Daniel Knowles
+        // Note this tries to retrieve an orbit or orbit range name
+        String metaData = getMetaData(product, METADATA_POSSIBLE_ORBIT_KEYS);
+
+        if (metaData != null && metaData.length() > 0) {
+            return metaData;
+        }
+
+        try {
+            String startOrbit = getMetaData(product, METADATA_POSSIBLE_START_ORBIT_KEYS);
+            String endOrbit = getMetaData(product, METADATA_POSSIBLE_END_ORBIT_KEYS);
+            if (startOrbit != null && startOrbit.length() > 0 && endOrbit != null && endOrbit.length() > 0) {
+                metaData = startOrbit + "-" + endOrbit;
+            } else if (endOrbit == null && startOrbit != null && startOrbit.length() > 0) {
+                metaData = startOrbit;
+            } else if (startOrbit == null && endOrbit != null && endOrbit.length() > 0) {
+                metaData = endOrbit;
+            }
+        } catch (Exception ignored) {
+        }
+
+
+        return metaData;
+    }
+
 
     public static void copyVectorData(Product sourceProduct, Product targetProduct) {
 

--- a/snap-core/src/main/java/org/esa/snap/core/util/StringUtils.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/StringUtils.java
@@ -23,10 +23,7 @@ import org.jdom.output.XMLOutputter;
 
 import java.awt.Color;
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.StringTokenizer;
+import java.util.*;
 
 /**
  * The <code>StringUtils</code> class provides frequently used utility methods dealing with <code>String</code> values
@@ -55,6 +52,22 @@ public class StringUtils {
      * @throws IllegalArgumentException if one of the arguments was null
      * @see java.util.StringTokenizer
      */
+
+    public  enum CaseType {
+        TITLE,
+        TITLE_UNDERSCORE,
+        LOWER_UNDERSCORE,
+        UPPER_UNDERSCORE,
+        CAMEL_LOWER_FIRST,
+        CAMEL_UPPER
+    }
+
+
+    public static String DELIMITOR_SPACE = " ";
+    public static String DELIMITOR_UNDERSCORE = "_";
+
+
+
     public static List<String> split(String text, char[] separators, boolean trimTokens, List<String> tokens) {
 
         Guardian.assertNotNull("text", text);
@@ -884,5 +897,144 @@ public class StringUtils {
         prettyFormat.setOmitDeclaration(true);
         prettyFormat.setTextMode(Format.TextMode.NORMALIZE);
         return prettyFormat;
+    }
+
+
+    public static String[] getStringCaseVariations(String s) {
+        // Created by Daniel Knowles
+        if (s == null || s.length() == 0) {
+            return null;
+        }
+
+        if (s.length() == 1) {
+            String[] stringArray = {s.toLowerCase(), s.toUpperCase()};
+            return stringArray;
+        }
+
+        LinkedHashSet<String> linkedHashSet = new LinkedHashSet<String>();
+        linkedHashSet.add(s);
+        linkedHashSet.add(getStringCaseVariation(s, CaseType.LOWER_UNDERSCORE));
+        linkedHashSet.add(getStringCaseVariation(s, CaseType.UPPER_UNDERSCORE));
+        linkedHashSet.add(getStringCaseVariation(s, CaseType.CAMEL_LOWER_FIRST));
+        linkedHashSet.add(getStringCaseVariation(s, CaseType.CAMEL_UPPER));
+        linkedHashSet.add(getStringCaseVariation(s, CaseType.TITLE_UNDERSCORE));
+
+        String[] stringArray = new String[linkedHashSet.size()];
+        linkedHashSet.toArray(stringArray);
+        return stringArray;
+    }
+
+
+
+    public static String getStringCaseVariation(String s, CaseType caseType) {
+        // Created by Daniel Knowles
+        if (s == null || s.length() == 0) {
+            return null;
+        }
+
+        String tmpString;
+        switch (caseType) {
+            case TITLE:
+                return toTitleCase(s, true);
+            case TITLE_UNDERSCORE:
+                return toTitleCase(s, false);
+            case LOWER_UNDERSCORE:
+                tmpString = toTitleCase(s, true);
+                if (tmpString != null) {
+                    return tmpString.toLowerCase();
+                } else {
+                    return null;
+                }
+            case UPPER_UNDERSCORE:
+                tmpString = toTitleCase(s, true);
+                if (tmpString != null) {
+                    return tmpString.toUpperCase();
+                } else {
+                    return null;
+                }
+            case CAMEL_LOWER_FIRST:
+                return toCamelCase(s, false);
+            case CAMEL_UPPER:
+                return toCamelCase(s, true);
+            default:
+                return null;
+        }
+
+
+    }
+
+
+    static String toCamelCase(String s, boolean upper) {
+        // Created by Daniel Knowles
+
+        if (s == null || s.length() == 0) {
+            return s;
+        }
+
+        String sourceDelimitor;
+
+        if (s.contains(DELIMITOR_SPACE)) {
+            sourceDelimitor = DELIMITOR_SPACE;
+        } else if (s.contains(DELIMITOR_UNDERSCORE)) {
+            sourceDelimitor = DELIMITOR_UNDERSCORE;
+        } else {
+            return s;
+        }
+
+        String[] parts = s.split(sourceDelimitor);
+        StringBuilder camelCaseString = new StringBuilder("");
+        boolean firstWordSet = false;
+        for (String part : parts) {
+            if (part != null && part.length() > 0) {
+                if (!firstWordSet && !upper) {
+                    camelCaseString.append(part.toLowerCase());
+                    firstWordSet = true;
+                } else {
+                    camelCaseString.append(toProperCase(part));
+                }
+            }
+        }
+
+        return camelCaseString.toString();
+    }
+
+
+    static String toTitleCase(String s, boolean spaceDelimitor) {
+        // Created by Daniel Knowles
+        // Source string is either space or underscore delimited
+        // Returned string is of format "This Is My Title" or "This_Is_My_Title"
+
+        String delimitor = (spaceDelimitor) ? DELIMITOR_SPACE : DELIMITOR_UNDERSCORE;
+        if (s == null || s.length() == 0) {
+            return s;
+        }
+
+        String sourceDelimitor;
+
+        if (s.contains(DELIMITOR_SPACE)) {
+            sourceDelimitor = DELIMITOR_SPACE;
+        } else if (s.contains(DELIMITOR_UNDERSCORE)) {
+            sourceDelimitor = DELIMITOR_UNDERSCORE;
+        } else {
+            return s;
+        }
+
+        String[] parts = s.split(sourceDelimitor);
+        for (int i = 0; i < parts.length; i++) {
+            parts[i] = toProperCase(parts[i]);
+        }
+
+        return StringUtils.join(parts, delimitor);
+    }
+
+
+    static String toProperCase(String s) {
+        // Created by Daniel Knowles
+
+        if (s == null || s.length() < 2) {
+            return s;
+}
+
+        return s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
     }
 }

--- a/snap-statistics/src/main/java/org/esa/snap/statistics/StatisticComputer.java
+++ b/snap-statistics/src/main/java/org/esa/snap/statistics/StatisticComputer.java
@@ -3,16 +3,7 @@ package org.esa.snap.statistics;
 import com.bc.ceres.core.ProgressMonitor;
 import com.bc.ceres.core.SubProgressMonitor;
 import com.bc.ceres.glevel.MultiLevelImage;
-import java.util.Date;
-import org.esa.snap.core.datamodel.Band;
-import org.esa.snap.core.datamodel.HistogramStxOp;
-import org.esa.snap.core.datamodel.Mask;
-import org.esa.snap.core.datamodel.Product;
-import org.esa.snap.core.datamodel.ProductData;
-import org.esa.snap.core.datamodel.QualitativeStxOp;
-import org.esa.snap.core.datamodel.StxFactory;
-import org.esa.snap.core.datamodel.SummaryStxOp;
-import org.esa.snap.core.datamodel.VectorDataNode;
+import org.esa.snap.core.datamodel.*;
 import org.esa.snap.core.gpf.OperatorException;
 import org.esa.snap.core.util.FeatureUtils;
 import org.esa.snap.core.util.SystemUtils;
@@ -27,15 +18,13 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import javax.media.jai.Histogram;
-import java.awt.Shape;
+import java.awt.*;
 import java.awt.image.DataBuffer;
 import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Logger;
 
 public class StatisticComputer {
@@ -47,18 +36,25 @@ public class StatisticComputer {
     private final Map<BandConfiguration, StxOpMapping>[] stxOpMappingsList;
     private final int initialBinCount;
     private final Logger logger;
+    private boolean calculateMedian = false;
     private final TimeInterval[] timeIntervals;
     private String featureId;
 
     public StatisticComputer(File shapefile, BandConfiguration[] bandConfigurations, int initialBinCount,
-                             String featureId, Logger logger) {
+                             TimeInterval[] timeIntervals, String featureId, Logger logger) {
         this(shapefile, bandConfigurations, initialBinCount,
                 new TimeInterval[]{new TimeInterval(0, new ProductData.UTC(0), new ProductData.UTC(1000000))},
-                featureId, logger);
+                featureId, logger, false);
+    }
+    public StatisticComputer(File shapefile, BandConfiguration[] bandConfigurations, int initialBinCount,
+                             String featureId, Logger logger, Boolean calculateMedian) {
+        this(shapefile, bandConfigurations, initialBinCount,
+                new TimeInterval[]{new TimeInterval(0, new ProductData.UTC(0), new ProductData.UTC(1000000))},
+                featureId, logger, calculateMedian);
     }
 
     public StatisticComputer(File shapefile, BandConfiguration[] bandConfigurations, int initialBinCount,
-                             TimeInterval[] timeIntervals, String featureId, Logger logger) {
+                             TimeInterval[] timeIntervals, String featureId, Logger logger, Boolean calculateMedian) {
         this.initialBinCount = initialBinCount;
         this.timeIntervals = timeIntervals;
         this.logger = logger != null ? logger : SystemUtils.LOG;
@@ -88,6 +84,7 @@ public class StatisticComputer {
         pm = ProgressMonitor.NULL;
         this.bandConfigurations = bandConfigurations;
         stxOpMappingsList = new Map[Math.max(1, timeIntervals.length)];
+        this.calculateMedian = calculateMedian;
         for (int i = 0; i < stxOpMappingsList.length; i++) {
             stxOpMappingsList[i] = new HashMap<>();
         }
@@ -167,7 +164,7 @@ public class StatisticComputer {
             final QualitativeStxOp qualitativeStxOp = stxOpsMapping.getQualitativeStxOp(regionName, band);
             StxFactory.accumulate(band, 0, roiImage, roiShape, qualitativeStxOp, SubProgressMonitor.create(pm, 50));
         } else {
-            final SummaryStxOp summaryStxOp = stxOpsMapping.getSummaryOp(regionName);
+            final SummaryStxOp summaryStxOp = stxOpsMapping.getSummaryOp(regionName, calculateMedian);
             StxFactory.accumulate(band, 0, roiImage, roiShape, summaryStxOp, SubProgressMonitor.create(pm, 50));
             final double minimum = summaryStxOp.getMinimum();
             final double maximum = summaryStxOp.getMaximum();
@@ -252,10 +249,10 @@ public class StatisticComputer {
             return qualitativeStxOp;
         }
 
-        private SummaryStxOp getSummaryOp(String vdnName) {
+        private SummaryStxOp getSummaryOp(String vdnName, boolean calculateMedian) {
             SummaryStxOp summaryStxOp = summaryMap.get(vdnName);
             if (summaryStxOp == null) {
-                summaryStxOp = new SummaryStxOp();
+                summaryStxOp = new SummaryStxOp(calculateMedian);
                 summaryMap.put(vdnName, summaryStxOp);
             }
             return summaryStxOp;

--- a/snap-statistics/src/main/java/org/esa/snap/statistics/StatisticsOp.java
+++ b/snap-statistics/src/main/java/org/esa/snap/statistics/StatisticsOp.java
@@ -19,14 +19,7 @@ package org.esa.snap.statistics;
 import com.bc.ceres.binding.ConversionException;
 import com.bc.ceres.binding.Converter;
 import com.bc.ceres.core.ProgressMonitor;
-import java.util.Calendar;
-import java.util.Collection;
-import org.esa.snap.core.datamodel.Band;
-import org.esa.snap.core.datamodel.HistogramStxOp;
-import org.esa.snap.core.datamodel.Product;
-import org.esa.snap.core.datamodel.ProductData;
-import org.esa.snap.core.datamodel.QualitativeStxOp;
-import org.esa.snap.core.datamodel.SummaryStxOp;
+import org.esa.snap.core.datamodel.*;
 import org.esa.snap.core.gpf.Operator;
 import org.esa.snap.core.gpf.OperatorException;
 import org.esa.snap.core.gpf.OperatorSpi;
@@ -36,34 +29,16 @@ import org.esa.snap.core.gpf.annotations.Parameter;
 import org.esa.snap.core.gpf.annotations.SourceProducts;
 import org.esa.snap.core.util.io.FileUtils;
 import org.esa.snap.core.util.io.WildcardMatcher;
-import org.esa.snap.statistics.output.BandNameCreator;
-import org.esa.snap.statistics.output.CsvStatisticsWriter;
-import org.esa.snap.statistics.output.FeatureStatisticsWriter;
-import org.esa.snap.statistics.output.MetadataWriter;
-import org.esa.snap.statistics.output.StatisticsOutputContext;
-import org.esa.snap.statistics.output.StatisticsOutputter;
-import org.esa.snap.statistics.output.Util;
+import org.esa.snap.statistics.output.*;
+import org.esa.snap.statistics.tools.TimeInterval;
 
 import javax.media.jai.Histogram;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.text.MessageFormat;
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.logging.Level;
-import org.esa.snap.statistics.tools.TimeInterval;
 
 /**
  * An operator that is used to compute statistics for any number of source products, restricted to time intervals and
@@ -96,17 +71,26 @@ public class StatisticsOp extends Operator {
     public static final String DATETIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
     public static final String MAJORITY_CLASS = "majority_class";
     public static final String SECOND_MAJORITY_CLASS = "second_majority_class";
-    public static final String MAXIMUM = "maximum";
-    public static final String MINIMUM = "minimum";
-    public static final String MEDIAN = "median";
-    public static final String AVERAGE = "average";
-    public static final String SIGMA = "sigma";
-    public static final String MAX_ERROR = "max_error";
-    public static final String TOTAL = "total";
-    public static final String PERCENTILE_PREFIX = "p";
-    public static final String PERCENTILE_SUFFIX = "_threshold";
-    public static final String DEFAULT_PERCENTILES = "90,95";
-    public static final int[] DEFAULT_PERCENTILES_INTS = new int[]{90, 95};
+    public static final String TOTAL = "SampleSize(Pixels)";
+    public static final String MAXIMUM = "Maximum";
+    public static final String MINIMUM = "Minimum";
+    public static final String MEDIAN_OLD_50P = "50%ThresholdHistogram"; // was "Median".  This variable no longer used.
+    public static final String MEDIAN = "Median";
+    public static final String MEAN = "Mean";
+    public static final String SIGMA = "StandardDeviation";
+    public static final String VARIANCE = "Variance";
+    public static final String COEF_VARIATION = "CoefficientOfVariation";
+    public static final String TOTAL_BINS = "TotalBins";
+    public static final String BIN_WIDTH = "BinWidth";
+    public static final String MAX_ERROR = "max_error"; // This variable no longer used.
+
+    public static final String PERCENTILE_PREFIX = "";
+    public static final String PERCENTILE_SUFFIX = "%Threshold";
+    public static final String DEFAULT_PERCENTILES = "50,80,85,90,95,98";
+    public static final int[] DEFAULT_PERCENTILES_INTS = new int[]{50,80,85,90,95,98};
+
+    public boolean calculateMedian = true;
+
 
     private static final double FILL_VALUE = -999.0;
     static final int ALL_MEASURES = 0;
@@ -163,10 +147,15 @@ public class StatisticsOp extends Operator {
             notNull = false, defaultValue = DEFAULT_PERCENTILES)
     int[] percentiles;
 
-    @Parameter(description = "The degree of accuracy used for statistics computation. Higher numbers " +
-            "indicate higher accuracy but may lead to a considerably longer computation time.",
-            defaultValue = "3")
-    int accuracy;
+//    @Parameter(description = "The degree of accuracy used for statistics computation. Higher numbers " +
+//            "indicate higher accuracy but may lead to a considerably longer computation time.",
+//               defaultValue = "3")
+//    int accuracy;
+
+    @Parameter(description = "The number of bins to use in the histogram statistics",
+            defaultValue = "1000")
+    int numBins;
+
 
     @Parameter(description = "If set, the StatisticsOp will divide the time between start and end time into time intervals" +
             "defined by this parameter. All measures will be aggregated from products within these intervals. " +
@@ -199,9 +188,9 @@ public class StatisticsOp extends Operator {
     public void doExecute(ProgressMonitor pm) throws OperatorException {
         TimeInterval[] timeIntervals = getTimeIntervals(interval, startDate, endDate);
 
-        final StatisticComputer statisticComputer = new StatisticComputer(shapefile, bandConfigurations,
-                Util.computeBinCount(accuracy), timeIntervals, featureId, getLogger());
-
+//        final StatisticComputer statisticComputer = new StatisticComputer(shapefile, bandConfigurations,
+//                Util.computeBinCount(accuracy), timeIntervals, featureId, getLogger());
+        final StatisticComputer statisticComputer = new StatisticComputer(shapefile, bandConfigurations, numBins, timeIntervals, featureId, getLogger(), calculateMedian);
         final ProductValidator productValidator = new ProductValidator(Arrays.asList(bandConfigurations), startDate, endDate, getLogger());
         final ProductLoop productLoop = new ProductLoop(new ProductLoader(), productValidator, statisticComputer, pm, getLogger());
         productLoop.loop(sourceProducts, getProductsToLoad());
@@ -259,7 +248,7 @@ public class StatisticsOp extends Operator {
     }
 
     private void processStatisticsPerTimeInterval(Map<BandConfiguration, StatisticComputer.StxOpMapping> stxOps,
-                                               TimeInterval timeInterval) {
+                                                  TimeInterval timeInterval) {
         for (Map.Entry<BandConfiguration, StatisticComputer.StxOpMapping> bandConfigurationStxOpMappingEntry : stxOps.entrySet()) {
             final BandConfiguration bandConfiguration = bandConfigurationStxOpMappingEntry.getKey();
             final String bandName;
@@ -297,27 +286,41 @@ public class StatisticsOp extends Operator {
                 final SummaryStxOp summaryStxOp = summaryMap.get(regionName);
                 final Histogram histogram = histogramMap.get(regionName).getHistogram();
                 if (histogram.getTotals()[0] == 0) {
+                    stxMap.put(TOTAL, 0);
                     stxMap.put(MINIMUM, FILL_VALUE);
                     stxMap.put(MAXIMUM, FILL_VALUE);
-                    stxMap.put(AVERAGE, FILL_VALUE);
-                    stxMap.put(SIGMA, FILL_VALUE);
-                    stxMap.put(TOTAL, 0);
+                    stxMap.put(MEAN, FILL_VALUE);
                     stxMap.put(MEDIAN, FILL_VALUE);
+                    stxMap.put(SIGMA, FILL_VALUE);
+                    stxMap.put(VARIANCE, FILL_VALUE);
+                    stxMap.put(COEF_VARIATION, FILL_VALUE);
+                    stxMap.put(TOTAL_BINS, FILL_VALUE);
+                    stxMap.put(BIN_WIDTH, FILL_VALUE);
+
                     for (int percentile : percentiles) {
                         stxMap.put(getPercentileName(percentile), FILL_VALUE);
                     }
                 } else {
+                    double median = summaryStxOp.getMedian();
+                    double stdDev = summaryStxOp.getStandardDeviation();
+                    double mean = summaryStxOp.getMean();
+
+                    stxMap.put(TOTAL, histogram.getTotals()[0]);
                     stxMap.put(MINIMUM, summaryStxOp.getMinimum());
                     stxMap.put(MAXIMUM, summaryStxOp.getMaximum());
-                    stxMap.put(AVERAGE, summaryStxOp.getMean());
-                    stxMap.put(SIGMA, summaryStxOp.getStandardDeviation());
-                    stxMap.put(TOTAL, histogram.getTotals()[0]);
-                    stxMap.put(MEDIAN, histogram.getPTileThreshold(0.5)[0]);
+                    stxMap.put(MEAN, summaryStxOp.getMean());
+                    stxMap.put(MEDIAN, median);
+                    stxMap.put(SIGMA, stdDev);
+                    stxMap.put(VARIANCE, summaryStxOp.getVariance());
+                    stxMap.put(COEF_VARIATION, Util.getCoefficientOfVariation(stdDev, mean));
+                    stxMap.put(TOTAL_BINS, histogram.getNumBins()[0]);
+                    stxMap.put(BIN_WIDTH, Util.getBinWidth(histogram));
+
                     for (int percentile : percentiles) {
                         stxMap.put(getPercentileName(percentile), computePercentile(percentile, histogram));
                     }
                 }
-                stxMap.put(MAX_ERROR, Util.getBinWidth(histogram));
+//                stxMap.put(MAX_ERROR, Util.getBinWidth(histogram));
                 for (StatisticsOutputter statisticsOutputter : quantitativeStatisticsOutputters) {
                     if (timeInterval != null) {
                         statisticsOutputter.addToOutput(bandName, timeInterval, regionName, stxMap);
@@ -401,7 +404,6 @@ public class StatisticsOp extends Operator {
                             measures.add(MINIMUM);
                             measures.add(MAXIMUM);
                             measures.add(MEDIAN);
-                            measures.add(AVERAGE);
                             measures.add(SIGMA);
                             for (int percentile : percentiles) {
                                 measures.add(getPercentileName(percentile));
@@ -444,19 +446,27 @@ public class StatisticsOp extends Operator {
      * will receive no replacement (@since 6.0.3)
      */
     public static String[] getAlgorithmNames(int[] percentiles) {
-        final List<String> algorithms = new ArrayList<>();
-        algorithms.add(MINIMUM);
-        algorithms.add(MAXIMUM);
-        algorithms.add(MEDIAN);
-        algorithms.add(AVERAGE);
-        algorithms.add(SIGMA);
+        final LinkedHashSet<String> fieldNamesLhs = new LinkedHashSet<String>();
+        fieldNamesLhs.add(TOTAL);
+        fieldNamesLhs.add(MINIMUM);
+        fieldNamesLhs.add(MAXIMUM);
+        fieldNamesLhs.add(MEAN);
+        fieldNamesLhs.add(MEDIAN);
+        fieldNamesLhs.add(SIGMA);
+        fieldNamesLhs.add(VARIANCE);
+        fieldNamesLhs.add(COEF_VARIATION);
+        fieldNamesLhs.add(TOTAL_BINS);
+        fieldNamesLhs.add(BIN_WIDTH);
         for (int percentile : percentiles) {
-            algorithms.add(getPercentileName(percentile));
+            fieldNamesLhs.add(getPercentileName(percentile));
         }
-        algorithms.add(MAX_ERROR);
-        algorithms.add(TOTAL);
-        return algorithms.toArray(new String[algorithms.size()]);
+
+        String[] fieldNamesArray = new String[fieldNamesLhs.size()];
+        fieldNamesLhs.toArray(fieldNamesArray);
+
+        return fieldNamesArray;
     }
+
 
     private static String getPercentileName(int percentile) {
         return PERCENTILE_PREFIX + percentile + PERCENTILE_SUFFIX;
@@ -611,11 +621,17 @@ public class StatisticsOp extends Operator {
         if (startDate != null && endDate != null && endDate.getAsDate().before(startDate.getAsDate())) {
             throw new OperatorException("End date '" + this.endDate + "' before start date '" + this.startDate + "'");
         }
-        if (accuracy < 0) {
-            throw new OperatorException("Parameter 'accuracy' must be greater than or equal to " + 0);
+//        if (accuracy < 0) {
+//            throw new OperatorException("Parameter 'accuracy' must be greater than or equal to " + 0);
+//        }
+//        if (accuracy > Util.MAX_ACCURACY) {
+//            throw new OperatorException("Parameter 'accuracy' must be less than or equal to " + Util.MAX_ACCURACY);
+//        }
+        if (numBins < Util.MIN_NUMBINS) {
+            throw new OperatorException("Parameter 'numBins' must be greater than or equal to " + Util.MIN_NUMBINS);
         }
-        if (accuracy > Util.MAX_ACCURACY) {
-            throw new OperatorException("Parameter 'accuracy' must be less than or equal to " + Util.MAX_ACCURACY);
+        if (numBins > Util.MAX_NUMBINS) {
+            throw new OperatorException("Parameter 'numBins' must be less than or equal to " + Util.MAX_NUMBINS);
         }
         if ((sourceProducts == null || sourceProducts.length == 0) &&
                 (sourceProductPaths == null || sourceProductPaths.length == 0)) {

--- a/snap-statistics/src/main/java/org/esa/snap/statistics/output/CsvStatisticsWriter.java
+++ b/snap-statistics/src/main/java/org/esa/snap/statistics/output/CsvStatisticsWriter.java
@@ -1,15 +1,10 @@
 package org.esa.snap.statistics.output;
 
+import org.esa.snap.statistics.tools.TimeInterval;
+
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TreeMap;
-import org.esa.snap.statistics.tools.TimeInterval;
+import java.util.*;
 
 public class CsvStatisticsWriter implements StatisticsOutputter {
 
@@ -37,7 +32,7 @@ public class CsvStatisticsWriter implements StatisticsOutputter {
     public void initialiseOutput(StatisticsOutputContext statisticsOutputContext) {
         this.measureNames = statisticsOutputContext.measureNames;
         featureId = statisticsOutputContext.featureId;
-        Arrays.sort(measureNames);
+//        Arrays.sort(measureNames);
     }
 
     /**

--- a/snap-statistics/src/main/java/org/esa/snap/statistics/output/Util.java
+++ b/snap-statistics/src/main/java/org/esa/snap/statistics/output/Util.java
@@ -28,7 +28,9 @@ import javax.media.jai.Histogram;
  */
 public class Util {
 
-    public static final int MAX_ACCURACY = 6;
+    public static final int MAX_ACCURACY = 6; // no longer used
+    public static final int MAX_NUMBINS = 10000000;
+    public static final int MIN_NUMBINS = 1;
 
     /**
      * Returns the 'best' name of the given feature.
@@ -80,5 +82,9 @@ public class Util {
             throw new IllegalArgumentException("accuracy is not in the range 0 ... " + MAX_ACCURACY);
         }
         return (int) Math.pow(10, accuracy);
+    }
+
+    public static double getCoefficientOfVariation(double std_dev, double mean) {
+        return std_dev / mean;
     }
 }

--- a/snap-statistics/src/main/java/org/esa/snap/statistics/tools/StatisticalMappingAnalyser.java
+++ b/snap-statistics/src/main/java/org/esa/snap/statistics/tools/StatisticalMappingAnalyser.java
@@ -1,12 +1,8 @@
 package org.esa.snap.statistics.tools;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.esa.snap.statistics.StatisticsOp;
 
-import java.util.Arrays;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 public class StatisticalMappingAnalyser {
 
@@ -36,7 +32,7 @@ public class StatisticalMappingAnalyser {
         algorithms.add(StatisticsOp.MINIMUM);
         algorithms.add(StatisticsOp.MAXIMUM);
         algorithms.add(StatisticsOp.MEDIAN);
-        algorithms.add(StatisticsOp.AVERAGE);
+        algorithms.add(StatisticsOp.MEAN);
         algorithms.add(StatisticsOp.SIGMA);
         for (int percentile : percentiles) {
             algorithms.add(StatisticsOp.PERCENTILE_PREFIX + percentile + StatisticsOp.PERCENTILE_SUFFIX);

--- a/snap-statistics/src/test/java/org/esa/snap/statistics/StatisticsOpTest.java
+++ b/snap-statistics/src/test/java/org/esa/snap/statistics/StatisticsOpTest.java
@@ -110,7 +110,8 @@ public class StatisticsOpTest {
         final URL resource = getClass().getResource("4_pixels.shp");
         final URI uri = new URI(resource.toString());
         statisticsOp.shapefile = new File(uri.getPath());
-        statisticsOp.accuracy = 6;
+        int accuracy = 6;
+        statisticsOp.numBins = (int) Math.pow(10, accuracy);
 
         final MyOutputter outputter = new MyOutputter();
         statisticsOp.allStatisticsOutputters.add(outputter);
@@ -141,7 +142,8 @@ public class StatisticsOpTest {
         final URL resource = getClass().getResource("4_pixels.shp");
         final URI uri = new URI(resource.toString());
         statisticsOp.shapefile = new File(uri.getPath());
-        statisticsOp.accuracy = 6;
+        int accuracy = 6;
+        statisticsOp.numBins = (int) Math.pow(10, accuracy);
         statisticsOp.percentiles = null;
 
         final MyOutputter outputter = new MyOutputter();

--- a/snap-statistics/src/test/java/org/esa/snap/statistics/StatisticsOpTest_ValidateInputTest.java
+++ b/snap-statistics/src/test/java/org/esa/snap/statistics/StatisticsOpTest_ValidateInputTest.java
@@ -21,7 +21,8 @@ public class StatisticsOpTest_ValidateInputTest {
         statisticsOp.setParameterDefaultValues();
         statisticsOp.startDate = ProductData.UTC.parse("2010-01-31 14:45:23", "yyyy-MM-ss hh:mm:ss");
         statisticsOp.endDate = ProductData.UTC.parse("2010-01-31 14:46:23", "yyyy-MM-ss hh:mm:ss");
-        statisticsOp.accuracy = 0;
+        int accuracy = 0;
+        statisticsOp.numBins = (int) Math.pow(10, accuracy);
         statisticsOp.sourceProducts = new Product[]{TestUtil.getTestProduct()};
     }
 
@@ -31,7 +32,8 @@ public class StatisticsOpTest_ValidateInputTest {
 
     @Test
     public void testValidation_PrecisionLessThanMinPrecision() {
-        statisticsOp.accuracy = -1;
+        int accuracy = -1;
+        statisticsOp.numBins = -1;
 
         try {
             statisticsOp.validateInput();
@@ -43,13 +45,14 @@ public class StatisticsOpTest_ValidateInputTest {
 
     @Test
     public void testValidation_PrecisionGreaterThanMaxPrecision() {
-        statisticsOp.accuracy = 7;
+        int accuracy = 7;
+        statisticsOp.numBins = (int) Math.pow(10, accuracy);
 
         try {
             statisticsOp.validateInput();
             fail();
         } catch (OperatorException expected) {
-            assertEquals("Parameter 'accuracy' must be less than or equal to 6", expected.getMessage());
+            assertEquals("Parameter 'accuracy' must be less than or equal to 7", expected.getMessage());
         }
     }
 

--- a/snap-statistics/src/test/java/org/esa/snap/statistics/tools/StatisticalMappingAnalyserTest.java
+++ b/snap-statistics/src/test/java/org/esa/snap/statistics/tools/StatisticalMappingAnalyserTest.java
@@ -64,9 +64,9 @@ public class StatisticalMappingAnalyserTest {
         fullNames.add(StatisticsOp.MAXIMUM +"_CHL");
         fullNames.add(StatisticsOp.MAXIMUM +"_YS");
         fullNames.add(StatisticsOp.MAXIMUM +"_TSM");
-        fullNames.add(StatisticsOp.AVERAGE +"_CHL");
-        fullNames.add(StatisticsOp.AVERAGE +"_YS");
-        fullNames.add(StatisticsOp.AVERAGE +"_TSM");
+        fullNames.add(StatisticsOp.MEAN +"_CHL");
+        fullNames.add(StatisticsOp.MEAN +"_YS");
+        fullNames.add(StatisticsOp.MEAN +"_TSM");
         fullNames.add(StatisticsOp.SIGMA +"_CHL");
         fullNames.add(StatisticsOp.SIGMA +"_YS");
         fullNames.add(StatisticsOp.SIGMA +"_TSM");
@@ -76,7 +76,7 @@ public class StatisticalMappingAnalyserTest {
         final StatisticalMappingAnalyser mappingAnalyser = new StatisticalMappingAnalyser(fullNames);
 
         assertEquals(7, mappingAnalyser.getStatisticalMeasureNames().length);
-        assertEquals(StatisticsOp.AVERAGE, mappingAnalyser.getStatisticalMeasureNames()[0]);
+        assertEquals(StatisticsOp.MEAN, mappingAnalyser.getStatisticalMeasureNames()[0]);
         assertEquals(StatisticsOp.MAX_ERROR, mappingAnalyser.getStatisticalMeasureNames()[1]);
         assertEquals(StatisticsOp.MAXIMUM, mappingAnalyser.getStatisticalMeasureNames()[2]);
         assertEquals(StatisticsOp.MEDIAN, mappingAnalyser.getStatisticalMeasureNames()[3]);


### PR DESCRIPTION
Major upgrade to Statistics Tool:

Note: Spans both the snap-desktop and snap-engine repositories

Includes:
Additional statistics fields
Viewing statistics on multiple bands at once
A spreadsheet (table) view of statistics with a lot of file meta
Log binning of the histogram statistics
Separate ROI (regional) and Quality masking
A lot a criteria settings
