### PR TITLE
SEADAS: Color Bar Legend Overlay (9.x)

### DIFF
--- a/ceres-binding/src/main/java/com/bc/ceres/binding/PropertyDescriptor.java
+++ b/ceres-binding/src/main/java/com/bc/ceres/binding/PropertyDescriptor.java
@@ -44,8 +44,11 @@ import java.util.regex.Pattern;
  * to instances of this class.
  *
  * @author Norman Fomferra
+ * @author Daniel Knowles
  * @since 0.6
  */
+// MAR2020 - Knowles - Added setEnabled so that some properties can be initially disabled
+
 public class PropertyDescriptor {
 
     private final String name;
@@ -79,6 +82,7 @@ public class PropertyDescriptor {
         if (type.isEnum() && getValueSet() == null)  {
             setValueSet(new ValueSet(type.getEnumConstants()));
         }
+        setEnabled(true);
     }
 
     public String getName() {
@@ -120,6 +124,14 @@ public class PropertyDescriptor {
 
     public void setDescription(String description) {
         setAttribute("description", description);
+    }
+
+    public boolean getEnabled() {
+        return getBooleanProperty("enabled");
+    }
+
+    public void setEnabled(boolean enabled) {
+        setAttribute("enabled", enabled);
     }
 
     public boolean isNotNull() {

--- a/ceres-ui/src/main/java/com/bc/ceres/swing/binding/BindingContext.java
+++ b/ceres-ui/src/main/java/com/bc/ceres/swing/binding/BindingContext.java
@@ -58,6 +58,8 @@ import java.util.Map;
  * @version $Revision$ $Date$
  * @since Ceres 0.6
  */
+// MAR2020 - Daniel Knowles - Added setEnabled so that some properties can be initially enabled/disabled
+
 public class BindingContext {
 
     private final PropertySet propertySet;
@@ -477,6 +479,22 @@ public class BindingContext {
         }
         component.setEnabled(enabled);
     }
+
+
+    /**
+     * Sets the <i>enabled</i> state of the components associated with {@code targetProperty}.
+     * Enablement of the target property matches that of the source property.
+     *
+     * @param targetPropertyName  The name of the target property.
+     * @param sourcePropertyName  The name of the source property.
+     */
+    public Enablement bindEnabledState(final String targetPropertyName,
+                                       final String sourcePropertyName) {
+        return bindEnabledState(targetPropertyName, true,
+                new EqualValuesCondition(sourcePropertyName, true));
+    }
+
+
 
     /**
      * Sets the <i>enabled</i> state of the components associated with {@code targetProperty}.

--- a/ceres-ui/src/main/java/com/bc/ceres/swing/binding/PropertyPane.java
+++ b/ceres-ui/src/main/java/com/bc/ceres/swing/binding/PropertyPane.java
@@ -43,15 +43,13 @@ import static com.bc.ceres.swing.TableLayout.cell;
  * @version $Revision$ $Date$
  * @
  */
-// JAN2018 - Daniel Knowles - Added method to return property pane as a JScrollPane
-
-
-// JAN2018 - Daniel Knowles - Moved some of the logic for adding components to a public method which can also be called by
+// JAN2019 - Knowles - Added method to return property pane as a JScrollPane
+// JAN2019 - Knowles - Moved some of the logic for adding components to a public method which can also be called by
 //                            the preferences GUIs.
 //                          - Added tooltips: NOTE: actual tooltips values will be added in the future.
 //                            NOTE: this does not contain section breaks which may be added in the future for a future
 //                                  revision of map gridlines and other tools.
-
+// MAR2021 - Knowles - Added setEnabled so that some properties can be initially disabled
 
 
 public class PropertyPane {
@@ -182,6 +180,8 @@ public class PropertyPane {
         if (components.length == 2) {
             components[0].setToolTipText(descriptor.getDescription());
             components[1].setToolTipText(descriptor.getDescription());
+            components[0].setEnabled(descriptor.getEnabled());
+            components[1].setEnabled(descriptor.getEnabled());
             layout.setCellWeightX(rowIndex, 0, 0.0);
             panel.add(components[1], cell(rowIndex, 0));
             layout.setCellWeightX(rowIndex, 1, 1.0);

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorBarInfo.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorBarInfo.java
@@ -1,0 +1,129 @@
+package org.esa.snap.core.datamodel;
+
+import java.text.DecimalFormat;
+
+/**
+ * @author Daniel Knowles
+ */
+
+public class ColorBarInfo {
+
+    private double value;
+    private double locationWeight;
+    private String formattedValue;
+    private int decimalPlaces;
+    private boolean decimalPlacesForce;
+
+
+    public ColorBarInfo(double value, double locationWeight, int decimalPlaces, boolean decimalPlacesForce) {
+        setValue(value);
+        setLocationWeight(locationWeight);
+        setDecimalPlaces(decimalPlaces);
+        setDecimalPlacesForce(decimalPlacesForce);
+        setFormattedValue();
+    }
+
+    public ColorBarInfo(double value, double locationWeight, String formattedValue) {
+        setValue(value);
+        setLocationWeight(locationWeight);
+        setFormattedValue(formattedValue);
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    private void setValue(double value) {
+        this.value = value;
+    }
+
+    public double getLocationWeight() {
+        return locationWeight;
+    }
+
+    public void setLocationWeight(double locationWeight) {
+        this.locationWeight = locationWeight;
+    }
+
+    public String getFormattedValue() {
+        return formattedValue;
+    }
+
+
+    public void setFormattedValue(String formattedValue) {
+        this.formattedValue = formattedValue;
+    }
+
+
+    private void setFormattedValue() {
+        StringBuilder decimalFormatStringBuilder = new StringBuilder("0");
+
+
+        if (getDecimalPlaces() > 0) {
+
+            double actualDecimalPlaces = getDecimalPlaces();
+            double minDisplayableValue = 1;
+            for (int j = 0; j < getDecimalPlaces(); j++) {
+                if (j > 0) {
+                    minDisplayableValue = minDisplayableValue / 10.0;
+                }
+            }
+
+            // handle small numbers increasing number of decimal places if needed
+            if (getValue() > 0) {
+                while ((getValue()) < minDisplayableValue) {
+                    double testValue = getValue();
+                    minDisplayableValue = minDisplayableValue / 10.0;
+                    actualDecimalPlaces++;
+                }
+            }
+
+            //set max decimal places
+            for (int j = 0; j < actualDecimalPlaces; j++) {
+                if (j == 0) {
+                    decimalFormatStringBuilder.append(".");
+                }
+                decimalFormatStringBuilder.append("0");
+
+            }
+
+            String formattedDecimalValue = new DecimalFormat(decimalFormatStringBuilder.toString()).format(getValue()).toString();
+
+
+            if (!isDecimalPlacesForce()) {
+                // trim off trailing zeros
+                while (formattedDecimalValue.length() > 0 && formattedDecimalValue.endsWith("0")) {
+                    formattedDecimalValue = formattedDecimalValue.substring(0, formattedDecimalValue.length() - 1);
+                }
+
+                // trim of period in the case of an integer
+                if (formattedDecimalValue.length() > 0 && formattedDecimalValue.endsWith(".")) {
+                    formattedDecimalValue = formattedDecimalValue.substring(0, formattedDecimalValue.length() - 1);
+                }
+            }
+
+
+            this.formattedValue = formattedDecimalValue;
+        } else {
+            String formattedDecimalValue = new DecimalFormat(decimalFormatStringBuilder.toString()).format(getValue()).toString();
+            this.formattedValue = formattedDecimalValue;
+        }
+    }
+
+
+    public int getDecimalPlaces() {
+        return decimalPlaces;
+    }
+
+    private void setDecimalPlaces(int decimalPlaces) {
+        this.decimalPlaces = decimalPlaces;
+    }
+
+    public boolean isDecimalPlacesForce() {
+        return decimalPlacesForce;
+    }
+
+    public void setDecimalPlacesForce(boolean decimalPlacesForce) {
+        this.decimalPlacesForce = decimalPlacesForce;
+    }
+}

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ImageLegend.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ImageLegend.java
@@ -16,26 +16,20 @@
 package org.esa.snap.core.datamodel;
 
 import org.esa.snap.core.image.ImageManager;
+import org.esa.snap.core.layer.ColorBarLayer;
+import org.esa.snap.core.layer.ColorBarLayerType;
+import org.esa.snap.core.util.PropertyMap;
 import org.esa.snap.core.util.StringUtils;
-import org.esa.snap.core.util.math.MathUtils;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.RenderingHints;
-import java.awt.Shape;
+import java.awt.*;
 import java.awt.geom.GeneralPath;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
 
-// @todo 2 nf/** - if orientation is vertical, sample values should increase from bottom to top
-// @todo 1 nf/** - make PALETTE_HEIGHT a fixed value, fill space into gaps instead
-// @todo 2 nf/** - draw header text vertically for vertical orientations
-// @todo 3 nf/** - also draw legend into product scene view
-//                 make "color legend properties" dialog a preferences page
+import static org.esa.snap.core.layer.ColorBarLayerType.PROPERTY_LABELS_FONT_SIZE_DEFAULT;
 
 
 /**
@@ -43,59 +37,476 @@ import java.awt.image.BufferedImage;
  * ImageInfo}</code> instance.
  *
  * @author Norman Fomferra
+ * @author Daniel Knowles
  * @version $Revision$ $Date$
  */
+// MAY2021 - Daniel Knowles - Major revisions to Color Bar Legend
+    // todo there is extra unused methods and some commented out code which relates so SeaDAS-BEAM code for defining preset colorbar labels based on a bandname lookup, the commented out and unused methods may be useful in implementing that mechanism later if it is desired.
+
 public class ImageLegend {
+
+    public static final String PROPERTY_NAME_COLORBAR_TITLE_OVERRIDE = "palettes.colorbar.Title.Override";
+    public static final boolean DEFAULT_COLORBAR_TITLE_OVERRIDE = false;
+    public static final String PROPERTY_NAME_COLORBAR_LABELS_OVERRIDE = "palettes.colorbar.Labels.Override";
+    public static final boolean DEFAULT_COLORBAR_LABELS_OVERRIDE = false;
+    public static final String PROPERTY_NAME_COLORBAR_ALLOW_RESET = "palettes.colorbar.Allow.Reset";
+    public static final boolean DEFAULT_COLORBAR_ALLOW_RESET = false;
 
     public static final int HORIZONTAL = 0;
     public static final int VERTICAL = 1;
 
-    private static final int GAP = 10;
-    private static final int LABEL_GAP = 12;
-    private static final int SLIDER_WIDTH = 10;
-    private static final int SLIDER_HEIGHT = 14;
+    public static final int NULL_INT = -999;
 
-    private static final int MIN_PALETTE_WIDTH = 256;
-    private static final int MIN_PALETTE_HEIGHT = 32;
-    private static final int MIN_LEGEND_WIDTH = 320;
-    private static final int MIN_LEGEND_HEIGHT = 48;
+    public static final String DISTRIB_EVEN_STR = ColorBarLayerType.DISTRIB_EVEN_STR;
+    public static final String DISTRIB_EXACT_STR = ColorBarLayerType.DISTRIB_EXACT_STR;
+    public static final String DISTRIB_MANUAL_STR = ColorBarLayerType.DISTRIB_MANUAL_STR;
 
-    private static final Font _DEFAULT_FONT = new Font("Arial", Font.BOLD, 14);
+    public static final double HORIZONTAL_TITLE_PARAMETER_UNITS_GAP_FACTOR = 2;
+    public static final double HORIZONTAL_INTER_LABEL_GAP_FACTOR = 3;
+    public static final double VERTICAL_INTER_LABEL_GAP_FACTOR = 0.75;
+
+    public static final double FORCED_CHANGE_FACTOR = 0.0001;
+
+    private double weightTolerance;
+
+    private double titleToUnitsVerticalGap;
+    private double titleToUnitsHorizontalGap;
+    private double titleHeight;
+    private double titleWidth;
+    private double titleSingleLetterWidth;
+    private double unitsHeight;
+    private double unitsWidth;
+    private double unitsSingleLetterWidth;
+    private double labelHeight;
+    private double labelLongestWidth;
+    private double labelSingleLetterWidth;
+
 
     // Independent attributes (Properties)
     private final ImageInfo imageInfo;
     private final RasterDataNode raster;
-    private boolean usingHeader;
-    private String headerText;
+    private boolean showTitle;
+    private boolean showUnits;
+    private String titleText;
+    private String unitsText;
     private int orientation;
-    private Font font;
-    private Color foregroundColor;
-    private Color backgroundColor;
-    private boolean backgroundTransparencyEnabled;
-    private float backgroundTransparency;
+    private String distributionType;
+    private int tickMarkCount;
+
+
+    private String titleVerticalAnchor;
+    private boolean reversePalette = true;
+
+    private Color tickmarkColor;
+    private int tickmarkLength = NULL_INT;
+    private int tickmarkWidth = NULL_INT;
+    private boolean tickmarkShow;
+
+    private int borderWidth;
+    private Color borderColor;
+    private boolean borderShow;
+
+    private Color backdropColor;
+    private boolean transparencyEnabled;
+    private float backdropTransparency;
+    private boolean backdropShow;
+
+    private Color backdropBorderColor;
+    private int backdropBorderWidth;
+    private boolean backdropBorderShow;
+
+    private String labelsFontName;
+    private int labelsFontType;
+
+    private String titleFontName;
+    private int titleFontType;
+    private String unitsFontName;
+    private int unitsFontType;
+
+    private Color labelsColor;
+    private boolean labelsShow;
+    private Color titleColor;
+    private Color unitsColor;
+
     private boolean antialiasing;
+    private int decimalPlaces;
+    private boolean decimalPlacesForce;
+    private String customLabelValues;
+
+    private double scalingFactor;
+    private int titleFontSize;
+    private int unitsFontSize;
+    private int labelsFontSize;
+    private int colorBarLength;
+    private int colorBarWidth;
+    private double layerScaling;
+
+    private String titleOverRide = null;
+
+    private int borderGap = NULL_INT;   // TITLE_TO_PALETTE_GAP
+    private int labelGap = NULL_INT;      // LABEL_TO_COLORBAR BORDER_GAP
+    private int titleGap = NULL_INT;      // HEADER_TO_COLORBAR BORDER_GAP
 
     // Dependent, internal attributes
     private Rectangle paletteRect;
+    private Rectangle legendRect;
     private Dimension legendSize;
-    private Shape sliderShape;
-    private String[] labels;
-    private int[] labelWidths;
-    private int palettePos1;
-    private int palettePos2;
+    private Shape tickMarkShape;
+    private int palettePosStart;
+    private int palettePosEnd;
+    private ArrayList<ColorBarInfo> colorBarInfos = new ArrayList<ColorBarInfo>();
+
 
     public ImageLegend(ImageInfo imageInfo, RasterDataNode raster) {
         this.imageInfo = imageInfo;
         this.raster = raster;
-        usingHeader = true;
-        headerText = "";
-        orientation = HORIZONTAL;
-        font = _DEFAULT_FONT;
-        antialiasing = false;
-        backgroundColor = Color.white;
-        foregroundColor = Color.black;
-        backgroundTransparency = 0.0f;
+
+        antialiasing = true;
+
+//        setCustomLabelValues("");
+
     }
+
+
+    public ImageLegend getCopyOfImageLegend() {
+
+        ImageLegend imageLegendCopy = new ImageLegend(raster.getImageInfo(), raster);
+
+        imageLegendCopy.setOrientation(getOrientation());
+        imageLegendCopy.setReversePalette(isReversePalette());
+
+        imageLegendCopy.setShowTitle(isShowTitle());
+        imageLegendCopy.setTitleText(getTitleText());
+        imageLegendCopy.setTitleFontSize(getTitleFontSize());
+        imageLegendCopy.setTitleColor(getTitleColor());
+        imageLegendCopy.setTitleFontName(getTitleFontName());
+        imageLegendCopy.setTitleFontType(getTitleFontType());
+
+        imageLegendCopy.setShowUnits(isShowUnits());
+        imageLegendCopy.setUnitsText(getUnitsText());
+        imageLegendCopy.setUnitsFontSize(getUnitsFontSize());
+        imageLegendCopy.setUnitsColor(getUnitsColor());
+        imageLegendCopy.setUnitsFontName(getUnitsFontName());
+        imageLegendCopy.setUnitsFontType(getUnitsFontType());
+
+        imageLegendCopy.setTickMarkCount(getTickMarkCount());
+        imageLegendCopy.setDistributionType(getDistributionType());
+        imageLegendCopy.setCustomLabelValues(getCustomLabelValues());
+        imageLegendCopy.setScalingFactor(getScalingFactor());
+        imageLegendCopy.setDecimalPlaces(getDecimalPlaces());
+        imageLegendCopy.setDecimalPlacesForce(isDecimalPlacesForce());
+
+        imageLegendCopy.setTitleVerticalAnchor(getTitleVerticalAnchor());
+        imageLegendCopy.setColorBarLength(getColorBarLength());
+        imageLegendCopy.setColorBarWidth(getColorBarWidth());
+
+        imageLegendCopy.setLayerScaling(getLayerScaling());
+        //            imageLegend.setBackgroundTransparencyEnabled(true);
+
+        imageLegendCopy.setAntialiasing((Boolean) true);
+
+        imageLegendCopy.setLabelsShow(isLabelsShow());
+        imageLegendCopy.setLabelsFontName(getLabelsFontName());
+        imageLegendCopy.setLabelsFontType(getLabelsFontType());
+        imageLegendCopy.setLabelsFontSize(getLabelsFontSize());
+        imageLegendCopy.setLabelsColor(getLabelsColor());
+
+        imageLegendCopy.setTickmarkColor(getTickmarkColor());
+        imageLegendCopy.setTickmarkLength(getTickmarkLength());
+        imageLegendCopy.setTickmarkWidth(getTickmarkWidth());
+        imageLegendCopy.setTickmarkShow(isTickmarkShow());
+
+        imageLegendCopy.setBackdropColor(getBackdropColor());
+        imageLegendCopy.setBackdropTransparency(getBackdropTransparency());
+        imageLegendCopy.setBackdropShow(isBackdropShow());
+
+        imageLegendCopy.setBorderShow(isBorderShow());
+        imageLegendCopy.setBorderWidth(getBorderWidth());
+        imageLegendCopy.setBorderColor(getBorderColor());
+
+        imageLegendCopy.setBackdropBorderColor(getBackdropBorderColor());
+        imageLegendCopy.setBackdropBorderWidth(getBackdropBorderWidth());
+        imageLegendCopy.setBackdropBorderShow(isBackdropBorderShow());
+
+        imageLegendCopy.setWeightTolerance(getWeightTolerance());
+
+        return imageLegendCopy;
+    }
+
+
+    public void initLegendWithPreferences(PropertyMap configuration, RasterDataNode raster) {
+
+
+        // Orientation Parameters
+
+        String orientationString = configuration.getPropertyString(ColorBarLayerType.PROPERTY_ORIENTATION_KEY,
+                ColorBarLayerType.PROPERTY_ORIENTATION_DEFAULT);
+
+        if (ColorBarLayerType.OPTION_VERTICAL.equals(orientationString)) {
+            setOrientation(ImageLegend.VERTICAL);
+        } else {
+            setOrientation(ImageLegend.HORIZONTAL);
+        }
+
+        setReversePalette(configuration.getPropertyBool(ColorBarLayerType.PROPERTY_ORIENTATION_REVERSE_PALETTE_KEY,
+                ColorBarLayerType.PROPERTY_ORIENTATION_REVERSE_PALETTE_DEFAULT));
+
+
+        // Label Distribution and Values
+
+        setTickMarkCount(configuration.getPropertyInt(ColorBarLayerType.PROPERTY_LABEL_VALUES_COUNT_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_COUNT_DEFAULT));
+
+        setDistributionType(configuration.getPropertyString(ColorBarLayerType.PROPERTY_LABEL_VALUES_MODE_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_MODE_DEFAULT));
+
+        setCustomLabelValues(configuration.getPropertyString(ColorBarLayerType.PROPERTY_LABEL_VALUES_ACTUAL_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_ACTUAL_DEFAULT));
+
+        setScalingFactor(configuration.getPropertyDouble(ColorBarLayerType.PROPERTY_LABEL_VALUES_SCALING_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_SCALING_DEFAULT));
+
+        setDecimalPlaces(configuration.getPropertyInt(ColorBarLayerType.PROPERTY_LABEL_VALUES_DECIMAL_PLACES_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_DECIMAL_PLACES_DEFAULT));
+
+        setDecimalPlacesForce(configuration.getPropertyBool(ColorBarLayerType.PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_DEFAULT));
+
+        setWeightTolerance(configuration.getPropertyDouble(ColorBarLayerType.PROPERTY_WEIGHT_TOLERANCE_KEY,
+                ColorBarLayerType.PROPERTY_WEIGHT_TOLERANCE_DEFAULT));
+
+
+
+
+
+        // Sizing and Location
+        setColorBarLength(configuration.getPropertyInt(ColorBarLayerType.PROPERTY_COLORBAR_LENGTH_KEY,
+                ColorBarLayerType.PROPERTY_COLORBAR_LENGTH_DEFAULT));
+
+        setColorBarWidth(configuration.getPropertyInt(ColorBarLayerType.PROPERTY_COLORBAR_WIDTH_KEY,
+                ColorBarLayerType.PROPERTY_COLORBAR_WIDTH_DEFAULT));
+
+        setTitleVerticalAnchor(configuration.getPropertyString(ColorBarLayerType.PROPERTY_LOCATION_TITLE_VERTICAL_KEY,
+                ColorBarLayerType.PROPERTY_LOCATION_TITLE_VERTICAL_DEFAULT));
+
+
+        // Title parameters
+
+        setShowTitle(
+                configuration.getPropertyBool(ColorBarLayerType.PROPERTY_TITLE_SHOW_KEY,
+                        ColorBarLayerType.PROPERTY_TITLE_SHOW_DEFAULT));
+
+
+        String titleTextDefault = configuration.getPropertyString(ColorBarLayerType.PROPERTY_TITLE_TEXT_KEY,
+                ColorBarLayerType.PROPERTY_TITLE_TEXT_DEFAULT);
+
+        String titleText = (ColorBarLayerType.NULL_SPECIAL.equals(titleTextDefault)) ? raster.getName() : titleTextDefault;
+
+        setTitleText(titleText);
+
+
+        setTitleFontSize(
+                configuration.getPropertyInt(ColorBarLayerType.PROPERTY_TITLE_FONT_SIZE_KEY,
+                        ColorBarLayerType.PROPERTY_TITLE_FONT_SIZE_DEFAULT));
+
+        setTitleColor(
+                configuration.getPropertyColor(ColorBarLayerType.PROPERTY_TITLE_COLOR_KEY,
+                        ColorBarLayerType.PROPERTY_TITLE_COLOR_DEFAULT));
+
+        setTitleFontName(
+                configuration.getPropertyString(ColorBarLayerType.PROPERTY_TITLE_FONT_NAME_KEY,
+                        ColorBarLayerType.PROPERTY_TITLE_FONT_NAME_DEFAULT));
+
+
+        boolean titleParameterBold = configuration.getPropertyBool(ColorBarLayerType.PROPERTY_TITLE_FONT_BOLD_KEY,
+                ColorBarLayerType.PROPERTY_TITLE_FONT_BOLD_DEFAULT);
+
+        boolean titleParameterItalic = configuration.getPropertyBool(ColorBarLayerType.PROPERTY_TITLE_FONT_ITALIC_KEY,
+                ColorBarLayerType.PROPERTY_TITLE_FONT_ITALIC_DEFAULT);
+
+        int titleFontType = ColorBarLayer.getFontType(titleParameterItalic, titleParameterBold);
+
+        setTitleFontType(titleFontType);
+
+
+        // Units parameters
+
+        setShowUnits(
+                configuration.getPropertyBool(ColorBarLayerType.PROPERTY_UNITS_SHOW_KEY,
+                        ColorBarLayerType.PROPERTY_UNITS_SHOW_DEFAULT));
+
+
+        String unitsTextDefault = configuration.getPropertyString(ColorBarLayerType.PROPERTY_UNITS_TEXT_KEY,
+                ColorBarLayerType.PROPERTY_UNITS_TEXT_DEFAULT);
+
+
+        String unitsText = "";
+        if (ColorBarLayerType.NULL_SPECIAL.equals(unitsTextDefault)) {
+            String unit = raster.getUnit();
+            if (unit != null && unit.length() > 0) {
+                unitsText = "(" + raster.getUnit() + ")";
+            }
+        } else {
+            unitsText = unitsTextDefault;
+        }
+
+
+        setUnitsText(unitsText);
+
+
+        setUnitsFontSize(
+                configuration.getPropertyInt(ColorBarLayerType.PROPERTY_UNITS_FONT_SIZE_KEY,
+                        ColorBarLayerType.PROPERTY_UNITS_FONT_SIZE_DEFAULT));
+
+        setUnitsColor(
+                configuration.getPropertyColor(ColorBarLayerType.PROPERTY_UNITS_FONT_COLOR_KEY,
+                        ColorBarLayerType.PROPERTY_UNITS_FONT_COLOR_DEFAULT));
+
+        setUnitsFontName(
+                configuration.getPropertyString(ColorBarLayerType.PROPERTY_UNITS_FONT_NAME_KEY,
+                        ColorBarLayerType.PROPERTY_UNITS_FONT_NAME_DEFAULT));
+
+
+        boolean unitsBold = configuration.getPropertyBool(ColorBarLayerType.PROPERTY_UNITS_FONT_BOLD_KEY,
+                ColorBarLayerType.PROPERTY_UNITS_FONT_BOLD_DEFAULT);
+
+        boolean unitsItalic = configuration.getPropertyBool(ColorBarLayerType.PROPERTY_UNITS_FONT_ITALIC_KEY,
+                ColorBarLayerType.PROPERTY_UNITS_FONT_ITALIC_DEFAULT);
+
+        int unitsFontType = ColorBarLayer.getFontType(unitsItalic, unitsBold);
+
+        setUnitsFontType(unitsFontType);
+
+
+        // Labels Parameters
+
+        setLabelsShow(configuration.getPropertyBool(ColorBarLayerType.PROPERTY_LABELS_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_SHOW_DEFAULT));
+
+        setLabelsFontName(configuration.getPropertyString(ColorBarLayerType.PROPERTY_LABELS_FONT_NAME_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_FONT_NAME_DEFAULT));
+
+        boolean labelsFontBold = configuration.getPropertyBool(ColorBarLayerType.PROPERTY_LABELS_FONT_BOLD_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_FONT_BOLD_DEFAULT);
+
+        boolean labelsFontItalic = configuration.getPropertyBool(ColorBarLayerType.PROPERTY_LABELS_FONT_ITALIC_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_FONT_ITALIC_DEFAULT);
+
+        setLabelsFontType(ColorBarLayer.getFontType(labelsFontItalic, labelsFontBold));
+
+        setLabelsFontSize(configuration.getPropertyInt(ColorBarLayerType.PROPERTY_LABELS_FONT_SIZE_KEY,
+                PROPERTY_LABELS_FONT_SIZE_DEFAULT));
+
+        setLabelsColor(configuration.getPropertyColor(ColorBarLayerType.PROPERTY_LABELS_FONT_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_FONT_COLOR_DEFAULT));
+
+
+        // Tick Marks Section
+
+        setTickmarkShow(configuration.getPropertyBool(ColorBarLayerType.PROPERTY_TICKMARKS_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_TICKMARKS_SHOW_DEFAULT));
+
+        setTickmarkLength(configuration.getPropertyInt(ColorBarLayerType.PROPERTY_TICKMARKS_LENGTH_KEY,
+                ColorBarLayerType.PROPERTY_TICKMARKS_LENGTH_DEFAULT));
+
+        setTickmarkWidth(configuration.getPropertyInt(ColorBarLayerType.PROPERTY_TICKMARKS_WIDTH_KEY,
+                ColorBarLayerType.PROPERTY_TICKMARKS_WIDTH_DEFAULT));
+
+        setTickmarkColor(configuration.getPropertyColor(ColorBarLayerType.PROPERTY_TICKMARKS_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_TICKMARKS_COLOR_DEFAULT));
+
+
+        // Backdrop Section
+
+        setBackdropShow(configuration.getPropertyBool(ColorBarLayerType.PROPERTY_BACKDROP_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_BACKDROP_SHOW_DEFAULT));
+
+        setBackdropColor(configuration.getPropertyColor(ColorBarLayerType.PROPERTY_BACKDROP_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_BACKDROP_COLOR_DEFAULT));
+
+        double backdropTrans = configuration.getPropertyDouble(ColorBarLayerType.PROPERTY_BACKDROP_TRANSPARENCY_KEY,
+                ColorBarLayerType.PROPERTY_BACKDROP_TRANSPARENCY_DEFAULT);
+
+        setBackdropTransparency(((Number) backdropTrans).floatValue());
+
+
+        // Palette Border Section
+
+        setBorderShow(configuration.getPropertyBool(ColorBarLayerType.PROPERTY_PALETTE_BORDER_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_PALETTE_BORDER_SHOW_DEFAULT));
+
+        setBorderWidth(configuration.getPropertyInt(ColorBarLayerType.PROPERTY_PALETTE_BORDER_WIDTH_KEY,
+                ColorBarLayerType.PROPERTY_PALETTE_BORDER_WIDTH_DEFAULT));
+
+        setBorderColor(configuration.getPropertyColor(ColorBarLayerType.PROPERTY_PALETTE_BORDER_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_PALETTE_BORDER_COLOR_DEFAULT));
+
+
+        // Legend Border Section
+
+        setBackdropBorderShow(configuration.getPropertyBool(ColorBarLayerType.PROPERTY_LEGEND_BORDER_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_LEGEND_BORDER_SHOW_DEFAULT));
+
+        setBackdropBorderWidth(configuration.getPropertyInt(ColorBarLayerType.PROPERTY_LEGEND_BORDER_WIDTH_KEY,
+                ColorBarLayerType.PROPERTY_LEGEND_BORDER_WIDTH_DEFAULT));
+
+        setBackdropBorderColor(configuration.getPropertyColor(ColorBarLayerType.PROPERTY_LEGEND_BORDER_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_LEGEND_BORDER_COLOR_DEFAULT));
+
+
+
+
+
+        setLayerScaling(100.0);
+
+
+        setAntialiasing((Boolean) true);
+
+        //  imageLegend.setBackgroundTransparencyEnabled(true);
+    }
+
+
+    // todo This block from SeaDAS 7 may contain useful info for later implementing a color bar scheme
+//    public void initDefaults(PropertyMap configuration) {
+//
+//
+//        //  configuration.getPropertyBool(PROPERTY_NAME_COLORBAR_TITLE_OVERRIDE, DEFAULT_COLORBAR_TITLE_OVERRIDE);
+//        ColorPaletteSourcesInfo colorPaletteSourcesInfo = raster.getImageInfo().getColorPaletteSourcesInfo();
+//
+//        if (colorPaletteSourcesInfo != null) {
+//            final String schemeName = colorPaletteSourcesInfo.getSchemeName();
+//            final double min = getImageInfo().getColorPaletteDef().getMinDisplaySample();
+//            final double max = getImageInfo().getColorPaletteDef().getMaxDisplaySample();
+//
+//            final boolean logScaled = getImageInfo().isLogScaled();
+//
+//            String labels = colorPaletteSourcesInfo.getColorBarLabels();
+//
+//
+//            setHeaderText(raster.getName());
+//            if (allowTitleOverride(configuration)) {
+//                String overrideColorBarTitle = colorPaletteSourcesInfo.getColorBarTitle();
+//                if (overrideColorBarTitle != null && overrideColorBarTitle.length() > 0) {
+//                    setHeaderText(overrideColorBarTitle);
+//                }
+//            }
+//
+//
+//            if (!colorPaletteSourcesInfo.isAlteredScheme(min, max, logScaled) && labels != null && labels.length() > 0 && allowLabelsOverride(configuration)) {
+//
+//                setDistributionType(ImageLegend.DISTRIB_MANUAL_STR);
+//                setFullCustomAddThesePoints(labels);
+//
+//            } else {
+//
+//                setNumberOfTicks(5);
+//                setScalingFactor(1.0);
+//                setDecimalPlaces(2);
+//                distributeEvenly();
+//                setDistributionType(ImageLegend.DISTRIB_MANUAL_STR);
+//            }
+//        }
+//    }
 
     public ImageInfo getImageInfo() {
         return imageInfo;
@@ -105,20 +516,40 @@ public class ImageLegend {
         return raster;
     }
 
-    public boolean isUsingHeader() {
-        return usingHeader;
+
+    public boolean isShowTitle() {
+        return showTitle;
     }
 
-    public void setUsingHeader(boolean usingHeader) {
-        this.usingHeader = usingHeader;
+    public void setShowTitle(boolean usingHeader) {
+        this.showTitle = usingHeader;
     }
 
-    public String getHeaderText() {
-        return headerText;
+    public String getTitleText() {
+        return (titleText == null) ? "null-test" : titleText;
+        // todo possible Color Bar Scheme could go here in the future
+//        if (!isInitialized() && titleOverRide != null && titleOverRide.length() > 0) {
+//            return titleOverRide;
+//        } else {
+//            return headerText;
+//        }
+//        return headerText;
     }
 
-    public void setHeaderText(String headerText) {
-        this.headerText = headerText;
+    public void setTitleText(String titleText) {
+        this.titleText = titleText;
+    }
+
+    public String getUnitsText() {
+        if (unitsText == null || unitsText.length() == 0) {
+            return "";
+        } else {
+            return unitsText;
+        }
+    }
+
+    public void setUnitsText(String unitsText) {
+        this.unitsText = unitsText;
     }
 
     public int getOrientation() {
@@ -129,29 +560,39 @@ public class ImageLegend {
         this.orientation = orientation;
     }
 
-    public Font getFont() {
-        return font;
+    public String getDistributionType() {
+        return distributionType;
     }
 
-    public void setFont(Font font) {
-        this.font = font;
+    public void setDistributionType(String distributionType) {
+        this.distributionType = distributionType;
     }
 
-    public Color getBackgroundColor() {
-        return backgroundColor;
+    public int getDecimalPlaces() {
+        return decimalPlaces;
     }
 
-    public void setBackgroundColor(Color backgroundColor) {
-        this.backgroundColor = backgroundColor;
+    public void setDecimalPlaces(int decimalPlaces) {
+        this.decimalPlaces = decimalPlaces;
     }
 
-    public Color getForegroundColor() {
-        return foregroundColor;
+
+    public int getTickMarkCount() {
+        return tickMarkCount;
     }
 
-    public void setForegroundColor(Color foregroundColor) {
-        this.foregroundColor = foregroundColor;
+    public void setTickMarkCount(int tickMarkCount) {
+        this.tickMarkCount = tickMarkCount;
     }
+
+    public Color getBackdropColor() {
+        return backdropColor;
+    }
+
+    public void setBackdropColor(Color backdropColor) {
+        this.backdropColor = backdropColor;
+    }
+
 
     public boolean isAntialiasing() {
         return antialiasing;
@@ -161,248 +602,1274 @@ public class ImageLegend {
         this.antialiasing = antialiasing;
     }
 
-    public boolean isBackgroundTransparencyEnabled() {
-        return backgroundTransparencyEnabled;
+    public void setTransparent(boolean isTransparent) {
+        if (isTransparent) {
+            setBackdropTransparency(1.0f);
+        } else {
+            setBackdropTransparency(0.0f);
+        }
+        setTransparencyEnabled(isTransparent);
     }
 
-    public void setBackgroundTransparencyEnabled(boolean backgroundTransparencyEnabled) {
-        this.backgroundTransparencyEnabled = backgroundTransparencyEnabled;
+    public boolean isTransparencyEnabled() {
+        return transparencyEnabled;
     }
 
-    public float getBackgroundTransparency() {
-        return backgroundTransparency;
+    public void setTransparencyEnabled(boolean transparencyEnabled) {
+        this.transparencyEnabled = transparencyEnabled;
     }
 
-    public void setBackgroundTransparency(float backgroundTransparency) {
-        this.backgroundTransparency = backgroundTransparency;
+    public float getBackdropTransparency() {
+        return backdropTransparency;
+    }
+
+    public void setBackdropTransparency(float backdropTransparency) {
+        this.backdropTransparency = backdropTransparency;
     }
 
     public boolean isAlphaUsed() {
-        return backgroundTransparencyEnabled && backgroundTransparency > 0.0f && backgroundTransparency <= 1.0f;
+        return transparencyEnabled;
+//        return transparencyEnabled && (backdropTransparency > 0.0f && backdropTransparency <= 1.0f);
     }
 
     public int getBackgroundAlpha() {
-        return isAlphaUsed() ? Math.round(255f * (1f - backgroundTransparency)) : 255;
+        if (transparencyEnabled) {
+            if (isBackdropShow()) {
+                return Math.round(255f * (1f - backdropTransparency));
+            } else {
+                return Math.round(0f);
+            }
+        } else {
+            return 255;
+        }
     }
 
+
+    public BufferedImage createImage(Dimension imageLayerDimension, boolean scaleToDimension) {
+
+        double scalingFactor = 1.0;
+
+        if (scaleToDimension) {
+
+            createColorBarInfos();
+            initDrawing();
+
+            double oneHundredPercentScalingFactor;
+            if (orientation == HORIZONTAL) {
+                oneHundredPercentScalingFactor = (double) imageLayerDimension.width / (double) legendSize.width;
+            } else {
+                oneHundredPercentScalingFactor = (double) imageLayerDimension.height / (double) legendSize.height;
+            }
+
+            scalingFactor = getLayerScaling() / 100.0;
+            scalingFactor = scalingFactor * oneHundredPercentScalingFactor;
+
+        }
+
+
+        int tmpLabelsFontSize = getLabelsFontSize();
+        int tmpTickmarkLength = getTickmarkLength();
+        int tmpTickmarkWidth = getTickmarkWidth();
+        int tmpTitleFontSize = getTitleFontSize();
+        int tmpTitleUnitsFontSize = getUnitsFontSize();
+        int tmpColorBarLength = getColorBarLength();
+        int tmpColorBarThickness = getColorBarWidth();
+
+        setLabelsFontSize((int) Math.round(scalingFactor * getLabelsFontSize()));
+        setTickmarkLength((int) Math.round(scalingFactor * getTickmarkLength()));
+        setTickmarkWidth((int) Math.round(scalingFactor * getTickmarkWidth()));
+        setTitleFontSize((int) Math.round(scalingFactor * getTitleFontSize()));
+        setUnitsFontSize((int) Math.round(scalingFactor * getUnitsFontSize()));
+        setColorBarLength((int) Math.round(scalingFactor * getColorBarLength()));
+        setColorBarWidth((int) Math.round(scalingFactor * getColorBarWidth()));
+
+        BufferedImage bufferedImage = createImage();
+
+        setLabelsFontSize(tmpLabelsFontSize);
+        setTickmarkLength(tmpTickmarkLength);
+        setTickmarkWidth(tmpTickmarkWidth);
+        setTitleFontSize(tmpTitleFontSize);
+        setUnitsFontSize(tmpTitleUnitsFontSize);
+        setColorBarLength(tmpColorBarLength);
+        setColorBarWidth(tmpColorBarThickness);
+
+        return bufferedImage;
+    }
+
+
     public BufferedImage createImage() {
+        createColorBarInfos();
         initDrawing();
         final BufferedImage bi = createBufferedImage(legendSize.width, legendSize.height);
         final Graphics2D g2d = bi.createGraphics();
         g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
         g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-        if (antialiasing) {
+        if (isAntialiasing()) {
             g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
             g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
         } else {
             g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
             g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
         }
-        if (font != null) {
-            g2d.setFont(font);
-        }
+
         draw(g2d);
         return bi;
     }
 
-    private void initDrawing() {
-        final FontMetrics fontMetrics = createFontMetrics();
-        final int n = getNumGradationCurvePoints();
-        labels = new String[n];
-        labelWidths = new int[n];
-        int textHeight = fontMetrics.getHeight();
-        final double minValue = imageInfo.getColorPaletteDef().getMinDisplaySample();
-        final double maxValue = imageInfo.getColorPaletteDef().getMaxDisplaySample();
-        double roundFactor = MathUtils.computeRoundFactor(minValue, maxValue, 2);
-        for (int i = 0; i < n; i++) {
-            ColorPaletteDef.Point slider = getGradationCurvePointAt(i);
-            labels[i] = String.valueOf(MathUtils.round(slider.getSample(), roundFactor));
-            labelWidths[i] = fontMetrics.stringWidth(labels[i]);
-        }
+    // todo Color Bar Scheme can possibly be added in the future
+//    private File getColorPalettesAuxdataDir() {
+//        return new File(SystemUtils.getApplicationDataDir(), "beam-ui/auxdata/color-palettes");
+//    }
 
-        int headerTextVSpace = 0;
-        int headerTextWidth = 0;
-        if (hasHeaderText()) {
-            headerTextVSpace = textHeight + GAP;
-            headerTextWidth = fontMetrics.stringWidth(headerText);
-        }
+    public void createColorBarInfos() {
 
-        int legendWidth = 0;
-        int legendHeight = 0;
-        int maxLabelWidth = 0;
-        for (int i = 0; i < n; i++) {
-            legendWidth += LABEL_GAP + labelWidths[i];
-            legendHeight += 2 * textHeight;
-            maxLabelWidth = Math.max(labelWidths[i], maxLabelWidth);
-        }
+        final double min = getImageInfo().getColorPaletteDef().getMinDisplaySample();
+        final double max = getImageInfo().getColorPaletteDef().getMaxDisplaySample();
 
-        if (orientation == HORIZONTAL) {
-            legendWidth = Math.max(legendWidth, MIN_PALETTE_HEIGHT);
-            legendWidth = GAP + Math.max(legendWidth, headerTextWidth) + GAP;
-            legendHeight = GAP + headerTextVSpace + MIN_PALETTE_HEIGHT + LABEL_GAP + textHeight + GAP;
-            legendWidth = Math.max(MIN_LEGEND_WIDTH, adjust(legendWidth, 16));
-            legendHeight = Math.max(MIN_LEGEND_HEIGHT, adjust(legendHeight, 16));
-        } else {
-            legendWidth = MIN_PALETTE_HEIGHT + LABEL_GAP + maxLabelWidth;
-            legendWidth = GAP + Math.max(legendWidth, headerTextWidth) + GAP;
-            legendHeight = GAP + headerTextVSpace + Math.max(legendHeight, MIN_PALETTE_WIDTH) + LABEL_GAP + textHeight + GAP;
-            legendWidth = Math.max(MIN_LEGEND_HEIGHT, adjust(legendWidth, 16));
-            legendHeight = Math.max(MIN_LEGEND_WIDTH, adjust(legendHeight, 16));
-        }
+        double value, weight;
+        double roundedValue, adjustedWeight;
+        colorBarInfos.clear();
 
-        legendSize = new Dimension(legendWidth, legendHeight);
+        // todo Color Bar Scheme can possibly be added in the future
+//
+//        String schemeName = imageInfo.getColorPaletteSourcesInfo().getSchemeName();
+//        boolean isDefault = false;
 
 
-        final int headerTextSpace = headerText != null ? textHeight + GAP : 0;
-        final int labelTextSpace = LABEL_GAP + textHeight;
-        if (orientation == HORIZONTAL) {
-            paletteRect = new Rectangle(GAP,
-                                        GAP + headerTextSpace,
-                                        legendSize.width - (GAP + GAP),
-                                        legendSize.height - (GAP + headerTextSpace + labelTextSpace + GAP));
-            int paletteGap = Math.max(labelWidths[0], labelWidths[n - 1]) / 2;
-            palettePos1 = paletteRect.x + paletteGap;
-            palettePos2 = paletteRect.x + paletteRect.width - paletteGap;
-        } else {
-            paletteRect = new Rectangle(GAP,
-                                        GAP + headerTextSpace,
-                                        legendSize.width - (GAP + labelTextSpace + maxLabelWidth + GAP),
-                                        legendSize.height - (GAP + headerTextSpace + GAP));
-            int paletteGap = Math.max(textHeight, SLIDER_WIDTH) / 2;
-            palettePos1 = paletteRect.y + paletteGap;
-            palettePos2 = paletteRect.y + paletteRect.height - paletteGap;
-        }
-        sliderShape = createSliderShape();
+//        if (DISTRIB_DEFAULT_STR.equals(getDistributionType()) && schemeName != null && schemeName.equals("chlor_a")) {
+//            String test = "0.01,0.03,0.1,0.3,1,3,10";
+//    //        setHeaderText("Chlorophyll");
+//            setFullCustomAddThesePoints(test);
+//            isDefault = true;
+//        }
+
+
+//        if (getFullCustomAddThesePoints() == null || getFullCustomAddThesePoints().length() == 0) {
+//            // this will initialize the points
+//            distributeEvenly();
+//            colorBarInfos.clear();
+//        }
+
+
+//        if (DISTRIB_EXACT_STR.equals(getDistributionType()) || imageInfo.getColorPaletteDef().isDiscrete()) {
+
+//        if (DISTRIB_EVEN_STR.equals(getDistributionType()) && imageInfo.getColorPaletteDef().isDiscrete()) {
+//            setDistributionType(DISTRIB_EXACT_STR);
+//        }
+
+        if (DISTRIB_EXACT_STR.equals(getDistributionType()) ||
+                (DISTRIB_EVEN_STR.equals(getDistributionType()) && imageInfo.getColorPaletteDef().isDiscrete())
+        ) {
+            final int numPointsInCpdFile = getNumGradationCurvePoints();
+            int stepSize = 1;
+            //    int stepSize = numPointsInCpdFile / getNumberOfTicks();
+            ArrayList<String> manualPointsArrayList = new ArrayList<>();
+
+            for (int i = 0; i < numPointsInCpdFile; i = i + stepSize) {
+
+                ColorPaletteDef.Point slider = getGradationCurvePointAt(i);
+                value = slider.getSample();
+
+                if (imageInfo.isLogScaled()) {
+                    weight = getLinearWeightFromLogValue(value, min, max);
+                } else {
+                    weight = getLinearWeightFromLinearValue(value, min, max);
+                }
+
+                // Apply tolerance to potentially bring weight into valid state
+                weight = getValidWeight(weight);
+
+                if (weight >= 0 && weight <= 1) {
+                    if (getScalingFactor() != 0) {
+                        value = value * getScalingFactor();
+                        ColorBarInfo colorBarInfo = new ColorBarInfo(value, weight, getDecimalPlaces(), isDecimalPlacesForce());
+
+                        double valueScaledFormatted = Double.valueOf(colorBarInfo.getFormattedValue());
+                        double minScaled = min * getScalingFactor();
+                        double maxScaled = max * getScalingFactor();
+
+                        double weightScaled;
+                        if (imageInfo.isLogScaled()) {
+                            weightScaled = getLinearWeightFromLogValue(valueScaledFormatted, minScaled, maxScaled);
+                        } else {
+                            weightScaled = getLinearWeightFromLinearValue(valueScaledFormatted, minScaled, maxScaled);
+                        }
+
+                        // Apply tolerance to potentially bring weight into valid state
+                        weightScaled = getValidWeight(weightScaled);
+
+                        if (weightScaled >= 0 && weightScaled <= 1) {
+                            // adjust weight to match formatted string
+                            colorBarInfo.setLocationWeight(weightScaled);
+
+                            colorBarInfos.add(colorBarInfo);
+                            manualPointsArrayList.add(colorBarInfo.getFormattedValue());
+                        }
+// This else block would put label in with no decimal restrictions for the case where the end point is not shown due to rounding
+//                        } else {
+//                            String newFormattedValue = Double.toString(colorBarInfo.getValue());
+//                            colorBarInfo.setFormattedValue(newFormattedValue);
+//                            colorBarInfos.add(colorBarInfo);
+//                            manualPointsArrayList.add(newFormattedValue);
+//                        }
+                    }
+                }
+            }
+
+            if (manualPointsArrayList.size() > 0) {
+                String manualPoints = StringUtils.join(manualPointsArrayList, ", ");
+                setCustomLabelValues(manualPoints);
+            }
+
+        } else if (DISTRIB_EVEN_STR.equals(getDistributionType())) {
+                distributeEvenly();
+
+        } else if (DISTRIB_MANUAL_STR.equals(getDistributionType())) {
+                if (getCustomLabelValues() == null || getCustomLabelValues().length() == 0) {
+                    // this will initialize the points
+                    distributeEvenly();
+                    colorBarInfos.clear();
+                }
+
+                String addThese = getCustomLabelValues();
+
+                if (addThese != null && addThese.length() > 0) {
+                    String[] formattedValues = addThese.split(",");
+
+
+                    for (String formattedValue : formattedValues) {
+                        if (formattedValue != null) {
+                            formattedValue.trim();
+                            if (formattedValue.length() > 0 && scalingFactor != 0) {
+
+                                String[] valueAndString = formattedValue.split(":");
+                                if (valueAndString.length == 2) {
+                                    value = Double.valueOf(valueAndString[0]) / getScalingFactor();
+                                    formattedValue = valueAndString[1];
+                                } else {
+                                    value = Double.valueOf(formattedValue) / getScalingFactor();
+                                }
+
+
+                                if (imageInfo.isLogScaled()) {
+                                    if (value == min) {
+                                        weight = 0;
+                                    } else if (value == max) {
+                                        weight = 1;
+                                    } else {
+                                        weight = getLinearWeightFromLogValue(value, min, max);
+                                    }
+                                } else {
+                                    weight = getLinearWeightFromLinearValue(value, min, max);
+                                }
+
+                                weight = getValidWeight(weight);
+                                if (weight >= 0 && weight <= 1) {
+                                    ColorBarInfo colorBarInfo = new ColorBarInfo(value, weight, formattedValue);
+                                    colorBarInfos.add(colorBarInfo);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
     }
 
-    private boolean hasHeaderText() {
-        return usingHeader && StringUtils.isNotNullAndNotEmpty(headerText);
+
+
+
+
+    private double getValidWeight(double weight) {
+        // due to rounding issues we want to make sure the weight isn't just below 0 or just above 1
+        // this would cause the tick mark to possibly be placed a very tiny amount outside of the colorbar if not corrected here
+
+        boolean valid = (weight >= (0 - weightTolerance) && weight <= (1 + weightTolerance))
+                ? true : false;
+
+        if (valid) {
+            if (weight > 1) {
+                weight = 1;
+            }
+            if (weight < 0) {
+                weight = 0;
+            }
+
+            return weight;
+        } else {
+            return -1;
+        }
+
+    }
+
+
+    private void initDrawing() {
+
+        final BufferedImage bufferedImage = createBufferedImage(100, 100);
+        final Graphics2D g2dTmp = bufferedImage.createGraphics();
+
+        initCoreGraphicSizes(g2dTmp);
+
+
+        g2dTmp.setFont(getLabelsFont());
+
+        Dimension headerRequiredDimension;
+
+        if (orientation == HORIZONTAL) {
+            headerRequiredDimension = getTitleRequiredDimension(false, false);
+        } else {
+            if (ColorBarLayerType.VERTICAL_TITLE_TOP.equals(getTitleVerticalAnchor()) ||
+                    ColorBarLayerType.VERTICAL_TITLE_BOTTOM.equals(getTitleVerticalAnchor())) {
+                headerRequiredDimension = getTitleRequiredDimension(true, false);
+
+            } else {
+                headerRequiredDimension = getTitleRequiredDimension(false, true);
+            }
+        }
+
+
+        double discreteBooster = 0;
+        final int n = getNumGradationCurvePoints();
+
+        double firstLabelWidth = getSingleLabelRequiredDimension(g2dTmp, 0).getWidth();
+        int firstLabelOverhangWidth = (int) Math.ceil(firstLabelWidth / 2.0);
+
+        double lastLabelWidth = getSingleLabelRequiredDimension(g2dTmp, colorBarInfos.size() - 1).getWidth();
+        int lastLabelOverhangWidth = (int) Math.ceil(lastLabelWidth / 2.0);
+
+        double firstLabelHeight = getSingleLabelRequiredDimension(g2dTmp, 0).getHeight();
+        int labelOverhangHeight = (int) Math.ceil(firstLabelHeight / 2.0);
+
+        int tickOffset = 0;
+
+        if (getTickmarkLength() > 0) {
+            tickOffset = getTickmarkLength();
+        }
+
+        if (orientation == HORIZONTAL) {
+
+
+            Dimension labelsRequiredDimension = getHorizontalLabelsRequiredDimension(g2dTmp);
+
+            double colorBarWithLabelsRequiredLength = firstLabelOverhangWidth + getColorBarLength() + lastLabelOverhangWidth;
+
+            double requiredWidth = Math.max(colorBarWithLabelsRequiredLength,
+                    headerRequiredDimension.getWidth());
+
+            requiredWidth = getBorderGap() + requiredWidth + getBorderGap();
+
+
+            if (n > 1 && imageInfo.getColorPaletteDef().isDiscrete()) {
+                discreteBooster = labelsRequiredDimension.getWidth() / (n - 1);
+                requiredWidth += discreteBooster;
+            }
+
+
+            int requiredHeaderHeight = (int) Math.ceil(headerRequiredDimension.getHeight());
+            int requiredLabelsHeight = (int) Math.ceil(labelsRequiredDimension.getHeight());
+
+
+            int requiredHeight = getBorderGap()
+                    + requiredHeaderHeight
+                    + getTitleGap()
+                    + getColorBarWidth()
+                    + getLabelGap()
+                    + tickOffset
+                    + requiredLabelsHeight
+                    + getBorderGap();
+
+
+            legendSize = new Dimension((int) requiredWidth, requiredHeight);
+
+
+            paletteRect = new Rectangle(getBorderGap() + firstLabelOverhangWidth,
+                    getBorderGap() + requiredHeaderHeight + getTitleGap(),
+                    legendSize.width - getBorderGap() - getBorderGap() - firstLabelOverhangWidth - lastLabelOverhangWidth,
+                    getColorBarWidth());
+
+            legendRect = new Rectangle(0, 0, legendSize.width - 1, legendSize.height - 1);
+
+
+            int paletteGap = 0;
+            palettePosStart = paletteRect.x + paletteGap;
+            palettePosEnd = paletteRect.x + paletteRect.width - (int) discreteBooster;
+
+            // todo a piece of the old beam code, see what adjust does
+            //   Math.max(_MIN_LEGEND_WIDTH, adjust(legendWidth, 16));
+
+        } else {
+
+
+            Dimension labelsRequiredDimension = getVerticalLabelsRequiredDimension(g2dTmp);
+            int requiredLabelsHeight = (int) Math.ceil(labelsRequiredDimension.getHeight());
+
+            double requiredWidth;
+            double requiredHeight;
+
+
+            if (ColorBarLayerType.VERTICAL_TITLE_TOP.equals(getTitleVerticalAnchor()) ||
+                    ColorBarLayerType.VERTICAL_TITLE_BOTTOM.equals(getTitleVerticalAnchor())) {
+
+
+                double colorBarAndLabelsRequiredWidth = getColorBarWidth() + getLabelGap() + tickOffset + labelsRequiredDimension.getWidth();
+
+                requiredWidth = Math.max(headerRequiredDimension.getWidth(), colorBarAndLabelsRequiredWidth);
+
+                requiredWidth = getBorderGap() + requiredWidth + getBorderGap();
+
+
+                double colorBarWithLabelsRequiredHeight = labelOverhangHeight + getColorBarLength() + labelOverhangHeight;
+
+
+                requiredHeight = getBorderGap() +
+                        colorBarWithLabelsRequiredHeight +
+                        getTitleGap() +
+                        headerRequiredDimension.getHeight()
+                        + getBorderGap();
+
+
+                if (n > 1 && imageInfo.getColorPaletteDef().isDiscrete()) {
+                    discreteBooster = labelsRequiredDimension.getHeight() / (n - 1);
+                    requiredWidth += discreteBooster;
+                }
+
+
+                legendSize = new Dimension((int) requiredWidth, (int) requiredHeight);
+
+
+            } else {
+
+                requiredWidth = getBorderGap()
+                        + getTitleHeight()
+                        + getColorBarWidth()
+                        + tickOffset
+                        + getLabelGap()
+                        + getLongestLabelWidth(g2dTmp)
+                        + getTitleGap()
+                        + getBorderGap();
+
+
+                double colorBarWithLabelsRequiredHeight = labelOverhangHeight + getColorBarLength() + labelOverhangHeight;
+
+                requiredHeight = Math.max(colorBarWithLabelsRequiredHeight, headerRequiredDimension.getHeight());
+                requiredHeight = getBorderGap() + requiredHeight + getBorderGap();
+
+                if (n > 1 && imageInfo.getColorPaletteDef().isDiscrete()) {
+                    discreteBooster = labelsRequiredDimension.getHeight() / (n - 1);
+                    requiredWidth += discreteBooster;
+                }
+
+                legendSize = new Dimension((int) requiredWidth, (int) requiredHeight);
+            }
+
+
+            if (ColorBarLayerType.VERTICAL_TITLE_TOP.equals(getTitleVerticalAnchor())) {
+                paletteRect = new Rectangle(getBorderGap(),
+                        getBorderGap() + labelOverhangHeight + (int) headerRequiredDimension.getHeight() + getTitleGap(),
+                        getColorBarWidth(),
+                        getColorBarLength());
+                legendRect = new Rectangle(0, 0, legendSize.width - 1, legendSize.height - 1);
+
+
+            } else if (ColorBarLayerType.VERTICAL_TITLE_BOTTOM.equals(getTitleVerticalAnchor())) {
+                paletteRect = new Rectangle(getBorderGap(),
+                        getBorderGap() + labelOverhangHeight,
+                        getColorBarWidth(),
+                        getColorBarLength());
+                legendRect = new Rectangle(0, 0, legendSize.width - 1, legendSize.height - 1);
+
+
+            } else if (ColorBarLayerType.VERTICAL_TITLE_LEFT.equals(getTitleVerticalAnchor())) {
+                paletteRect = new Rectangle(getBorderGap() + headerRequiredDimension.width + getTitleGap(),
+                        getBorderGap() + labelOverhangHeight,
+                        getColorBarWidth(),
+                        getColorBarLength());
+                legendRect = new Rectangle(0, 0, legendSize.width - 1, legendSize.height - 1);
+
+
+            } else { // VERTICAL_TITLE_RIGHT
+                paletteRect = new Rectangle(getBorderGap(),
+                        getBorderGap() + labelOverhangHeight,
+                        getColorBarWidth(),
+                        getColorBarLength());
+                legendRect = new Rectangle(0, 0, legendSize.width - 1, legendSize.height - 1);
+
+            }
+
+            palettePosStart = paletteRect.y + paletteRect.height;
+            palettePosEnd = paletteRect.y + (int) discreteBooster;
+        }
+
+
+        tickMarkShape = createTickMarkShape();
+    }
+
+
+    private boolean hasTitleParameter() {
+        return isShowTitle() && StringUtils.isNotNullAndNotEmpty(titleText);
+    }
+
+    private boolean hasTitleUnits() {
+        return isShowUnits() && StringUtils.isNotNullAndNotEmpty(unitsText);
     }
 
     private void draw(Graphics2D g2d) {
         fillBackground(g2d);
-        drawHeaderText(g2d);
         drawPalette(g2d);
-        drawLabels(g2d);
+        drawHeaderText(g2d);
+
+        if (isLabelsShow()) {
+            drawLabelsAndTickMarks(g2d);
+        }
     }
 
     private void fillBackground(Graphics2D g2d) {
-        Color c = backgroundColor;
+        Color color = backdropColor;
         if (isAlphaUsed()) {
-            c = new Color(c.getRed(), c.getGreen(), c.getBlue(), getBackgroundAlpha());
+            color = new Color(color.getRed(), color.getGreen(), color.getBlue(), getBackgroundAlpha());
         }
-        g2d.setColor(c);
+
+        g2d.setColor(color);
         g2d.fillRect(0, 0, legendSize.width + 1, legendSize.height + 1);
     }
 
-    private void drawHeaderText(Graphics2D g2d) {
-        if (hasHeaderText()) {
-            final FontMetrics fontMetrics = g2d.getFontMetrics();
-            g2d.setPaint(foregroundColor);
-            int x0 = GAP;
-            int y0 = GAP + fontMetrics.getMaxAscent();
-            g2d.drawString(headerText, x0, y0);
+
+    private void initCoreGraphicSizes(Graphics2D g2d) {
+
+        double vertical_gap_factor = 0.3;
+        double horizontal_gap_factor = HORIZONTAL_TITLE_PARAMETER_UNITS_GAP_FACTOR;
+
+        Font originalFont = g2d.getFont();
+
+        g2d.setFont(getTitleParameterFont());
+        Rectangle2D titleRectangle = g2d.getFontMetrics().getStringBounds(getTitleText(), g2d);
+        Rectangle2D titleSingleLetterRectangle = g2d.getFontMetrics().getStringBounds("A", g2d);
+
+        double titleParameterHeight = titleRectangle.getHeight();
+        double titleParameterWidth = titleRectangle.getWidth();
+        double titleParameterSingleLetterWidth = titleSingleLetterRectangle.getWidth();
+
+        g2d.setFont(getTitleUnitsFont());
+        Rectangle2D unitsRectangle = g2d.getFontMetrics().getStringBounds(getUnitsText(), g2d);
+        Rectangle2D unitsSingleLetterRectangle = g2d.getFontMetrics().getStringBounds("A", g2d);
+
+        double titleUnitsHeight = unitsRectangle.getHeight();
+        double titleUnitsWidth = unitsRectangle.getWidth();
+        double titleUnitsSingleLetterWidth = unitsSingleLetterRectangle.getWidth();
+
+        double titleToUnitsVerticalGap = 0.0;
+        double titleToUnitsHorizontalGap = 0.0;
+
+        if (hasTitleParameter() && hasTitleUnits()) {
+            titleToUnitsVerticalGap = vertical_gap_factor * titleUnitsHeight;
+            titleToUnitsHorizontalGap = horizontal_gap_factor * titleUnitsSingleLetterWidth;
+        }
+
+        g2d.setFont(getTitleUnitsFont());
+        Rectangle2D labelSingleLetterRectangle = g2d.getFontMetrics().getStringBounds("A", g2d);
+
+        int headerGap = (int) Math.round(0.5 * getTitleFontSize());
+        int borderGap = (int) Math.round(0.3 * getTitleFontSize());
+
+
+        setTitleToUnitsVerticalGap(titleToUnitsVerticalGap);
+        setTitleToUnitsHorizontalGap(titleToUnitsHorizontalGap);
+
+        setTitleHeight(titleParameterHeight);
+        setTitleWidth(titleParameterWidth);
+        setTitleSingleLetterWidth(titleParameterSingleLetterWidth);
+
+        setUnitsHeight(titleUnitsHeight);
+        setUnitsWidth(titleUnitsWidth);
+        setUnitsSingleLetterWidth(titleUnitsSingleLetterWidth);
+
+        setLabelLongestWidth(getLongestLabelWidth(g2d));
+        setLabelHeight(labelSingleLetterRectangle.getHeight());
+        setLabelSingleLetterWidth(labelSingleLetterRectangle.getWidth());
+
+        setTitleGap(headerGap);
+        setBorderGap(borderGap);
+
+
+        g2d.setFont(originalFont);
+    }
+
+
+    private Dimension getTitleRequiredDimension(boolean lineBreak, boolean rotate) {
+
+        double width = 0;
+        double height = 0;
+
+        if (hasTitleParameter() && hasTitleUnits()) {
+            if (lineBreak) {
+                height = getTitleHeight() + getTitleToUnitsVerticalGap() + getUnitsHeight();
+                width = Math.max(getTitleWidth(), getUnitsWidth());
+            } else {
+                height = Math.max(getTitleHeight(), getUnitsHeight());
+                width = getTitleWidth() + getTitleToUnitsHorizontalGap() + getUnitsWidth();
+            }
+        } else if (hasTitleUnits()) {
+            // hasTitleUnits only
+            height = getUnitsHeight();
+            width = getUnitsWidth();
+        } else {
+            // hasTitleParameter only
+            height = getTitleHeight();
+            width = getTitleWidth();
+        }
+
+        if (rotate) {
+            return new Dimension((int) Math.ceil(height), (int) Math.ceil(width));
+        } else {
+            return new Dimension((int) Math.ceil(width), (int) Math.ceil(height));
         }
     }
+
+
+    private Dimension getHorizontalLabelsRequiredDimension(Graphics2D g2d) {
+
+        double width = 0;
+        double height = 0;
+
+        if (isLabelsShow() && colorBarInfos.size() > 0) {
+
+
+            Font originalFont = g2d.getFont();
+            g2d.setFont(getLabelsFont());
+
+            double totalLabelsNoGapsWidth = 0;
+
+            for (ColorBarInfo colorBarInfo : colorBarInfos) {
+                Rectangle2D labelRectangle = g2d.getFontMetrics().getStringBounds(colorBarInfo.getFormattedValue(), g2d);
+                totalLabelsNoGapsWidth += labelRectangle.getWidth();
+            }
+
+            Rectangle2D singleLetter = g2d.getFontMetrics().getStringBounds("A", g2d);
+            double interLabelGap = (HORIZONTAL_INTER_LABEL_GAP_FACTOR * singleLetter.getWidth());
+
+            double totalLabelGapsWidth = (colorBarInfos.size() - 1) * interLabelGap;
+
+            width = totalLabelsNoGapsWidth + totalLabelGapsWidth;
+
+            height = singleLetter.getHeight();
+
+            g2d.setFont(originalFont);
+        }
+
+        return new Dimension((int) Math.ceil(width), (int) Math.ceil(height));
+    }
+
+
+    private Dimension getVerticalLabelsRequiredDimension(Graphics2D g2d) {
+
+        double width = 0;
+        double height = 0;
+
+        if (isLabelsShow() && colorBarInfos.size() > 0) {
+
+            Font originalFont = g2d.getFont();
+            g2d.setFont(getLabelsFont());
+
+            double totalLabelsNoGapHeight = 0;
+
+            for (ColorBarInfo colorBarInfo : colorBarInfos) {
+                Rectangle2D labelRectangle = g2d.getFontMetrics().getStringBounds(colorBarInfo.getFormattedValue(), g2d);
+                totalLabelsNoGapHeight += labelRectangle.getHeight();
+                width = Math.max(width, labelRectangle.getWidth());
+            }
+
+            Rectangle2D singleLetter = g2d.getFontMetrics().getStringBounds("A", g2d);
+            double interLabelGap = (VERTICAL_INTER_LABEL_GAP_FACTOR * singleLetter.getHeight());
+
+            double totalLabelGapsHeight = (colorBarInfos.size() - 1) * interLabelGap;
+
+            height = totalLabelsNoGapHeight + totalLabelGapsHeight;
+
+            g2d.setFont(originalFont);
+        }
+
+        return new Dimension((int) Math.ceil(width), (int) Math.ceil(height));
+    }
+
+
+    private double getLongestLabelWidth(Graphics2D g2d) {
+
+        double width = 0;
+
+        if (isLabelsShow() && colorBarInfos.size() > 0) {
+
+            Font originalFont = g2d.getFont();
+            g2d.setFont(getLabelsFont());
+
+            for (ColorBarInfo colorBarInfo : colorBarInfos) {
+                Rectangle2D labelRectangle = g2d.getFontMetrics().getStringBounds(colorBarInfo.getFormattedValue(), g2d);
+                width = Math.max(width, labelRectangle.getWidth());
+            }
+
+            g2d.setFont(originalFont);
+        }
+
+        return width;
+    }
+
+
+    private Dimension getSingleLabelRequiredDimension(Graphics2D g2d, int colorBarInfoIndex) {
+
+        double width = 0;
+        double height = 0;
+
+        if (colorBarInfos.size() > 0 && colorBarInfos.size() > colorBarInfoIndex) {
+            Font originalFont = g2d.getFont();
+            g2d.setFont(getLabelsFont());
+
+            ColorBarInfo colorBarInfo = colorBarInfos.get(colorBarInfoIndex);
+            Rectangle2D labelRectangle = g2d.getFontMetrics().getStringBounds(colorBarInfo.getFormattedValue(), g2d);
+            width = labelRectangle.getWidth();
+            height = labelRectangle.getHeight();
+
+
+            g2d.setFont(originalFont);
+        }
+
+        return new Dimension((int) Math.ceil(width), (int) Math.ceil(height));
+    }
+
+
+    private void drawHeaderText(Graphics2D g2d) {
+        if (hasTitleParameter() || hasTitleUnits()) {
+            Font origFont = g2d.getFont();
+            Paint origPaint = g2d.getPaint();
+
+            int x0 = paletteRect.x;
+            int y0 = paletteRect.y;
+
+
+            if (orientation == HORIZONTAL) {
+                double translateTitleX = x0;
+                double translateTitleY = y0 - getTitleGap();
+
+                double translateUnitsX = 0;
+                double translateUnitsY = 0;
+
+                g2d.translate(translateTitleX, translateTitleY);
+
+
+                if (hasTitleParameter()) {
+                    g2d.setFont(getTitleParameterFont());
+                    g2d.setPaint(getTitleColor());
+                    g2d.drawString(titleText, 0, 0);
+
+                    translateUnitsX = getTitleWidth() + getTitleToUnitsHorizontalGap();
+                }
+
+
+                g2d.translate(translateUnitsX, translateUnitsY);
+
+                if (hasTitleUnits()) {
+                    g2d.setFont(getTitleUnitsFont());
+                    g2d.setPaint(getUnitsColor());
+                    g2d.drawString(getUnitsText(), 0, 0);
+                }
+
+
+                g2d.translate(-translateUnitsX, -translateUnitsY);
+                g2d.translate(-translateTitleX, -translateTitleY);
+
+
+            } else {
+
+                g2d.setFont(getTitleUnitsFont());
+                Rectangle2D singleLetter = g2d.getFontMetrics().getStringBounds("A", g2d);
+                int labelOverhangHeight = (int) Math.ceil(singleLetter.getHeight() / 2.0);
+
+                double translateX;
+
+                if (ColorBarLayerType.VERTICAL_TITLE_TOP.equals(getTitleVerticalAnchor())) {
+                    translateX = x0;
+
+                } else if (ColorBarLayerType.VERTICAL_TITLE_BOTTOM.equals(getTitleVerticalAnchor())) {
+                    translateX = x0;
+
+                } else if (ColorBarLayerType.VERTICAL_TITLE_LEFT.equals(getTitleVerticalAnchor())) {
+                    translateX = x0 - getTitleGap() - 0.5 * getTitleHeight();
+
+
+                } else { // VERTICAL_TITLE_RIGHT
+                    translateX = x0
+                            + 0.5 * getTitleHeight()
+                            + getColorBarWidth()
+                            + getTickmarkLength()
+                            + getLabelGap()
+                            + getLongestLabelWidth(g2d)
+                            + getTitleGap();
+
+                }
+
+
+                double translateY;
+
+
+                if (ColorBarLayerType.VERTICAL_TITLE_TOP.equals(getTitleVerticalAnchor()) ||
+                        ColorBarLayerType.VERTICAL_TITLE_BOTTOM.equals(getTitleVerticalAnchor())) {
+
+                    double translateY2 = 0;
+
+
+                    if (ColorBarLayerType.VERTICAL_TITLE_TOP.equals(getTitleVerticalAnchor())) {
+                        if (hasTitleParameter() && hasTitleUnits()) {
+                            translateY = y0 - getTitleGap() - labelOverhangHeight - getUnitsHeight() - 0.5 * getTitleHeight() - getTitleToUnitsVerticalGap();
+                        } else {
+                            translateY = y0 - getTitleGap() - labelOverhangHeight - 0.5 * getTitleHeight();
+                        }
+                    } else {
+                        translateY = y0 + getColorBarLength() + labelOverhangHeight + getTitleGap() + 0.5 * getTitleHeight();
+                    }
+
+                    g2d.translate(translateX, translateY);
+
+                    if (hasTitleParameter()) {
+                        g2d.setFont(getTitleParameterFont());
+                        g2d.setPaint(getTitleColor());
+                        g2d.drawString(titleText, 0, 0);
+                        translateY2 = getTitleHeight() + getTitleToUnitsVerticalGap();
+                    }
+
+
+                    g2d.translate(0, translateY2);
+
+                    if (hasTitleUnits()) {
+                        g2d.setFont(getTitleUnitsFont());
+                        g2d.setPaint(getUnitsColor());
+                        g2d.drawString(getUnitsText(), 0, 0);
+                    }
+
+                    g2d.translate(0, -translateY2);
+                    g2d.translate(-translateX, -translateY);
+
+
+                } else if (ColorBarLayerType.VERTICAL_TITLE_BOTTOM.equals(getTitleVerticalAnchor())) {
+                    translateY = y0;
+
+                } else { // VERTICAL_TITLE_RIGHT || VERTICAL_TITLE_LEFT
+                    translateY = y0 + getColorBarLength();
+                    double translateY2 = 0;
+
+
+                    double rotate = -Math.PI / 2.0;
+                    g2d.translate(translateX, translateY);
+
+
+                    if (hasTitleParameter()) {
+                        g2d.rotate(rotate);
+                        g2d.setFont(getTitleParameterFont());
+                        g2d.setPaint(getTitleColor());
+                        g2d.drawString(titleText, 0, 0);
+                        g2d.rotate(-rotate);
+
+                        translateY2 = -getTitleWidth() - getTitleToUnitsHorizontalGap();
+                    }
+
+
+                    g2d.translate(0, translateY2);
+
+                    if (hasTitleUnits()) {
+                        g2d.rotate(rotate);
+                        g2d.setFont(getTitleUnitsFont());
+                        g2d.setPaint(getUnitsColor());
+                        g2d.drawString(getUnitsText(), 0, 0);
+                        g2d.rotate(-rotate);
+                    }
+
+                    g2d.translate(0, -translateY2);
+                    g2d.translate(-translateX, -translateY);
+
+                }
+
+
+            }
+
+
+            // Restore font graphics
+            g2d.setPaint(origPaint);
+            g2d.setFont(origFont);
+        }
+    }
+
 
     private void drawPalette(Graphics2D g2d) {
+
         final Color[] palette = ImageManager.createColorPalette(getRaster().getImageInfo());
-//        final Color[] palette = imageInfo.getColorPaletteDef().createColorPalette(getRaster());
-        final int x1 = paletteRect.x;
-        final int x2 = paletteRect.x + paletteRect.width;
-        final int y1 = paletteRect.y;
-        final int y2 = paletteRect.y + paletteRect.height;
-        final int i1;
-        final int i2;
-        if (orientation == HORIZONTAL) {
-            i1 = x1;
-            i2 = x2;
-        } else {
-            i1 = y1;
-            i2 = y2;
-        }
+
+        Stroke originalStroke = g2d.getStroke();
         g2d.setStroke(new BasicStroke(1));
-        for (int i = i1; i < i2; i++) {
-            int divisor = palettePos2 - palettePos1;
+
+
+        if (orientation == HORIZONTAL) {
+            int xStart = paletteRect.x;
+            int xEnd = paletteRect.x + paletteRect.width;
+            int y1 = paletteRect.y;
+            int y2 = paletteRect.y + paletteRect.height;
+
+            int divisor = palettePosEnd - palettePosStart;
             int palIndex;
-            if (divisor == 0) {
-                palIndex = i < palettePos1 ? 0 : palette.length - 1;
+
+            if (isReversePalette()) {
+                for (int x = xEnd; x > xStart; x--) {
+
+                    if (divisor == 0) {
+                        palIndex = x < palettePosStart ? 0 : palette.length - 1;
+                    } else {
+                        palIndex = Math.round((palette.length * (palettePosEnd - x)) / divisor);
+                    }
+
+                    drawLineInHorizontalPalette(g2d, palette, palIndex, x, y1, y2);
+                }
             } else {
-                palIndex = (palette.length * (i - palettePos1)) / divisor;
+                for (int x = xStart; x < xEnd; x++) {
+                    if (divisor == 0) {
+                        palIndex = x < palettePosStart ? 0 : palette.length - 1;
+                    } else {
+                        palIndex = Math.round((palette.length * (x - palettePosStart)) / divisor);
+                    }
+
+                    drawLineInHorizontalPalette(g2d, palette, palIndex, x, y1, y2);
+                }
             }
-            if (palIndex < 0) {
-                palIndex = 0;
-            }
-            if (palIndex > palette.length - 1) {
-                palIndex = palette.length - 1;
-            }
-            g2d.setColor(palette[palIndex]);
-            if (orientation == HORIZONTAL) {
-                g2d.drawLine(i, y1, i, y2);
+        } else {
+            int x1 = paletteRect.x;
+            int x2 = paletteRect.x + paletteRect.width;
+            int yStart = paletteRect.y + paletteRect.height;
+            int yEnd = paletteRect.y;
+
+            int divisor = Math.abs(palettePosEnd - palettePosStart);
+            int palIndex;
+
+            if (isReversePalette()) {
+                for (int y = yEnd; y < yStart; y++) {
+
+                    if (divisor == 0) {
+                        palIndex = y < palettePosStart ? 0 : palette.length - 1;
+                    } else {
+                        palIndex = Math.round((palette.length * (y - palettePosEnd)) / divisor);
+                    }
+
+                    drawLineInVerticalPalette(g2d, palette, palIndex, x1, x2, y);
+                }
             } else {
-                g2d.drawLine(x1, i, x2, i);
+                for (int y = yStart; y > yEnd; y--) {
+
+                    if (divisor == 0) {
+                        palIndex = y < palettePosStart ? 0 : palette.length - 1;
+                    } else {
+                        palIndex = Math.round((palette.length * (palettePosStart - y)) / divisor);
+                    }
+
+                    drawLineInVerticalPalette(g2d, palette, palIndex, x1, x2, y);
+                }
             }
         }
-        g2d.setStroke(new BasicStroke(2));
-        g2d.setColor(foregroundColor);
-        g2d.draw(paletteRect);
-    }
 
-    private void drawLabels(Graphics2D g2d) {
-        final FontMetrics fontMetrics = g2d.getFontMetrics();
-        final int n = getNumGradationCurvePoints();
-        g2d.setStroke(new BasicStroke(2));
-        Color c1 = (foregroundColor != null ? foregroundColor : Color.black).brighter();
-        Color c2 = (backgroundColor != null ? backgroundColor : Color.white).darker();
-        for (int i = 0; i < n; i++) {
 
-            ColorPaletteDef.Point slider = getGradationCurvePointAt(i);
-            final double normalizedSample = normalizeSample(slider.getSample());
-            double sliderPos = normalizedSample * (palettePos2 - palettePos1);
-
-            double tx;
-            double ty;
-            if (orientation == HORIZONTAL) {
-                tx = palettePos1 + sliderPos;
-                ty = paletteRect.y + paletteRect.height;
-            } else {
-                tx = paletteRect.x + paletteRect.width;
-                ty = palettePos1 + sliderPos;
-            }
-            g2d.translate(tx, ty);
-
-            g2d.setPaint(slider.getColor());
-            g2d.fill(sliderShape);
-
-            int gray = (slider.getColor().getRed() + slider.getColor().getGreen() + slider.getColor().getBlue()) / 3;
-            g2d.setColor(gray < 128 ? c2 : c1);
-            g2d.draw(sliderShape);
-
-            float x0;
-            float y0;
-            if (orientation == HORIZONTAL) {
-                x0 = -0.5f * labelWidths[i];
-                y0 = LABEL_GAP + fontMetrics.getMaxAscent();
-            } else {
-                x0 = LABEL_GAP;
-                y0 = fontMetrics.getMaxAscent();
-            }
-            g2d.setPaint(foregroundColor);
-            g2d.drawString(labels[i], x0, y0);
-
-            g2d.translate(-tx, -ty);
+        if (isBorderShow()) {
+            g2d.setColor(getBorderColor());
+            g2d.setStroke(new BasicStroke(getBorderWidth()));
+            g2d.draw(paletteRect);
         }
+
+        if (isBackdropBorderShow()) {
+            g2d.setColor(getBackdropBorderColor());
+            g2d.setStroke(new BasicStroke(getBackdropBorderWidth()));
+            g2d.draw(legendRect);
+        }
+
+        g2d.setStroke(originalStroke);
     }
+
+
+    private void drawLineInHorizontalPalette(Graphics2D g2d, Color[] palette, int index, int x, int y1, int y2) {
+        index = forceIndexInBounds(palette, index);
+
+        g2d.setColor(palette[index]);
+        g2d.drawLine(x, y1, x, y2);
+    }
+
+
+    private void drawLineInVerticalPalette(Graphics2D g2d, Color[] palette, int index, int x1, int x2, int y) {
+        index = forceIndexInBounds(palette, index);
+
+        g2d.setColor(palette[index]);
+        g2d.drawLine(x1, y, x2, y);
+    }
+
+
+    private int forceIndexInBounds(Color[] palette, int index) {
+        if (index < 0) {
+            index = 0;
+        }
+        if (index > palette.length - 1) {
+            index = palette.length - 1;
+        }
+
+        return index;
+    }
+
+
+    private void drawLabelsAndTickMarks(Graphics2D g2d) {
+
+        Color originalColor = g2d.getColor();
+        Stroke originalStroke = g2d.getStroke();
+        Color originalPaint = (Color) g2d.getPaint();
+        Font originalFont = g2d.getFont();
+
+        g2d.setFont(getLabelsFont());
+        g2d.setPaint(getLabelsColor());
+
+        Stroke tickMarkStroke = new BasicStroke(getTickmarkWidth());
+        g2d.setStroke(tickMarkStroke);
+
+        double translateX, translateY;
+
+        int tickMarkOverHang;
+        if (Math.floor((getTickmarkWidth()) / 2) == (getTickmarkWidth()) / 2) {
+            // even
+            tickMarkOverHang = (int) Math.floor((getTickmarkWidth()) / 2);
+        } else {
+            // odd
+            tickMarkOverHang = (int) Math.floor((getTickmarkWidth() - 1) / 2);
+        }
+
+        for (ColorBarInfo colorBarInfo : colorBarInfos) {
+            String formattedValue = colorBarInfo.getFormattedValue();
+            double weight = colorBarInfo.getLocationWeight();
+
+            double tickMarkRelativePosition = weight * (palettePosEnd - palettePosStart);
+
+            if (orientation == HORIZONTAL) {
+                translateY = paletteRect.y + paletteRect.height;
+
+                if (isReversePalette()) {
+                    translateX = palettePosEnd - tickMarkRelativePosition;
+                    translateX = keepTickMarkInBoundsHorizontal(translateX, tickMarkOverHang);
+                } else {
+                    translateX = palettePosStart + tickMarkRelativePosition;
+                    translateX = keepTickMarkInBoundsHorizontal(translateX, tickMarkOverHang);
+                }
+            } else {
+                translateX = paletteRect.x + paletteRect.width;
+
+                if (isReversePalette()) {
+                    translateY = palettePosEnd - tickMarkRelativePosition;
+                    translateY = keepTickMarkInBoundsVertical(translateY, tickMarkOverHang);
+                } else {
+                    translateY = palettePosStart + tickMarkRelativePosition;
+                    translateY = keepTickMarkInBoundsVertical(translateY, tickMarkOverHang);
+                }
+            }
+
+
+            g2d.translate(translateX, translateY);
+
+            if (isTickmarkShow()) {
+                g2d.setPaint(getTickmarkColor());
+                g2d.draw(tickMarkShape);
+            }
+
+            final FontMetrics fontMetrics = g2d.getFontMetrics();
+            int labelWidth = fontMetrics.stringWidth(formattedValue);
+            int labelHeight = fontMetrics.getHeight();
+
+            float x0, y0;
+            int tickOffset = 0;
+
+            if (getTickmarkLength() > 0) {
+                tickOffset = getTickmarkLength();
+            }
+
+
+
+            if (orientation == HORIZONTAL) {
+                x0 = -0.5f * labelWidth;
+                y0 = getLabelGap() + tickOffset + fontMetrics.getMaxAscent();
+            } else {
+                x0 = getLabelGap() + tickOffset;
+                y0 = -0.5f * labelHeight + fontMetrics.getMaxAscent();
+            }
+
+            g2d.setPaint(getLabelsColor());
+            g2d.drawString(formattedValue, x0, y0);
+            g2d.translate(-translateX, -translateY);
+        }
+
+        g2d.setFont(originalFont);
+        g2d.setColor(originalColor);
+        g2d.setStroke(originalStroke);
+        g2d.setPaint(originalPaint);
+    }
+
+
+    private double keepTickMarkInBoundsHorizontal(double translate, int tickMarkOverHang) {
+        // make sure end tickmarks are placed within palette
+        // tickmark hardcoded at 3 width will have 1 tickMarkOverHang
+
+        if (translate <= (palettePosStart + tickMarkOverHang)) {
+            translate = (palettePosStart + tickMarkOverHang);
+        }
+
+        if (translate >= (palettePosEnd - tickMarkOverHang)) {
+            translate = (palettePosEnd - tickMarkOverHang);
+        }
+
+        return translate;
+    }
+
+
+    private double keepTickMarkInBoundsVertical(double translate, int tickMarkOverHang) {
+        // make sure end tickmarks are placed within palette
+        // tickmark hardcoded at 3 width will have 1 tickMarkOverHang
+
+        if (translate >= (palettePosStart - tickMarkOverHang)) {
+            translate = (palettePosStart - tickMarkOverHang);
+        }
+
+        if (translate <= (palettePosEnd + tickMarkOverHang)) {
+            translate = (palettePosEnd + tickMarkOverHang);
+        }
+
+        return translate;
+    }
+
+
+    public static double getLinearWeightFromLinearValue(double linearValue, double min, double max) {
+
+        // Prevent extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearValue == min) {
+            return 0;
+        }
+        if (linearValue == max) {
+            return 1;
+        }
+
+        double linearWeight = (linearValue - min) / (max - min);
+
+        // Prevent UNEXPECTED interpolation/extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearValue > min && linearWeight < 0) {
+            return 0;
+        }
+        if (linearValue < max && linearWeight > 1) {
+            return 1;
+        }
+        if (linearValue < min && linearWeight >= 0) {
+            return 0 - FORCED_CHANGE_FACTOR;
+        }
+        if (linearValue > max && linearWeight <= 1) {
+            return 1 + FORCED_CHANGE_FACTOR;
+        }
+        return linearWeight;
+    }
+
+
+    public static double getLinearWeightFromLogValue(double logValue, double min, double max) {
+
+        // Prevent extrapolation which could occur due to machine roundoffs in the calculations
+        if (logValue == min) {
+            return 0;
+        }
+        if (logValue == max) {
+            return 1;
+        }
+
+        double b = Math.log(max / min) / (max - min);
+        double a = min / (Math.exp(b * min));
+        double linearValue = Math.log(logValue / a) / b;
+        double linearWeight = (linearValue - min) / (max - min);
+
+        // Prevent UNEXPECTED interpolation/extrapolation which could occur due to machine roundoffs in the calculations
+        if (logValue > min && linearWeight < 0) {
+            return 0;
+        }
+        if (logValue < max && linearWeight > 1) {
+            return 1;
+        }
+        if (logValue < min && linearWeight >= 0) {
+            return 0 - FORCED_CHANGE_FACTOR;
+        }
+        if (logValue > max && linearWeight <= 1.0) {
+            return 1 + FORCED_CHANGE_FACTOR;
+        }
+
+        return linearWeight;
+    }
+
+
+    public static double getLinearValueUsingLinearWeight(double linearWeight, double min, double max) {
+
+        // Prevent extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearWeight == 0) {
+            return min;
+        }
+        if (linearWeight == 1) {
+            return max;
+        }
+
+        double deltaNormalized = (max - min);
+        double linearValue = min + linearWeight * (deltaNormalized);
+
+        // Prevent UNEXPECTED interpolation/extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearWeight > 0 && linearValue < min) {
+            return min;
+        }
+        if (linearWeight < 1 && linearValue > max) {
+            return max;
+        }
+        if (linearWeight < 0 && linearValue >= min) {
+            return min - (max - min) * FORCED_CHANGE_FACTOR;
+        }
+        if (linearWeight > 1 && linearValue <= max) {
+            return max + (max - min) * FORCED_CHANGE_FACTOR;
+        }
+
+        return linearValue;
+    }
+
+
+    public static double getLogarithmicValueUsingLinearWeight(double weight, double min, double max) {
+
+        double linearValue = getLinearValueUsingLinearWeight(weight, min, max);
+
+        // Prevent extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearValue == min) {
+            return min;
+        }
+        if (linearValue == max) {
+            return max;
+        }
+
+        double b = Math.log(max / min) / (max - min);
+        double a = min / (Math.exp(b * min));
+        double logValue = a * Math.exp(b * linearValue);
+
+        // Prevent UNEXPECTED interpolation/extrapolation which could occur due to machine roundoffs in the calculations
+        if (linearValue > min && logValue < min) {
+            return min;
+        }
+        if (linearValue < max && logValue > max) {
+            return max;
+        }
+        if (linearValue < min && logValue >= min) {
+            return min - (max - min) * FORCED_CHANGE_FACTOR;
+        }
+        if (linearValue > max && logValue <= max) {
+            return max + (max - min) * FORCED_CHANGE_FACTOR;
+        }
+
+        return logValue;
+    }
+
 
     private double normalizeSample(double sample) {
-        double minDisplaySample = getImageInfo().getColorPaletteDef().getMinDisplaySample();
-        double maxDisplaySample = getImageInfo().getColorPaletteDef().getMaxDisplaySample();
-        if (imageInfo.isLogScaled()) {
-            minDisplaySample = Math.log10(imageInfo.getColorPaletteDef().getMinDisplaySample());
-            maxDisplaySample = Math.log10(imageInfo.getColorPaletteDef().getMaxDisplaySample());
-            sample = Math.log10(sample);
-        }
-
+        final double minDisplaySample = getRaster().scaleInverse(getImageInfo().getColorPaletteDef().getMinDisplaySample());
+        final double maxDisplaySample = getRaster().scaleInverse(getImageInfo().getColorPaletteDef().getMaxDisplaySample());
+        sample = getRaster().scaleInverse(sample);
         double delta = maxDisplaySample - minDisplaySample;
         if (delta == 0 || Double.isNaN(delta)) {
             delta = 1;
@@ -410,16 +1877,14 @@ public class ImageLegend {
         return (sample - minDisplaySample) / delta;
     }
 
-    private Shape createSliderShape() {
+    private Shape createTickMarkShape() {
         GeneralPath path = new GeneralPath();
         if (orientation == HORIZONTAL) {
-            path.moveTo(0.0F, -0.5F * SLIDER_HEIGHT);
-            path.lineTo(+0.5F * SLIDER_WIDTH, +0.5F * SLIDER_HEIGHT);
-            path.lineTo(-0.5F * SLIDER_WIDTH, +0.5F * SLIDER_HEIGHT);
+            path.moveTo(0.0F, 1.0F * getTickmarkLength());
+            path.lineTo(0.0F, 0.0F);
         } else {
-            path.moveTo(-0.5F * SLIDER_HEIGHT, 0.0F);
-            path.lineTo(+0.5F * SLIDER_HEIGHT, +0.5F * SLIDER_WIDTH);
-            path.lineTo(+0.5F * SLIDER_HEIGHT, -0.5F * SLIDER_WIDTH);
+            path.moveTo(0.0F, 0.0F);
+            path.lineTo(1.0F * getTickmarkLength(), 0.0F);
         }
         path.closePath();
         return path;
@@ -440,9 +1905,6 @@ public class ImageLegend {
     private FontMetrics createFontMetrics() {
         BufferedImage bi = createBufferedImage(32, 32);
         final Graphics2D g2d = bi.createGraphics();
-        if (font != null) {
-            g2d.setFont(font);
-        }
         final FontMetrics fontMetrics = g2d.getFontMetrics();
         g2d.dispose();
         return fontMetrics;
@@ -450,7 +1912,538 @@ public class ImageLegend {
 
     private BufferedImage createBufferedImage(final int width, final int height) {
         return new BufferedImage(width, height,
-                                 isAlphaUsed() ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB);
+                isAlphaUsed() ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB);
     }
 
+
+    public String getCustomLabelValues() {
+        return customLabelValues;
+    }
+
+    public void setCustomLabelValues(String customLabelValues) {
+        this.customLabelValues = customLabelValues;
+    }
+
+
+    public Font getTitleParameterFont() {
+        return new Font(getTitleFontName(), getTitleFontType(), getTitleFontSize());
+    }
+
+    public Font getTitleUnitsFont() {
+        return new Font(getUnitsFontName(), getUnitsFontType(), getUnitsFontSize());
+    }
+
+
+    public Font getLabelsFont() {
+        return new Font(getLabelsFontName(), getLabelsFontType(), getLabelsFontSize());
+    }
+
+
+    public int getTitleFontSize() {
+        return titleFontSize;
+    }
+
+    public void setTitleFontSize(int titleFontSize) {
+        this.titleFontSize = titleFontSize;
+    }
+
+    public int getUnitsFontSize() {
+        return unitsFontSize;
+    }
+
+    public void setUnitsFontSize(int unitsFontSize) {
+        this.unitsFontSize = unitsFontSize;
+    }
+
+    public int getLabelsFontSize() {
+        return labelsFontSize;
+    }
+
+    public void setLabelsFontSize(int labelsFontSize) {
+        this.labelsFontSize = labelsFontSize;
+    }
+
+    public double getScalingFactor() {
+        return scalingFactor;
+    }
+
+    public void setScalingFactor(double scalingFactor) {
+        this.scalingFactor = scalingFactor;
+    }
+
+    public int getColorBarLength() {
+        return colorBarLength;
+    }
+
+    public void setColorBarLength(int colorBarLength) {
+        this.colorBarLength = colorBarLength;
+    }
+
+    public int getColorBarWidth() {
+        return colorBarWidth;
+    }
+
+    public void setColorBarWidth(int colorBarThickness) {
+        this.colorBarWidth = colorBarThickness;
+    }
+
+    public double getLayerScaling() {
+        return layerScaling;
+    }
+
+    public void setLayerScaling(double layerScaling) {
+        this.layerScaling = layerScaling;
+    }
+
+
+    public int getBorderGap() {
+        if (borderGap != NULL_INT) {
+            return borderGap;
+        } else {
+            return (int) Math.round(0.3 * getLabelsFontSize());
+        }
+    }
+
+    public void setBorderGap(int borderGap) {
+        this.borderGap = borderGap;
+    }
+
+    public int getLabelGap() {
+        if (labelGap != NULL_INT) {
+            return labelGap;
+        } else {
+            return (int) Math.round(0.3 * getLabelsFontSize());
+        }
+    }
+
+    public void setLabelGap(int labelGap) {
+        this.labelGap = labelGap;
+    }
+
+    public int getTitleGap() {
+        if (titleGap != NULL_INT) {
+            return titleGap;
+        } else {
+            return (int) Math.round(0.5 * getTitleFontSize());
+        }
+    }
+
+    public void setTitleGap(int titleGap) {
+        this.titleGap = titleGap;
+    }
+
+
+    public static double round(double value, int places) {
+        if (places < 0) throw new IllegalArgumentException();
+
+        BigDecimal bd = new BigDecimal(value);
+        bd = bd.setScale(places, RoundingMode.HALF_UP);
+        return bd.doubleValue();
+    }
+
+    public boolean isDecimalPlacesForce() {
+        return decimalPlacesForce;
+    }
+
+    public void setDecimalPlacesForce(boolean decimalPlacesForce) {
+        this.decimalPlacesForce = decimalPlacesForce;
+    }
+
+    public void distributeEvenly() {
+
+        final double min = getImageInfo().getColorPaletteDef().getMinDisplaySample();
+        final double max = getImageInfo().getColorPaletteDef().getMaxDisplaySample();
+
+        double value;
+        double weight;
+
+        colorBarInfos.clear();
+
+        if (getTickMarkCount() >= 2) {
+            ArrayList<String> manualPointsArrayList = new ArrayList<>();
+            double normalizedDelta = (1.0 / (getTickMarkCount() - 1.0));
+
+            for (int i = 0; i < getTickMarkCount(); i++) {
+
+                weight = i * normalizedDelta;
+                if (imageInfo.isLogScaled()) {
+                    value = getLogarithmicValueUsingLinearWeight(weight, min, max);
+                } else {
+                    value = getLinearValueUsingLinearWeight(weight, min, max);
+                }
+
+
+                // Apply tolerance to potentially bring weight into valid state
+                weight = getValidWeight(weight);
+
+                if (weight >= 0 && weight <= 1) {
+                    if (getScalingFactor() != 0) {
+                        value = value * getScalingFactor();
+                        ColorBarInfo colorBarInfo = new ColorBarInfo(value, weight, getDecimalPlaces(), isDecimalPlacesForce());
+
+                        double valueScaledFormatted = Double.valueOf(colorBarInfo.getFormattedValue());
+                        double minScaled = min * getScalingFactor();
+                        double maxScaled = max * getScalingFactor();
+
+                        double weightScaled;
+                        if (imageInfo.isLogScaled()) {
+                            weightScaled = getLinearWeightFromLogValue(valueScaledFormatted, minScaled, maxScaled);
+                        } else {
+                            weightScaled = getLinearWeightFromLinearValue(valueScaledFormatted, minScaled, maxScaled);
+                        }
+
+                        // Apply tolerance to potentially bring weight into valid state
+                        weightScaled = getValidWeight(weightScaled);
+
+                        if (weightScaled >= 0 && weightScaled <= 1) {
+                            // adjust weight to match formatted string
+                            colorBarInfo.setLocationWeight(weightScaled);
+
+                            colorBarInfos.add(colorBarInfo);
+                            manualPointsArrayList.add(colorBarInfo.getFormattedValue());
+                        }
+
+                    }
+                }
+            }
+            if (manualPointsArrayList.size() > 0) {
+                String manualPoints = StringUtils.join(manualPointsArrayList, ", ");
+                setCustomLabelValues(manualPoints);
+            }
+        }
+    }
+
+    public String getTitleOverRide() {
+        return titleOverRide;
+    }
+
+    public void setTitleOverRide(String titleOverRide) {
+        this.titleOverRide = titleOverRide;
+    }
+
+
+    public boolean allowTitleOverride(PropertyMap configuration) {
+        if (configuration != null) {
+            return configuration.getPropertyBool(PROPERTY_NAME_COLORBAR_TITLE_OVERRIDE, DEFAULT_COLORBAR_TITLE_OVERRIDE);
+        } else {
+            return DEFAULT_COLORBAR_TITLE_OVERRIDE;
+        }
+    }
+
+    public boolean allowLabelsOverride(PropertyMap configuration) {
+        if (configuration != null) {
+            return configuration.getPropertyBool(PROPERTY_NAME_COLORBAR_LABELS_OVERRIDE, DEFAULT_COLORBAR_LABELS_OVERRIDE);
+        } else {
+            return DEFAULT_COLORBAR_LABELS_OVERRIDE;
+        }
+    }
+
+    public static boolean allowColorbarAutoReset(PropertyMap configuration) {
+        if (configuration != null) {
+            return configuration.getPropertyBool(PROPERTY_NAME_COLORBAR_ALLOW_RESET, DEFAULT_COLORBAR_ALLOW_RESET);
+        } else {
+            return DEFAULT_COLORBAR_ALLOW_RESET;
+        }
+    }
+
+
+    public Color getTickmarkColor() {
+        return tickmarkColor;
+    }
+
+    public void setTickmarkColor(Color tickmarkColor) {
+        this.tickmarkColor = tickmarkColor;
+    }
+
+    public Color getLabelsColor() {
+        return labelsColor;
+    }
+
+    public void setLabelsColor(Color labelsColor) {
+        this.labelsColor = labelsColor;
+    }
+
+    public Color getTitleColor() {
+        return titleColor;
+    }
+
+    public void setTitleColor(Color color) {
+        this.titleColor = color;
+    }
+
+    public int getTickmarkLength() {
+        if (tickmarkLength != NULL_INT) {
+            return tickmarkLength;
+        } else {
+            return (int) Math.round(0.8 * getLabelGap());
+        }
+    }
+
+    public void setTickmarkLength(int tickmarkLength) {
+        this.tickmarkLength = tickmarkLength;
+    }
+
+    public int getTickmarkWidth() {
+        if (tickmarkWidth != NULL_INT) {
+            return tickmarkWidth;
+        } else {
+            return (int) Math.round(0.8 * getLabelGap());
+        }
+    }
+
+    public void setTickmarkWidth(int tickmarkWidth) {
+        this.tickmarkWidth = tickmarkWidth;
+    }
+
+
+    public boolean isTickmarkShow() {
+        return tickmarkShow;
+    }
+
+    public void setTickmarkShow(boolean tickmarkShow) {
+        this.tickmarkShow = tickmarkShow;
+    }
+
+    public int getBorderWidth() {
+        return borderWidth;
+    }
+
+    public void setBorderWidth(int borderWidth) {
+        this.borderWidth = borderWidth;
+    }
+
+    public Color getBorderColor() {
+        return borderColor;
+    }
+
+    public void setBorderColor(Color borderColor) {
+        this.borderColor = borderColor;
+    }
+
+    public boolean isBorderShow() {
+        return borderShow;
+    }
+
+    public void setBorderShow(boolean borderShow) {
+        this.borderShow = borderShow;
+    }
+
+    public boolean isBackdropShow() {
+        return backdropShow;
+    }
+
+    public void setBackdropShow(boolean backdropShow) {
+        this.backdropShow = backdropShow;
+    }
+
+    public String getLabelsFontName() {
+        return labelsFontName;
+    }
+
+    public void setLabelsFontName(String labelsFontName) {
+        this.labelsFontName = labelsFontName;
+    }
+
+    public int getLabelsFontType() {
+        return labelsFontType;
+    }
+
+    public void setLabelsFontType(int labelsFontType) {
+        this.labelsFontType = labelsFontType;
+    }
+
+    public Color getUnitsColor() {
+        return unitsColor;
+    }
+
+    public void setUnitsColor(Color unitsColor) {
+        this.unitsColor = unitsColor;
+    }
+
+    public boolean isShowUnits() {
+        return showUnits;
+    }
+
+    public void setShowUnits(boolean showUnits) {
+        this.showUnits = showUnits;
+    }
+
+    public String getTitleFontName() {
+        return titleFontName;
+    }
+
+    public void setTitleFontName(String titleFontName) {
+        this.titleFontName = titleFontName;
+    }
+
+    public int getTitleFontType() {
+        return titleFontType;
+    }
+
+    public void setTitleFontType(int titleFontType) {
+        this.titleFontType = titleFontType;
+    }
+
+    public String getUnitsFontName() {
+        return unitsFontName;
+    }
+
+    public void setUnitsFontName(String unitsFontName) {
+        this.unitsFontName = unitsFontName;
+    }
+
+    public int getUnitsFontType() {
+        return unitsFontType;
+    }
+
+    public void setUnitsFontType(int unitsFontType) {
+        this.unitsFontType = unitsFontType;
+    }
+
+    public boolean isLabelsShow() {
+        return labelsShow;
+    }
+
+    public void setLabelsShow(boolean labelsShow) {
+        this.labelsShow = labelsShow;
+    }
+
+    public boolean isReversePalette() {
+        return reversePalette;
+    }
+
+    public void setReversePalette(boolean reversePalette) {
+        this.reversePalette = reversePalette;
+    }
+
+    public String getTitleVerticalAnchor() {
+        return titleVerticalAnchor;
+    }
+
+    public void setTitleVerticalAnchor(String titleVerticalAnchor) {
+        this.titleVerticalAnchor = titleVerticalAnchor;
+    }
+
+
+    private double getTitleToUnitsVerticalGap() {
+        return titleToUnitsVerticalGap;
+    }
+
+    private void setTitleToUnitsVerticalGap(double titleToUnitsVerticalGap) {
+        this.titleToUnitsVerticalGap = titleToUnitsVerticalGap;
+    }
+
+
+    public double getTitleToUnitsHorizontalGap() {
+        return titleToUnitsHorizontalGap;
+    }
+
+    public void setTitleToUnitsHorizontalGap(double titleToUnitsHorizontalGap) {
+        this.titleToUnitsHorizontalGap = titleToUnitsHorizontalGap;
+    }
+
+    public double getTitleHeight() {
+        return titleHeight;
+    }
+
+    public void setTitleHeight(double titleHeight) {
+        this.titleHeight = titleHeight;
+    }
+
+    public double getTitleWidth() {
+        return titleWidth;
+    }
+
+    public void setTitleWidth(double titleWidth) {
+        this.titleWidth = titleWidth;
+    }
+
+    public double getTitleSingleLetterWidth() {
+        return titleSingleLetterWidth;
+    }
+
+    public void setTitleSingleLetterWidth(double titleSingleLetterWidth) {
+        this.titleSingleLetterWidth = titleSingleLetterWidth;
+    }
+
+    public double getUnitsHeight() {
+        return unitsHeight;
+    }
+
+    public void setUnitsHeight(double unitsHeight) {
+        this.unitsHeight = unitsHeight;
+    }
+
+    public double getUnitsWidth() {
+        return unitsWidth;
+    }
+
+    public void setUnitsWidth(double unitsWidth) {
+        this.unitsWidth = unitsWidth;
+    }
+
+    public double getUnitsSingleLetterWidth() {
+        return unitsSingleLetterWidth;
+    }
+
+    public void setUnitsSingleLetterWidth(double unitsSingleLetterWidth) {
+        this.unitsSingleLetterWidth = unitsSingleLetterWidth;
+    }
+
+
+    public double getLabelHeight() {
+        return labelHeight;
+    }
+
+    public void setLabelHeight(double labelHeight) {
+        this.labelHeight = labelHeight;
+    }
+
+    public double getLabelLongestWidth() {
+        return labelLongestWidth;
+    }
+
+    public void setLabelLongestWidth(double labelLongestWidth) {
+        this.labelLongestWidth = labelLongestWidth;
+    }
+
+    public double getLabelSingleLetterWidth() {
+        return labelSingleLetterWidth;
+    }
+
+    public void setLabelSingleLetterWidth(double labelSingleLetterWidth) {
+        this.labelSingleLetterWidth = labelSingleLetterWidth;
+    }
+
+    public Color getBackdropBorderColor() {
+        return backdropBorderColor;
+    }
+
+    public void setBackdropBorderColor(Color backdropBorderColor) {
+        this.backdropBorderColor = backdropBorderColor;
+    }
+
+    public int getBackdropBorderWidth() {
+        return backdropBorderWidth;
+    }
+
+    public void setBackdropBorderWidth(int backdropBorderWidth) {
+        this.backdropBorderWidth = backdropBorderWidth;
+    }
+
+    public boolean isBackdropBorderShow() {
+        return backdropBorderShow;
+    }
+
+    public void setBackdropBorderShow(boolean backdropBorderShow) {
+        this.backdropBorderShow = backdropBorderShow;
+    }
+
+    public double getWeightTolerance() {
+        return weightTolerance;
+    }
+
+    public void setWeightTolerance(double weightTolerance) {
+        this.weightTolerance = weightTolerance;
+    }
 }

--- a/snap-core/src/main/java/org/esa/snap/core/layer/ColorBarLayer.java
+++ b/snap-core/src/main/java/org/esa/snap/core/layer/ColorBarLayer.java
@@ -1,0 +1,925 @@
+/*
+ * Copyright (C) 2010 Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
+package org.esa.snap.core.layer;
+
+import com.bc.ceres.binding.PropertySet;
+import com.bc.ceres.binding.ValidationException;
+import com.bc.ceres.glayer.Layer;
+import com.bc.ceres.glayer.LayerTypeRegistry;
+import com.bc.ceres.grender.Rendering;
+import com.bc.ceres.grender.Viewport;
+import org.esa.snap.core.datamodel.*;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.beans.PropertyChangeEvent;
+
+
+/**
+ * @author Daniel Knowles
+ */
+
+public class ColorBarLayer extends Layer {
+
+    private static final ColorBarLayerType LAYER_TYPE = LayerTypeRegistry.getLayerType(ColorBarLayerType.class);
+
+    private RasterDataNode raster;
+
+    private ProductNodeHandler productNodeHandler;
+    private ImageLegend imageLegend;
+    BufferedImage bufferedImage = null;
+
+    private double NULL_DOUBLE = -1.0;
+    private double ptsToPixelsMultiplier = NULL_DOUBLE;
+
+    private boolean allowImageLegendReset = true;
+
+
+    public ColorBarLayer(RasterDataNode raster) {
+        this(LAYER_TYPE, raster, initConfiguration(LAYER_TYPE.createLayerConfig(null), raster));
+    }
+
+    public ColorBarLayer(ColorBarLayerType type, RasterDataNode raster, PropertySet configuration) {
+        super(type, configuration);
+        setName(ColorBarLayerType.COLOR_BAR_LAYER_NAME);
+        this.raster = raster;
+
+        productNodeHandler = new ProductNodeHandler();
+        raster.getProduct().addProductNodeListener(productNodeHandler);
+
+        setTransparency(0.0);
+    }
+
+
+    private static PropertySet initConfiguration(PropertySet configurationTemplate, RasterDataNode raster) {
+        configurationTemplate.setValue(ColorBarLayerType.PROPERTY_NAME_RASTER, raster);
+        return configurationTemplate;
+    }
+
+    private Product getProduct() {
+        return getRaster().getProduct();
+    }
+
+    RasterDataNode getRaster() {
+        return raster;
+    }
+
+    @Override
+    public void renderLayer(Rendering rendering) {
+//        System.out.println("Rendering Layer");
+
+        if (allowImageLegendReset == true) {
+            allowImageLegendReset = false;
+
+
+            imageLegend = new ImageLegend(raster.getImageInfo(), raster);
+
+            String title = (ColorBarLayerType.NULL_SPECIAL.equals(getTitle())) ? raster.getName() : getTitle();
+
+
+            String unitsText = "";
+            if (ColorBarLayerType.NULL_SPECIAL.equals(getUnits())) {
+                String unit = raster.getUnit();
+                if (unit != null && unit.length() > 0) {
+                    unitsText = "(" + raster.getUnit() + ")";
+                }
+            } else {
+                unitsText = getUnits();
+            }
+
+
+            // Title & Units Text
+            imageLegend.setTitleText(title);
+            imageLegend.setUnitsText(unitsText);
+
+
+            // Orientation
+            imageLegend.setOrientation(getOrientation());
+            imageLegend.setTitleVerticalAnchor(getTitleVerticalAnchor());
+            imageLegend.setReversePalette(isReversePalette());
+
+
+            // Tick Label Values
+            imageLegend.setDistributionType(getLabelValuesMode());
+            imageLegend.setTickMarkCount(getLabelValuesCount());
+            imageLegend.setCustomLabelValues(getLabelValuesActual());
+            imageLegend.setScalingFactor(getLabelValuesScalingFactor());
+            imageLegend.setDecimalPlaces(getDecimalPlaces());
+            imageLegend.setDecimalPlacesForce(getDecimalPlacesForce());
+            imageLegend.setWeightTolerance(getWeightTolerance());
+
+
+            // Placement Location
+
+
+            // Size & Scaling
+            imageLegend.setLayerScaling(getLayerScaling());
+            imageLegend.setColorBarLength(getColorBarLength());
+            imageLegend.setColorBarWidth(getColorBarWidth());
+
+
+            // Title Format
+            imageLegend.setShowTitle(isShowTitle());
+            imageLegend.setTitleFontSize(getTitleFontSize());
+            imageLegend.setTitleColor(getTitleColor());
+            imageLegend.setTitleFontName(getTitleFontName());
+            imageLegend.setTitleFontType(getTitleFontType());
+
+
+            // Units Format
+            imageLegend.setShowUnits(isShowTitleUnits());
+            imageLegend.setUnitsFontSize(getUnitsFontSize());
+            imageLegend.setUnitsColor(getUnitsColor());
+            imageLegend.setUnitsFontName(getUnitsFontName());
+            imageLegend.setUnitsFontType(getUnitsFontType());
+
+
+            // Tick Label Format
+            imageLegend.setLabelsShow(isLabelsShow());
+            imageLegend.setLabelsFontName(getLabelsFontName());
+            imageLegend.setLabelsFontType(getLabelsFontType());
+            imageLegend.setLabelsFontSize(getLabelsFontSize());
+            imageLegend.setLabelsColor(getLabelsColor());
+
+
+            // Tickmarks
+            imageLegend.setTickmarkShow(isTickmarksShow());
+            imageLegend.setTickmarkLength(getTickmarksLength());
+            imageLegend.setTickmarkWidth(getTickmarksWidth());
+            imageLegend.setTickmarkColor(getTickmarksColor());
+
+
+            // Palette Border
+            imageLegend.setBorderShow(isBorderShow());
+            imageLegend.setBorderWidth(getBorderWidth());
+            imageLegend.setBorderColor(getBorderColor());
+
+
+            // Legend Border
+            imageLegend.setBackdropBorderShow(isBackdropBorderShow());
+            imageLegend.setBackdropBorderWidth(getBackdropBorderWidth());
+            imageLegend.setBackdropBorderColor(getBackdropBorderColor());
+
+
+            // Legend Backdrop
+            imageLegend.setBackdropShow(isBackdropShow());
+            imageLegend.setBackdropTransparency(((Number) getBackdropTransparency()).floatValue());
+            imageLegend.setBackdropColor(getBackdropColor());
+
+
+
+            imageLegend.setTransparencyEnabled(true);
+            imageLegend.setAntialiasing((Boolean) true);
+
+
+
+            int imageHeight = raster.getRasterHeight();
+            int imageWidth = raster.getRasterWidth();
+
+            
+            if (applySizeScaling()) {
+                bufferedImage = imageLegend.createImage(new Dimension(imageWidth, imageHeight), true);
+            } else {
+                bufferedImage = imageLegend.createImage();
+            }
+
+
+            // Update the properties with some calculated/looked-up values
+
+            if (getPopulateLabelsTextfield()) {
+                setLabelValuesActual(imageLegend.getCustomLabelValues());
+            }
+
+            setTitle(imageLegend.getTitleText());
+
+            setUnits(unitsText);
+
+
+            if (imageLegend != null && bufferedImage != null) {
+
+
+                final Graphics2D g2d = rendering.getGraphics();
+                // added this to improve text
+                g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+                g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+                g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+                final Viewport vp = rendering.getViewport();
+                final AffineTransform transformSave = g2d.getTransform();
+                try {
+                    final AffineTransform transform = new AffineTransform();
+                    transform.concatenate(transformSave);
+                    transform.concatenate(vp.getModelToViewTransform());
+                    g2d.setTransform(transform);
+                    drawImage(g2d, raster, bufferedImage);
+
+                } finally {
+                    g2d.setTransform(transformSave);
+                }
+
+            }
+
+            allowImageLegendReset = true;
+        }
+    }
+
+
+    private void drawImage(Graphics2D g2d, RasterDataNode raster, BufferedImage bufferedImage) {
+
+        AffineTransform transform = createTransform(bufferedImage);
+        g2d.drawRenderedImage(bufferedImage, transform);
+
+    }
+
+    private AffineTransform createTransform(BufferedImage image) {
+
+        AffineTransform transform = raster.getSourceImage().getModel().getImageToModelTransform(0);
+        transform.concatenate(createTransform(raster, image));
+        return transform;
+    }
+
+    private AffineTransform createTransform(RasterDataNode raster, RenderedImage colorBarImage) {
+
+
+        int colorBarImageWidth = colorBarImage.getWidth();
+        int colorBarImageHeight = colorBarImage.getHeight();
+
+        int rasterWidth = raster.getRasterWidth();
+        int rasterHeight = raster.getRasterHeight();
+
+
+        double offset = (getOrientation() == ImageLegend.HORIZONTAL) ? -(colorBarImageHeight * getLocationOffset() / 100) : (colorBarImageWidth * getLocationOffset() / 100);
+        double shift = (getOrientation() == ImageLegend.HORIZONTAL) ? (colorBarImageWidth * getLocationShift() / 100) : -(colorBarImageHeight * getLocationShift() / 100);
+
+        double offsetAdjust = 0;
+        double shiftAdjust = 0;
+
+
+        if (getOrientation() == ImageLegend.HORIZONTAL) {
+            if (isColorBarLocationInside()) {
+                switch (getColorBarLocationPlacement()) {
+
+                    case ColorBarLayerType.LOCATION_LOWER_LEFT:
+                        offsetAdjust = -colorBarImageHeight;
+                        shiftAdjust = 0;
+                        break;
+                    case ColorBarLayerType.LOCATION_LOWER_CENTER:
+                        offsetAdjust = -colorBarImageHeight;
+                        shiftAdjust = (rasterWidth - colorBarImageWidth) / 2;
+                        break;
+                    case ColorBarLayerType.LOCATION_LOWER_RIGHT:
+                        offsetAdjust = -colorBarImageHeight;
+                        shiftAdjust = rasterWidth - colorBarImageWidth;
+                        break;
+                    case ColorBarLayerType.LOCATION_UPPER_LEFT:
+                        offsetAdjust = -rasterHeight;
+                        shiftAdjust = 0;
+                        break;
+                    case ColorBarLayerType.LOCATION_UPPER_CENTER:
+                        offsetAdjust = -rasterHeight;
+                        shiftAdjust = (rasterWidth - colorBarImageWidth) / 2;
+                        break;
+                    case ColorBarLayerType.LOCATION_UPPER_RIGHT:
+                        offsetAdjust = -rasterHeight;
+                        shiftAdjust = rasterWidth - colorBarImageWidth;
+                        break;
+                    case ColorBarLayerType.LOCATION_LEFT_CENTER:
+                        offsetAdjust = -(rasterHeight + colorBarImageHeight) / 2;
+                        ;
+                        shiftAdjust = 0;
+                        break;
+                    case ColorBarLayerType.LOCATION_RIGHT_CENTER:
+                        offsetAdjust = -(rasterHeight + colorBarImageHeight) / 2;
+                        ;
+                        shiftAdjust = rasterWidth - colorBarImageWidth;
+                        break;
+                    default:
+                        offsetAdjust = -colorBarImageHeight;
+                        shiftAdjust = (rasterWidth - colorBarImageWidth) / 2;
+                }
+
+
+            } else {
+                switch (getColorBarLocationPlacement()) {
+
+                    case ColorBarLayerType.LOCATION_LOWER_LEFT:
+                        offsetAdjust = 0;
+                        shiftAdjust = 0;
+                        break;
+                    case ColorBarLayerType.LOCATION_LOWER_CENTER:
+                        offsetAdjust = 0;
+                        shiftAdjust = (rasterWidth - colorBarImageWidth) / 2;
+                        break;
+                    case ColorBarLayerType.LOCATION_LOWER_RIGHT:
+                        offsetAdjust = 0;
+                        shiftAdjust = rasterWidth - colorBarImageWidth;
+                        break;
+                    case ColorBarLayerType.LOCATION_UPPER_LEFT:
+                        offsetAdjust = -rasterHeight - colorBarImageHeight;
+                        shiftAdjust = 0;
+                        break;
+                    case ColorBarLayerType.LOCATION_UPPER_CENTER:
+                        offsetAdjust = -rasterHeight - colorBarImageHeight;
+                        shiftAdjust = (rasterWidth - colorBarImageWidth) / 2;
+                        break;
+                    case ColorBarLayerType.LOCATION_UPPER_RIGHT:
+                        offsetAdjust = -rasterHeight - colorBarImageHeight;
+                        shiftAdjust = rasterWidth - colorBarImageWidth;
+                        break;
+                    case ColorBarLayerType.LOCATION_LEFT_CENTER:
+                        offsetAdjust = -(rasterHeight + colorBarImageHeight) / 2;
+                        shiftAdjust = -colorBarImageWidth;
+                        break;
+                    case ColorBarLayerType.LOCATION_RIGHT_CENTER:
+                        offsetAdjust = -(rasterHeight + colorBarImageHeight) / 2;
+                        shiftAdjust = rasterWidth;
+                        break;
+                    default:
+                        offsetAdjust = 0;
+                        shiftAdjust = (rasterWidth - colorBarImageWidth) / 2;
+                }
+            }
+
+        } else {
+            if (isColorBarLocationInside()) {
+                offset = -offset;
+
+                switch (getColorBarLocationPlacement()) {
+                    case ColorBarLayerType.LOCATION_UPPER_LEFT:
+                        offsetAdjust = -rasterWidth;
+                        shiftAdjust = 0;
+                        break;
+                    case ColorBarLayerType.LOCATION_LEFT_CENTER:
+                        offsetAdjust = -rasterWidth;
+                        shiftAdjust = (rasterHeight - colorBarImageHeight) / 2;
+                        break;
+                    case ColorBarLayerType.LOCATION_LOWER_LEFT:
+                        offsetAdjust = -rasterWidth;
+                        shiftAdjust = rasterHeight - colorBarImageHeight;
+                        break;
+                    case ColorBarLayerType.LOCATION_UPPER_RIGHT:
+                        offsetAdjust = -colorBarImageWidth;
+                        shiftAdjust = 0;
+                        break;
+                    case ColorBarLayerType.LOCATION_RIGHT_CENTER:
+                        offsetAdjust = -colorBarImageWidth;
+                        shiftAdjust = (rasterHeight - colorBarImageHeight) / 2;
+                        break;
+                    case ColorBarLayerType.LOCATION_LOWER_RIGHT:
+                        offsetAdjust = -colorBarImageWidth;
+                        shiftAdjust = rasterHeight - colorBarImageHeight;
+                        break;
+                    case ColorBarLayerType.LOCATION_UPPER_CENTER:
+                        offsetAdjust = -rasterWidth / 2.0 - colorBarImageWidth / 2.0;
+                        shiftAdjust = 0;
+                        break;
+                    case ColorBarLayerType.LOCATION_LOWER_CENTER:
+                        offsetAdjust = -rasterWidth / 2.0 - colorBarImageWidth / 2.0;
+                        shiftAdjust = rasterHeight - colorBarImageHeight;
+                        break;
+                    default:
+                        offsetAdjust = -colorBarImageWidth;
+                        shiftAdjust = rasterHeight - colorBarImageHeight;
+                }
+            } else {
+                switch (getColorBarLocationPlacement()) {
+                    case ColorBarLayerType.LOCATION_UPPER_LEFT:
+                        offsetAdjust = -rasterWidth - colorBarImageWidth;
+                        shiftAdjust = 0;
+                        break;
+                    case ColorBarLayerType.LOCATION_LEFT_CENTER:
+                        offsetAdjust = -rasterWidth - colorBarImageWidth;
+                        shiftAdjust = (rasterHeight - colorBarImageHeight) / 2;
+                        break;
+                    case ColorBarLayerType.LOCATION_LOWER_LEFT:
+                        offsetAdjust = -rasterWidth - colorBarImageWidth;
+                        shiftAdjust = rasterHeight - colorBarImageHeight;
+                        break;
+                    case ColorBarLayerType.LOCATION_UPPER_RIGHT:
+                        offsetAdjust = 0;
+                        shiftAdjust = 0;
+                        break;
+                    case ColorBarLayerType.LOCATION_RIGHT_CENTER:
+                        offsetAdjust = 0;
+                        shiftAdjust = (rasterHeight - colorBarImageHeight) / 2;
+                        break;
+                    case ColorBarLayerType.LOCATION_LOWER_RIGHT:
+                        offsetAdjust = 0;
+                        shiftAdjust = rasterHeight - colorBarImageHeight;
+                        break;
+                    case ColorBarLayerType.LOCATION_UPPER_CENTER:
+                        offsetAdjust = -rasterWidth / 2.0 - colorBarImageWidth / 2.0;
+                        shiftAdjust = -colorBarImageHeight;
+                        break;
+                    case ColorBarLayerType.LOCATION_LOWER_CENTER:
+                        offsetAdjust = -rasterWidth / 2.0 - colorBarImageWidth / 2.0;
+                        shiftAdjust = rasterHeight;
+                        break;
+                    default:
+                        offsetAdjust = 0;
+                        shiftAdjust = rasterHeight - colorBarImageHeight;
+                }
+            }
+        }
+
+        double y_axis_translation = (getOrientation() == ImageLegend.HORIZONTAL) ? rasterHeight + offset + offsetAdjust : shift + shiftAdjust;
+        double x_axis_translation = (getOrientation() == ImageLegend.HORIZONTAL) ? shift + shiftAdjust : rasterWidth + offset + offsetAdjust;
+
+        double[] flatmatrix = {1, 0.0, 0.0, 1, x_axis_translation, y_axis_translation};
+
+
+        AffineTransform i2mTransform = new AffineTransform(flatmatrix);
+        return i2mTransform;
+    }
+
+
+    private AlphaComposite getAlphaComposite(double itemTransparancy) {
+        double combinedAlpha = (1.0 - getTransparency()) * (1.0 - itemTransparancy);
+        return AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) combinedAlpha);
+    }
+
+    @Override
+    public void disposeLayer() {
+        final Product product = getProduct();
+        if (product != null) {
+            product.removeProductNodeListener(productNodeHandler);
+            imageLegend = null;
+            raster = null;
+        }
+    }
+
+    @Override
+    protected void fireLayerPropertyChanged(PropertyChangeEvent event) {
+        String propertyName = event.getPropertyName();
+
+
+        if (allowImageLegendReset) {
+            imageLegend = null;
+        }
+
+
+        if (getConfiguration().getProperty(propertyName) != null) {
+            getConfiguration().setValue(propertyName, event.getNewValue());
+        }
+
+        super.fireLayerPropertyChanged(event);
+    }
+
+
+
+
+    // Title & Units Text
+
+    private String getTitle() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TITLE_TEXT_KEY,
+                ColorBarLayerType.PROPERTY_TITLE_TEXT_DEFAULT);
+    }
+
+    private void setTitle(String value) {
+        try {
+            String valueCurrent = getTitle();
+            System.out.println("Current title = " + valueCurrent);
+            if (valueCurrent == null || (valueCurrent != null && !valueCurrent.equals(value))) {
+                System.out.println("Inside and setting title to " + value);
+                getConfiguration().getProperty(ColorBarLayerType.PROPERTY_TITLE_TEXT_KEY).setValue((Object) value);
+            }
+        } catch (ValidationException v) {
+        }
+    }
+
+
+
+    private String getUnits() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_UNITS_TEXT_KEY,
+                ColorBarLayerType.PROPERTY_UNITS_TEXT_DEFAULT);
+    }
+
+    private void setUnits(String value) {
+        try {
+            String valueCurrent = getUnits();
+
+            if (valueCurrent == null || (valueCurrent != null && !valueCurrent.equals(value))) {
+                getConfiguration().getProperty(ColorBarLayerType.PROPERTY_UNITS_TEXT_KEY).setValue((Object) value);
+            }
+        } catch (ValidationException v) {
+        }
+    }
+
+
+
+
+
+    // Orientation
+
+    private int getOrientation() {
+        String orientation = getConfigurationProperty(ColorBarLayerType.PROPERTY_ORIENTATION_KEY,
+                ColorBarLayerType.PROPERTY_ORIENTATION_DEFAULT);
+
+        if (ColorBarLayerType.OPTION_VERTICAL.equals(orientation)) {
+            return ImageLegend.VERTICAL;
+        } else {
+            return ImageLegend.HORIZONTAL;
+        }
+    }
+
+    private String getTitleVerticalAnchor() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LOCATION_TITLE_VERTICAL_KEY,
+                ColorBarLayerType.PROPERTY_LOCATION_TITLE_VERTICAL_DEFAULT);
+    }
+
+
+    private boolean isReversePalette() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_ORIENTATION_REVERSE_PALETTE_KEY,
+                ColorBarLayerType.PROPERTY_ORIENTATION_REVERSE_PALETTE_DEFAULT);
+    }
+
+
+
+    // Tick Label Values
+
+    private String getLabelValuesMode() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABEL_VALUES_MODE_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_MODE_DEFAULT);
+    }
+
+    private int getLabelValuesCount() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABEL_VALUES_COUNT_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_COUNT_DEFAULT);
+    }
+
+    private String getLabelValuesActual() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABEL_VALUES_ACTUAL_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_ACTUAL_DEFAULT);
+    }
+
+    private void setLabelValuesActual(String value) {
+        try {
+            getConfiguration().getProperty(ColorBarLayerType.PROPERTY_LABEL_VALUES_ACTUAL_KEY).setValue((Object) value);
+        } catch (ValidationException v) {
+        }
+    }
+
+    private boolean getPopulateLabelsTextfield() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_POPULATE_VALUES_TEXTFIELD_KEY,
+                ColorBarLayerType.PROPERTY_POPULATE_VALUES_TEXTFIELD_DEFAULT);
+    }
+
+
+    private double getLabelValuesScalingFactor() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABEL_VALUES_SCALING_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_SCALING_DEFAULT);
+    }
+
+
+    private int getDecimalPlaces() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABEL_VALUES_DECIMAL_PLACES_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_DECIMAL_PLACES_DEFAULT);
+    }
+
+    private boolean getDecimalPlacesForce() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_KEY,
+                ColorBarLayerType.PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_DEFAULT);
+    }
+
+
+    private Double getWeightTolerance() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_WEIGHT_TOLERANCE_KEY,
+                ColorBarLayerType.PROPERTY_WEIGHT_TOLERANCE_DEFAULT);
+    }
+
+
+
+    // Placement Location
+
+    private boolean isColorBarLocationInside() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LOCATION_INSIDE_KEY,
+                ColorBarLayerType.PROPERTY_LOCATION_INSIDE_DEFAULT);
+    }
+
+
+    private String getColorBarLocationPlacement() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LOCATION_PLACEMENT_KEY,
+                ColorBarLayerType.PROPERTY_LOCATION_PLACEMENT_DEFAULT);
+    }
+
+    private Double getLocationOffset() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LOCATION_OFFSET_KEY,
+                ColorBarLayerType.PROPERTY_LOCATION_OFFSET_DEFAULT);
+    }
+
+    private Double getLocationShift() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LOCATION_SHIFT_KEY,
+                ColorBarLayerType.PROPERTY_LOCATION_SHIFT_DEFAULT);
+    }
+
+
+
+    // Size & Scaling
+
+    private boolean applySizeScaling() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_IMAGE_SCALING_APPLY_SIZE_KEY,
+                ColorBarLayerType.PROPERTY_IMAGE_SCALING_APPLY_SIZE_DEFAULT);
+    }
+
+
+    private Double getLayerScaling() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_IMAGE_SCALING_SIZE_KEY,
+                ColorBarLayerType.PROPERTY_IMAGE_SCALING_SIZE_DEFAULT);
+    }
+
+
+    private int getColorBarLength() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_COLORBAR_LENGTH_KEY,
+                ColorBarLayerType.PROPERTY_COLORBAR_LENGTH_DEFAULT);
+    }
+
+
+    private int getColorBarWidth() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_COLORBAR_WIDTH_KEY,
+                ColorBarLayerType.PROPERTY_COLORBAR_WIDTH_DEFAULT);
+    }
+
+
+
+    // Title Format
+
+    private boolean isShowTitle() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TITLE_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_TITLE_SHOW_DEFAULT);
+    }
+
+
+    private int getTitleFontSize() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TITLE_FONT_SIZE_KEY,
+                ColorBarLayerType.PROPERTY_TITLE_FONT_SIZE_DEFAULT);
+    }
+
+    private Boolean isTitleFontBold() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TITLE_FONT_BOLD_KEY,
+                ColorBarLayerType.PROPERTY_TITLE_FONT_BOLD_DEFAULT);
+    }
+
+    private Boolean isTitleFontItalic() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TITLE_FONT_ITALIC_KEY,
+                ColorBarLayerType.PROPERTY_TITLE_FONT_ITALIC_DEFAULT);
+    }
+
+
+    private int getTitleFontType() {
+        return getFontType(isTitleFontItalic(), isTitleFontBold());
+    }
+
+    private String getTitleFontName() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TITLE_FONT_NAME_KEY,
+                ColorBarLayerType.PROPERTY_TITLE_FONT_NAME_DEFAULT);
+    }
+
+    private Color getTitleColor() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TITLE_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_TITLE_COLOR_DEFAULT);
+    }
+
+
+
+
+    // Units Format
+
+    private boolean isShowTitleUnits() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_UNITS_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_UNITS_SHOW_DEFAULT);
+    }
+
+    private int getUnitsFontSize() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_UNITS_FONT_SIZE_KEY,
+                ColorBarLayerType.PROPERTY_UNITS_FONT_SIZE_DEFAULT);
+    }
+
+    private Boolean isTitleUnitsFontBold() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_UNITS_FONT_BOLD_KEY,
+                ColorBarLayerType.PROPERTY_UNITS_FONT_BOLD_DEFAULT);
+    }
+    private Boolean isTitleUnitsFontItalic() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_UNITS_FONT_ITALIC_KEY,
+                ColorBarLayerType.PROPERTY_UNITS_FONT_ITALIC_DEFAULT);
+    }
+
+    private int getUnitsFontType() {
+        return getFontType(isTitleUnitsFontItalic(), isTitleUnitsFontBold());
+    }
+
+    private String getUnitsFontName() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_UNITS_FONT_NAME_KEY,
+                ColorBarLayerType.PROPERTY_UNITS_FONT_NAME_DEFAULT);
+    }
+
+    private Color getUnitsColor() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_UNITS_FONT_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_UNITS_FONT_COLOR_DEFAULT);
+    }
+
+
+
+    // Tick Label Format
+
+    private boolean isLabelsShow() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABELS_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_SHOW_DEFAULT);
+    }
+
+    private int getLabelsFontSize() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABELS_FONT_SIZE_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_FONT_SIZE_DEFAULT);
+    }
+
+    private Boolean isLabelsBold() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABELS_FONT_BOLD_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_FONT_BOLD_DEFAULT);
+    }
+
+    private Boolean isLabelsItalic() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABELS_FONT_ITALIC_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_FONT_ITALIC_DEFAULT);
+    }
+
+    private String getLabelsFontName() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABELS_FONT_NAME_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_FONT_NAME_DEFAULT);
+    }
+
+    private int getLabelsFontType() {
+        return getFontType(isLabelsItalic(), isLabelsBold());
+    }
+
+
+    private Color getLabelsColor() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LABELS_FONT_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_LABELS_FONT_COLOR_DEFAULT);
+    }
+
+
+
+
+    // Tickmarks
+
+    private boolean isTickmarksShow() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TICKMARKS_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_TICKMARKS_SHOW_DEFAULT);
+    }
+
+
+    private int getTickmarksLength() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TICKMARKS_LENGTH_KEY,
+                ColorBarLayerType.PROPERTY_TICKMARKS_LENGTH_DEFAULT);
+    }
+
+    private int getTickmarksWidth() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TICKMARKS_WIDTH_KEY,
+                ColorBarLayerType.PROPERTY_TICKMARKS_WIDTH_DEFAULT);
+    }
+
+    private Color getTickmarksColor() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_TICKMARKS_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_TICKMARKS_COLOR_DEFAULT);
+    }
+
+
+
+    // Palette Border
+
+    private boolean isBorderShow() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_PALETTE_BORDER_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_PALETTE_BORDER_SHOW_DEFAULT);
+    }
+
+    private Color getBorderColor() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_PALETTE_BORDER_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_PALETTE_BORDER_COLOR_DEFAULT);
+    }
+
+    private int getBorderWidth() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_PALETTE_BORDER_WIDTH_KEY,
+                ColorBarLayerType.PROPERTY_PALETTE_BORDER_WIDTH_DEFAULT);
+    }
+
+
+
+    // Legend Border
+
+    private boolean isBackdropBorderShow() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LEGEND_BORDER_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_LEGEND_BORDER_SHOW_DEFAULT);
+    }
+
+    private int getBackdropBorderWidth() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LEGEND_BORDER_WIDTH_KEY,
+                ColorBarLayerType.PROPERTY_LEGEND_BORDER_WIDTH_DEFAULT);
+    }
+
+    private Color getBackdropBorderColor() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_LEGEND_BORDER_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_LEGEND_BORDER_COLOR_DEFAULT);
+    }
+
+
+
+    // Legend Backdrop
+
+    private boolean isBackdropShow() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_BACKDROP_SHOW_KEY,
+                ColorBarLayerType.PROPERTY_BACKDROP_SHOW_DEFAULT);
+    }
+
+    private double getBackdropTransparency() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_BACKDROP_TRANSPARENCY_KEY,
+                ColorBarLayerType.PROPERTY_BACKDROP_TRANSPARENCY_DEFAULT);
+    }
+
+    private Color getBackdropColor() {
+        return getConfigurationProperty(ColorBarLayerType.PROPERTY_BACKDROP_COLOR_KEY,
+                ColorBarLayerType.PROPERTY_BACKDROP_COLOR_DEFAULT);
+    }
+
+
+
+
+
+    // Some general font methods
+
+    public static int getFontType(boolean italic, boolean bold) {
+        if (italic && bold) {
+            return Font.ITALIC | Font.BOLD;
+        } else if (italic) {
+            return Font.ITALIC;
+        } else if (bold) {
+            return Font.BOLD;
+        } else {
+            return Font.PLAIN;
+        }
+    }
+
+    public static boolean isFontTypeBold(int fontType) {
+        if (fontType  == (Font.ITALIC | Font.BOLD) || fontType == Font.BOLD) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public static boolean isFontTypeItalic(int fontType) {
+        if (fontType  == (Font.ITALIC | Font.BOLD) || fontType == Font.ITALIC) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+    private class ProductNodeHandler extends ProductNodeListenerAdapter {
+
+        /**
+         * Overwrite this method if you want to be notified when a node changed.
+         *
+         * @param event the product node which the listener to be notified
+         */
+        @Override
+        public void nodeChanged(ProductNodeEvent event) {
+            if (event.getSourceNode() == getProduct() && Product.PROPERTY_NAME_SCENE_GEO_CODING.equals(
+                    event.getPropertyName())) {
+                // Force recreation
+                imageLegend = null;
+                fireLayerDataChanged(getModelBounds());
+            }
+        }
+    }
+
+
+    public ImageLegend getImageLegend() {
+        return imageLegend;
+    }
+}

--- a/snap-core/src/main/java/org/esa/snap/core/layer/ColorBarLayerType.java
+++ b/snap-core/src/main/java/org/esa/snap/core/layer/ColorBarLayerType.java
@@ -1,0 +1,1203 @@
+
+
+package org.esa.snap.core.layer;
+
+import com.bc.ceres.binding.Property;
+import com.bc.ceres.binding.PropertyContainer;
+import com.bc.ceres.binding.PropertySet;
+import com.bc.ceres.glayer.Layer;
+import com.bc.ceres.glayer.LayerContext;
+import com.bc.ceres.glayer.LayerType;
+import com.bc.ceres.glayer.annotations.LayerTypeMetadata;
+import org.esa.snap.core.datamodel.RasterDataNode;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+
+import static org.esa.snap.core.util.NamingConvention.COLOR_LOWER_CASE;
+import static org.esa.snap.core.util.NamingConvention.COLOR_MIXED_CASE;
+
+/**
+ * Defines key property fields, variables, and variable constants for the Color Bar Legend Tool
+ *
+ * @author Daniel Knowles
+ */
+
+
+
+@LayerTypeMetadata(name = "ColorBarLayerType", aliasNames = {"org.esa.snap.core.layer.ColorBarLayerType"})
+public class ColorBarLayerType extends LayerType {
+
+    public static final String COLOR_BAR_LAYER_NAME = COLOR_MIXED_CASE + " Bar Legend";
+    public static final String COLOR_BAR_LEGEND_NAME = COLOR_MIXED_CASE + " Bar Legend";
+    public static final String COLOR_BAR_LEGEND_NAME_LOWER_CASE = COLOR_LOWER_CASE + " bar legend";
+
+    public static final String OPTION_HORIZONTAL = "Horizontal";
+    public static final String OPTION_VERTICAL = "Vertical";
+
+    public static final String FONT_NAME_SANSERIF = "SanSerif";
+    public static final String FONT_NAME_SERIF = "Serif";
+    public static final String FONT_NAME_COURIER = "Courier";
+    public static final String FONT_NAME_MONOSPACED = "Monospaced";
+    public static final Object FONT_NAME_VALUE_SET[] = {FONT_NAME_SANSERIF, FONT_NAME_SERIF, FONT_NAME_COURIER, FONT_NAME_MONOSPACED};
+
+    public static final String DISTRIB_EVEN_STR = "Generated Values";
+    public static final String DISTRIB_EXACT_STR = "Palette Values";
+    public static final String DISTRIB_MANUAL_STR = "Entered Values";
+
+    public static final String NULL_SPECIAL = "-1";  // a null value to use for string cases where an empty string would be valid
+    public final static String DASHES = "----------";
+
+
+    //--------------------------------------------------------------------------------------------------------------
+    // Color Bar Legend parameters
+
+    // Preferences property prefix
+    private static final String PROPERTY_ROOT_KEY = "color.bar.legend";
+    private static final String PROPERTY_ROOT_ALIAS = "colorBarLegend";
+
+
+
+    // Title
+
+    private static final String PROPERTY_TITLE_TEXT_ROOT_KEY = PROPERTY_ROOT_KEY + ".title";
+    private static final String PROPERTY_TITLE_TEXT_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "Title";
+
+    public static final String PROPERTY_TITLE_TEXT_SECTION_KEY = PROPERTY_TITLE_TEXT_ROOT_KEY + ".section";
+    public static final String PROPERTY_TITLE_TEXT_SECTION_LABEL = "Title";
+    public static final String PROPERTY_TITLE_TEXT_SECTION_TOOLTIP = "Title for the " + COLOR_LOWER_CASE + " bar legend";
+    public static final String PROPERTY_TITLE_TEXT_SECTION_ALIAS = PROPERTY_TITLE_TEXT_ROOT_ALIAS + "Section";
+
+    public static final String PROPERTY_TITLE_TEXT_KEY = PROPERTY_TITLE_TEXT_ROOT_KEY + ".text";
+    public static final String PROPERTY_TITLE_TEXT_LABEL = "Title Text";
+    public static final String PROPERTY_TITLE_TEXT_TOOLTIP = "Add title parameter to the " + COLOR_LOWER_CASE + " bar";
+    public static final String PROPERTY_TITLE_TEXT_ALIAS = PROPERTY_TITLE_TEXT_ROOT_ALIAS + "Text";
+    public static final String PROPERTY_TITLE_TEXT_DEFAULT = NULL_SPECIAL;
+    public static final Class PROPERTY_TITLE_TEXT_TYPE = String.class;
+
+    public static final String PROPERTY_UNITS_TEXT_KEY = PROPERTY_TITLE_TEXT_ROOT_KEY + ".units.text";
+    public static final String PROPERTY_UNITS_TEXT_LABEL = "Units Text";
+    public static final String PROPERTY_UNITS_TEXT_TOOLTIP = "Add units to the title of the " + COLOR_LOWER_CASE + " bar";
+    public static final String PROPERTY_UNITS_TEXT_ALIAS = PROPERTY_TITLE_TEXT_ROOT_ALIAS + "Text";
+    public static final String PROPERTY_UNITS_TEXT_DEFAULT = NULL_SPECIAL;
+    public static final Class PROPERTY_UNITS_TEXT_TYPE = String.class;
+
+
+
+    // Orientation
+
+    private static final String PROPERTY_ORIENTATION_ROOT_KEY = PROPERTY_ROOT_KEY + ".orientation";
+    private static final String PROPERTY_ORIENTATION_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "Orientation";
+
+    public static final String PROPERTY_ORIENTATION_SECTION_KEY = PROPERTY_ORIENTATION_ROOT_KEY + ".section";
+    public static final String PROPERTY_ORIENTATION_SECTION_LABEL = "Orientation";
+    public static final String PROPERTY_ORIENTATION_SECTION_TOOLTIP = "Orientation options for the " + COLOR_LOWER_CASE + " bar legend";
+    public static final String PROPERTY_ORIENTATION_SECTION_ALIAS = PROPERTY_ORIENTATION_ROOT_ALIAS + "Section";
+
+    public static final String PROPERTY_ORIENTATION_KEY = PROPERTY_ORIENTATION_ROOT_KEY + ".orientation";
+    public static final String PROPERTY_ORIENTATION_LABEL = "Alignment";
+    public static final String PROPERTY_ORIENTATION_TOOLTIP = "Alignment (vertical/horizontal) of the " + COLOR_LOWER_CASE + " bar legend";
+    public static final Class PROPERTY_ORIENTATION_TYPE = String.class;
+    public static final String PROPERTY_ORIENTATION_ALIAS = PROPERTY_ORIENTATION_ROOT_ALIAS + "Alignment";
+    public static final String PROPERTY_ORIENTATION_OPTION1 = OPTION_HORIZONTAL;
+    public static final String PROPERTY_ORIENTATION_OPTION2 = OPTION_VERTICAL;
+    public static final String PROPERTY_ORIENTATION_DEFAULT = OPTION_HORIZONTAL;
+    public static final Object PROPERTY_ORIENTATION_VALUE_SET[] = {PROPERTY_ORIENTATION_OPTION1, PROPERTY_ORIENTATION_OPTION2};
+
+
+    public static final String PROPERTY_ORIENTATION_REVERSE_PALETTE_KEY = PROPERTY_ORIENTATION_ROOT_KEY + ".reverse.palette";
+    public static final String PROPERTY_ORIENTATION_REVERSE_PALETTE_LABEL = "Reverse Palette & Labels";
+    public static final String PROPERTY_ORIENTATION_REVERSE_PALETTE_TOOLTIP = "Reverse direction of palette and labels";
+    private static final String PROPERTY_ORIENTATION_REVERSE_PALETTE_ALIAS = PROPERTY_ORIENTATION_ROOT_ALIAS + "ReversePalette";
+    public static final boolean PROPERTY_ORIENTATION_REVERSE_PALETTE_DEFAULT = false;
+    public static final Class PROPERTY_ORIENTATION_REVERSE_PALETTE_TYPE = Boolean.class;
+
+
+
+
+
+    // Label (Values)
+
+    private static final String PROPERTY_LABEL_VALUES_ROOT_KEY = PROPERTY_ROOT_KEY + ".label.values";
+    private static final String PROPERTY_LABEL_VALUES_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "LabelValues";
+
+    public static final String PROPERTY_LABEL_VALUES_SECTION_KEY = PROPERTY_LABEL_VALUES_ROOT_KEY + ".section";
+    public static final String PROPERTY_LABEL_VALUES_SECTION_LABEL = "Tick Label Values";
+    public static final String PROPERTY_LABEL_VALUES_SECTION_TOOLTIP = "Numeric value options for the " + COLOR_LOWER_CASE + " bar legend labels";
+    public static final String PROPERTY_LABEL_VALUES_SECTION_ALIAS = PROPERTY_LABEL_VALUES_ROOT_ALIAS +"Section";
+
+    public static final String PROPERTY_LABEL_VALUES_MODE_KEY = PROPERTY_LABEL_VALUES_ROOT_KEY + ".mode";
+    public static final String PROPERTY_LABEL_VALUES_MODE_LABEL = "Label Value Mode";
+    public static final String PROPERTY_LABEL_VALUES_MODE_TOOLTIP = "Mode for setting label values on the " + COLOR_LOWER_CASE + " bar legend";
+    public static final Class PROPERTY_LABEL_VALUES_MODE_TYPE = String.class;
+    public static final String PROPERTY_LABEL_VALUES_MODE_ALIAS = PROPERTY_LABEL_VALUES_ROOT_ALIAS + "Mode";
+    public static final String PROPERTY_LABEL_VALUES_MODE_OPTION1 = DISTRIB_EVEN_STR;
+    public static final String PROPERTY_LABEL_VALUES_MODE_OPTION2 = DISTRIB_MANUAL_STR;
+    public static final String PROPERTY_LABEL_VALUES_MODE_OPTION3 = DISTRIB_EXACT_STR;
+    public static final String PROPERTY_LABEL_VALUES_MODE_DEFAULT = DISTRIB_EVEN_STR;
+    public static final Object PROPERTY_LABEL_VALUES_MODE_VALUE_SET[] = {
+            PROPERTY_LABEL_VALUES_MODE_OPTION1,
+            PROPERTY_LABEL_VALUES_MODE_OPTION2,
+            PROPERTY_LABEL_VALUES_MODE_OPTION3 };
+
+
+    public static final String PROPERTY_LABEL_VALUES_COUNT_KEY = PROPERTY_LABEL_VALUES_ROOT_KEY + ".count";
+    public static final String PROPERTY_LABEL_VALUES_COUNT_LABEL = "Label Count";
+    public static final String PROPERTY_LABEL_VALUES_COUNT_TOOLTIP = "Number of tick marks and labels";
+    public static final String PROPERTY_LABEL_VALUES_COUNT_ALIAS = PROPERTY_LABEL_VALUES_ROOT_ALIAS + "Count";
+    public static final int PROPERTY_LABEL_VALUES_COUNT_DEFAULT = 5;
+    public static final boolean PROPERTY_LABEL_VALUES_COUNT_ENABLED = false;
+    public static final Class PROPERTY_LABEL_VALUES_COUNT_TYPE = Integer.class;
+    public static final int PROPERTY_LABEL_VALUES_COUNT_MIN = 2;
+    public static final int PROPERTY_LABEL_VALUES_COUNT_MAX = 50;
+    public static final String PROPERTY_LABEL_VALUES_COUNT_INTERVAL = "[" + ColorBarLayerType.PROPERTY_LABEL_VALUES_COUNT_MIN + "," + ColorBarLayerType.PROPERTY_LABEL_VALUES_COUNT_MAX + "]";
+
+    public static final String PROPERTY_LABEL_VALUES_ACTUAL_KEY = PROPERTY_LABEL_VALUES_ROOT_KEY + ".actual";
+    public static final String PROPERTY_LABEL_VALUES_ACTUAL_LABEL = "Label Values";
+    public static final String PROPERTY_LABEL_VALUES_ACTUAL_TOOLTIP = "Set actual values of the tick marks";
+    private static final String PROPERTY_LABEL_VALUES_ACTUAL_ALIAS = PROPERTY_LABEL_VALUES_ROOT_ALIAS + "Actual";
+    public static final boolean PROPERTY_LABEL_VALUES_ACTUAL_ENABLED = true;
+    public static final String PROPERTY_LABEL_VALUES_ACTUAL_DEFAULT = "";
+    public static final Class PROPERTY_LABEL_VALUES_ACTUAL_TYPE = String.class;
+
+    public static final String PROPERTY_POPULATE_VALUES_TEXTFIELD_KEY = PROPERTY_LABEL_VALUES_ROOT_KEY + ".populate.values.textfield";
+    public static final String PROPERTY_POPULATE_VALUES_TEXTFIELD_LABEL = "Auto-Fill Label Values Textfield";
+    public static final String PROPERTY_POPULATE_VALUES_TEXTFIELD_TOOLTIP = "Auto-populate the values field with the generated values";
+    private static final String PROPERTY_POPULATE_VALUES_TEXTFIELD_ALIAS = PROPERTY_LABEL_VALUES_ROOT_ALIAS + "PopulateValueTextfield";
+    public static final boolean PROPERTY_POPULATE_VALUES_TEXTFIELD_DEFAULT = false;
+    public static final Class PROPERTY_POPULATE_VALUES_TEXTFIELD_TYPE = Boolean.class;
+
+
+    public static final String PROPERTY_LABEL_VALUES_SCALING_KEY = PROPERTY_LABEL_VALUES_ROOT_KEY + ".scaling.factor";
+    public static final String PROPERTY_LABEL_VALUES_SCALING_LABEL = "Label Scaling";
+    public static final String PROPERTY_LABEL_VALUES_SCALING_TOOLTIP = "Tick mark labels will be displayed after multiplication with this scaling factor";
+    public static final String PROPERTY_LABEL_VALUES_SCALING_ALIAS = PROPERTY_LABEL_VALUES_ROOT_ALIAS + "ScalingFactor";
+    public static final double PROPERTY_LABEL_VALUES_SCALING_DEFAULT = 1.0;
+    public static final Class PROPERTY_LABEL_VALUES_SCALING_TYPE = Double.class;
+    public static final double PROPERTY_LABEL_VALUES_SCALING_MIN = 0.0000000001;
+    public static final double PROPERTY_LABEL_VALUES_SCALING_MAX = 1000000000;
+    public static final String PROPERTY_LABEL_VALUES_SCALING_INTERVAL = "[" +
+            ColorBarLayerType.PROPERTY_LABEL_VALUES_SCALING_MIN + "," +
+            ColorBarLayerType.PROPERTY_LABEL_VALUES_SCALING_MAX + "]";
+
+
+    public static final String PROPERTY_LABEL_VALUES_DECIMAL_PLACES_KEY = PROPERTY_LABEL_VALUES_ROOT_KEY + ".decimal.places";
+    public static final String PROPERTY_LABEL_VALUES_DECIMAL_PLACES_LABEL = "Decimal Places";
+    public static final String PROPERTY_LABEL_VALUES_DECIMAL_PLACES_TOOLTIP = "Decimal places to display the numeric tick mark labels";
+    public static final String PROPERTY_LABEL_VALUES_DECIMAL_PLACES_ALIAS = PROPERTY_LABEL_VALUES_ROOT_ALIAS + "DecimalPlaces";
+    public static final int PROPERTY_LABEL_VALUES_DECIMAL_PLACES_DEFAULT = 2;
+    public static final Class PROPERTY_LABEL_VALUES_DECIMAL_PLACES_TYPE = Integer.class;
+    public static final int PROPERTY_LABEL_VALUES_DECIMAL_PLACES_MIN = 0;
+    public static final int PROPERTY_LABEL_VALUES_DECIMAL_PLACES_MAX = 10;
+    public static final String PROPERTY_LABEL_VALUES_DECIMAL_PLACES_INTERVAL = "[" +
+            ColorBarLayerType.PROPERTY_LABEL_VALUES_DECIMAL_PLACES_MIN + "," +
+            ColorBarLayerType.PROPERTY_LABEL_VALUES_DECIMAL_PLACES_MAX + "]";
+
+
+    public static final String PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_KEY = PROPERTY_LABEL_VALUES_ROOT_KEY + ".force.decimal.places";
+    public static final String PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_LABEL = "Force Trailing Decimal Zeros";
+    public static final String PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_TOOLTIP = "Force to exact decimal places by adding trailing zeros as needed";
+    private static final String PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_ALIAS = PROPERTY_LABEL_VALUES_ROOT_ALIAS + "ForceDecimalPlaces";
+    public static final boolean PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_DEFAULT = false;
+    public static final Class PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_TYPE = Boolean.class;
+
+
+    public static final String PROPERTY_WEIGHT_TOLERANCE_KEY = PROPERTY_LABEL_VALUES_ROOT_KEY + "weight.tolerance";
+    public static final String PROPERTY_WEIGHT_TOLERANCE_LABEL = "Weight Tolerance";
+    public static final String PROPERTY_WEIGHT_TOLERANCE_TOOLTIP = "Weight tolerance to keep desired auto-generated rounded values on the ends of the color bar";
+    private static final String PROPERTY_WEIGHT_TOLERANCE_ALIAS = PROPERTY_LABEL_VALUES_ROOT_ALIAS + "WeightTolerance";
+    public static final Double PROPERTY_WEIGHT_TOLERANCE_DEFAULT = 0.001;
+    public static final Class PROPERTY_WEIGHT_TOLERANCE_TYPE = Double.class;
+
+
+
+
+    // ColorBar Location Section
+
+    private static final String PROPERTY_LOCATION_ROOT_KEY = PROPERTY_ROOT_KEY + ".location";
+    private static final String PROPERTY_LOCATION_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "Location";
+
+    public static final String PROPERTY_LOCATION_SECTION_KEY = PROPERTY_LOCATION_ROOT_KEY + ".section";
+    public static final String PROPERTY_LOCATION_SECTION_LABEL = "Placement Location";
+    public static final String PROPERTY_LOCATION_SECTION_TOOLTIP = "Set placement location of " + COLOR_LOWER_CASE + " bar image legend on the scene image";
+    public static final String PROPERTY_LOCATION_SECTION_ALIAS = PROPERTY_LOCATION_ROOT_ALIAS + "Section";
+
+    public static final String PROPERTY_LOCATION_INSIDE_KEY = PROPERTY_LOCATION_ROOT_KEY + ".inside";
+    public static final String PROPERTY_LOCATION_INSIDE_LABEL = "Place " + COLOR_MIXED_CASE + " Bar Inside Image";
+    public static final String PROPERTY_LOCATION_INSIDE_TOOLTIP = "Place " + COLOR_LOWER_CASE + " bar inside/outside scene image bounds";
+    private static final String PROPERTY_LOCATION_INSIDE_ALIAS = PROPERTY_LOCATION_ROOT_ALIAS + "Inside";
+    public static final boolean PROPERTY_LOCATION_INSIDE_DEFAULT = true;
+    public static final Class PROPERTY_LOCATION_INSIDE_TYPE = Boolean.class;
+
+
+    public static final String LOCATION_UPPER_LEFT = "Upper Left";
+    public static final String LOCATION_UPPER_CENTER = "Upper Center";
+    public static final String LOCATION_UPPER_RIGHT = "Upper Right";
+    public static final String LOCATION_LOWER_LEFT = "Lower Left";
+    public static final String LOCATION_LOWER_CENTER = "Lower Center";
+    public static final String LOCATION_LOWER_RIGHT = "Lower Right";
+    public static final String LOCATION_LEFT_CENTER = "Left Side Center";
+    public static final String LOCATION_RIGHT_CENTER = "Right Side Center";
+    public static String[] getColorBarLocationArray() {
+        return  new String[]{
+                LOCATION_UPPER_LEFT,
+                LOCATION_UPPER_CENTER,
+                LOCATION_UPPER_RIGHT,
+                LOCATION_LOWER_LEFT,
+                LOCATION_LOWER_CENTER,
+                LOCATION_LOWER_RIGHT,
+                LOCATION_LEFT_CENTER,
+                LOCATION_RIGHT_CENTER
+        };
+    }
+
+    public static final String PROPERTY_LOCATION_PLACEMENT_KEY = PROPERTY_LOCATION_ROOT_KEY + ".anchor";
+    public static final String PROPERTY_LOCATION_PLACEMENT_LABEL = "Scene Anchor";
+    public static final String PROPERTY_LOCATION_PLACEMENT_TOOLTIP = "Where to place " + COLOR_LOWER_CASE + " bar on image";
+    private static final String PROPERTY_LOCATION_PLACEMENT_ALIAS = PROPERTY_LOCATION_ROOT_ALIAS + "Anchor";
+    public static final String PROPERTY_LOCATION_PLACEMENT_DEFAULT = LOCATION_LOWER_RIGHT;
+    public static final Class PROPERTY_LOCATION_PLACEMENT_TYPE = String.class;
+
+    public static final String PROPERTY_LOCATION_OFFSET_KEY = PROPERTY_LOCATION_ROOT_KEY + ".offset";
+    public static final String PROPERTY_LOCATION_OFFSET_LABEL = "Scene Anchor Offset";
+    public static final String PROPERTY_LOCATION_OFFSET_TOOLTIP = "Move " + COLOR_LOWER_CASE + " bar legend away from anchored axis (by percentage of " + COLOR_LOWER_CASE + " bar height)";
+    private static final String PROPERTY_LOCATION_OFFSET_ALIAS = PROPERTY_LOCATION_ROOT_ALIAS + "Offset";
+    public static final Double PROPERTY_LOCATION_OFFSET_DEFAULT = 0.0;
+    public static final Class PROPERTY_LOCATION_OFFSET_TYPE = Double.class;
+
+    public static final String PROPERTY_LOCATION_SHIFT_KEY = PROPERTY_LOCATION_ROOT_KEY + ".shift";
+    public static final String PROPERTY_LOCATION_SHIFT_LABEL = "Scene Anchor Shift";
+    public static final String PROPERTY_LOCATION_SHIFT_TOOLTIP = "Move " + COLOR_LOWER_CASE + " bar legend along the anchored axis (by percentage of " + COLOR_LOWER_CASE + " bar width)";
+    private static final String PROPERTY_LOCATION_SHIFT_ALIAS = PROPERTY_LOCATION_ROOT_ALIAS + "Shift";
+    public static final Double PROPERTY_LOCATION_SHIFT_DEFAULT = 0.0;
+    public static final Class PROPERTY_LOCATION_SHIFT_TYPE = Double.class;
+
+
+    public static final String VERTICAL_TITLE_LEFT = "Left";
+    public static final String VERTICAL_TITLE_RIGHT = "Right";
+    public static final String VERTICAL_TITLE_TOP = "Top";
+    public static final String VERTICAL_TITLE_BOTTOM = "Bottom";
+
+
+    public static Object[] VERTICAL_TITLE_LOCATION_VALUE_SET = {
+            VERTICAL_TITLE_LEFT,
+            VERTICAL_TITLE_RIGHT,
+            VERTICAL_TITLE_TOP,
+            VERTICAL_TITLE_BOTTOM
+    };
+
+    public static final String PROPERTY_LOCATION_TITLE_VERTICAL_KEY = PROPERTY_LOCATION_ROOT_KEY + "title.vertical.anchor";
+    public static final String PROPERTY_LOCATION_TITLE_VERTICAL_LABEL = "Title Anchor";
+    public static final String PROPERTY_LOCATION_TITLE_VERTICAL_TOOLTIP = "Where to place title on vertical legend";
+    private static final String PROPERTY_LOCATION_TITLE_VERTICAL_ALIAS = PROPERTY_LOCATION_ROOT_ALIAS + "TitleAnchor";
+    public static final String PROPERTY_LOCATION_TITLE_VERTICAL_DEFAULT = VERTICAL_TITLE_TOP;
+    public static final Class PROPERTY_LOCATION_TITLE_VERTICAL_TYPE = String.class;
+    public static final Object PROPERTY_LOCATION_TITLE_VERTICAL_VALUE_SET[] = VERTICAL_TITLE_LOCATION_VALUE_SET;
+    public static final boolean PROPERTY_LOCATION_TITLE_VERTICAL_ENABLED = false;
+
+
+
+    // Image Scaling Section
+
+    private static final String PROPERTY_IMAGE_SCALING_ROOT_KEY = PROPERTY_ROOT_KEY + ".scaling";
+    private static final String PROPERTY_IMAGE_SCALING_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "Scaling";
+
+    public static final String PROPERTY_IMAGE_SCALING_SECTION_KEY = PROPERTY_IMAGE_SCALING_ROOT_KEY + ".section";
+    public static final String PROPERTY_IMAGE_SCALING_SECTION_LABEL = "Size & Scaling";
+    public static final String PROPERTY_IMAGE_SCALING_SECTION_TOOLTIP = "Set scaling and relative size of " + COLOR_LOWER_CASE + " bar image";
+    public static final String PROPERTY_IMAGE_SCALING_SECTION_ALIAS = PROPERTY_IMAGE_SCALING_ROOT_ALIAS + "Section";
+
+    public static final String PROPERTY_IMAGE_SCALING_APPLY_SIZE_KEY = PROPERTY_IMAGE_SCALING_ROOT_KEY + ".apply";
+    public static final String PROPERTY_IMAGE_SCALING_APPLY_SIZE_LABEL = "Scale to Scene Size";
+    public static final String PROPERTY_IMAGE_SCALING_APPLY_SIZE_TOOLTIP = "Scale the " + COLOR_LOWER_CASE + " bar legend size to percentage of the scene image size using Legend Scaling Factor";
+    private static final String PROPERTY_IMAGE_SCALING_APPLY_SIZE_ALIAS = PROPERTY_IMAGE_SCALING_ROOT_ALIAS + "Apply";
+    public static final boolean PROPERTY_IMAGE_SCALING_APPLY_SIZE_DEFAULT = true;
+    public static final Class PROPERTY_IMAGE_SCALING_APPLY_SIZE_TYPE = Boolean.class;
+
+    public static final String PROPERTY_IMAGE_SCALING_SIZE_KEY = PROPERTY_IMAGE_SCALING_ROOT_KEY + ".size";
+    public static final String PROPERTY_IMAGE_SCALING_SIZE_LABEL = "Scene Size Scaling";
+    public static final String PROPERTY_IMAGE_SCALING_SIZE_TOOLTIP = "Percent to scale " + COLOR_LOWER_CASE + " bar legend relative to the scene image size";
+    private static final String PROPERTY_IMAGE_SCALING_SIZE_ALIAS = PROPERTY_IMAGE_SCALING_ROOT_ALIAS + "Size";
+    public static final double PROPERTY_IMAGE_SCALING_SIZE_DEFAULT = 60.0;
+    public static final Class PROPERTY_IMAGE_SCALING_SIZE_TYPE = Double.class;
+    public static final double PROPERTY_IMAGE_SCALING_SIZE_MIN = 5;
+    public static final double PROPERTY_IMAGE_SCALING_SIZE_MAX = 200;
+    public static final String PROPERTY_IMAGE_SCALING_SIZE_INTERVAL = "[" +
+            ColorBarLayerType.PROPERTY_IMAGE_SCALING_SIZE_MIN + "," +
+            ColorBarLayerType.PROPERTY_IMAGE_SCALING_SIZE_MAX + "]";
+
+
+
+    public static final String PROPERTY_COLORBAR_LENGTH_KEY = PROPERTY_IMAGE_SCALING_ROOT_KEY + ".colorbar.length";
+    public static final String PROPERTY_COLORBAR_LENGTH_LABEL = COLOR_MIXED_CASE + " Bar Length";
+    public static final String PROPERTY_COLORBAR_LENGTH_TOOLTIP = "Length in pixels of the " + COLOR_LOWER_CASE + " bar";
+    private static final String PROPERTY_COLORBAR_LENGTH_ALIAS = PROPERTY_IMAGE_SCALING_ROOT_ALIAS + "ColorbarLength";
+    public static final int PROPERTY_COLORBAR_LENGTH_VALUE_MIN = 500;
+    public static final int PROPERTY_COLORBAR_LENGTH_VALUE_MAX = 8000;
+    public static final String PROPERTY_COLORBAR_LENGTH_VALUE_INTERVAL = "[" + ColorBarLayerType.PROPERTY_COLORBAR_LENGTH_VALUE_MIN + "," + ColorBarLayerType.PROPERTY_COLORBAR_LENGTH_VALUE_MAX + "]";
+    public static final int PROPERTY_COLORBAR_LENGTH_DEFAULT = 1200;
+    public static final Class PROPERTY_COLORBAR_LENGTH_TYPE = Integer.class;
+
+    public static final String PROPERTY_COLORBAR_WIDTH_KEY = PROPERTY_IMAGE_SCALING_ROOT_KEY + ".colorbar.width";
+    public static final String PROPERTY_COLORBAR_WIDTH_LABEL = COLOR_MIXED_CASE + " Bar Width";
+    public static final String PROPERTY_COLORBAR_WIDTH_TOOLTIP = "Width in pixels of the " + COLOR_LOWER_CASE + " bar";
+    private static final String PROPERTY_COLORBAR_WIDTH_ALIAS = PROPERTY_IMAGE_SCALING_ROOT_ALIAS + "ColorWidth";
+    public static final int PROPERTY_COLORBAR_WIDTH_MIN = 5;
+    public static final int PROPERTY_COLORBAR_WIDTH_MAX = 1000;
+    public static final String PROPERTY_COLORBAR_WIDTH_INTERVAL = "[" + ColorBarLayerType.PROPERTY_COLORBAR_WIDTH_MIN + "," + ColorBarLayerType.PROPERTY_COLORBAR_WIDTH_MAX + "]";
+    public static final int PROPERTY_COLORBAR_WIDTH_DEFAULT = 70;
+    public static final Class PROPERTY_COLORBAR_WIDTH_TYPE = Integer.class;
+
+
+    
+
+
+
+    // Title Section
+
+    private static final String PROPERTY_TITLE_ROOT_KEY = PROPERTY_ROOT_KEY + ".title.parameter";
+    private static final String PROPERTY_TITLE_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "TitleParameter";
+
+    public static final String PROPERTY_TITLE_SECTION_KEY = PROPERTY_TITLE_ROOT_KEY + ".section";
+    public static final String PROPERTY_TITLE_SECTION_LABEL = "Title Format";
+    public static final String PROPERTY_TITLE_SECTION_TOOLTIP = "Set parameter options in title of " + COLOR_LOWER_CASE + " bar";
+    public static final String PROPERTY_TITLE_SECTION_ALIAS = PROPERTY_TITLE_ROOT_ALIAS + "Section";
+
+    public static final String PROPERTY_TITLE_SHOW_KEY = PROPERTY_TITLE_ROOT_KEY + ".show";
+    public static final String PROPERTY_TITLE_SHOW_LABEL = "Show Title";
+    public static final String PROPERTY_TITLE_SHOW_TOOLTIP = "Add title to the " + COLOR_LOWER_CASE + " bar";
+    private static final String PROPERTY_TITLE_SHOW_ALIAS = PROPERTY_TITLE_ROOT_ALIAS + "Show";
+    public static final boolean PROPERTY_TITLE_SHOW_DEFAULT = true;
+    public static final Class PROPERTY_TITLE_SHOW_TYPE = Boolean.class;
+
+
+    public static final String PROPERTY_TITLE_FONT_SIZE_KEY = PROPERTY_TITLE_ROOT_KEY + "font.size";
+    public static final String PROPERTY_TITLE_FONT_SIZE_LABEL = "Title Size";
+    public static final String PROPERTY_TITLE_FONT_SIZE_TOOLTIP = "Set size of the title parameter";
+    private static final String PROPERTY_TITLE_FONT_SIZE_ALIAS = PROPERTY_TITLE_ROOT_ALIAS + "FontSize";
+    public static final int PROPERTY_TITLE_FONT_SIZE_DEFAULT = 50;
+    public static final Class PROPERTY_TITLE_FONT_SIZE_TYPE = Integer.class;
+    public static final int PROPERTY_TITLE_FONT_SIZE_VALUE_MIN = 10;
+    public static final int PROPERTY_TITLE_FONT_SIZE_VALUE_MAX = 200;
+    public static final String PROPERTY_TITLE_FONT_SIZE_INTERVAL =
+            "[" + ColorBarLayerType.PROPERTY_TITLE_FONT_SIZE_VALUE_MIN +
+                    "," + ColorBarLayerType.PROPERTY_TITLE_FONT_SIZE_VALUE_MAX + "]";
+
+
+
+    public static final String PROPERTY_TITLE_FONT_BOLD_KEY = PROPERTY_TITLE_ROOT_KEY + ".font.bold";
+    public static final String PROPERTY_TITLE_FONT_BOLD_LABEL = "Title Font Bold";
+    public static final String PROPERTY_TITLE_FONT_BOLD_TOOLTIP = "Format title parameter text font in bold";
+    public static final String PROPERTY_TITLE_FONT_BOLD_ALIAS = PROPERTY_TITLE_ROOT_ALIAS + "FontBold";
+    public static final boolean PROPERTY_TITLE_FONT_BOLD_DEFAULT = false;
+    public static final Class PROPERTY_TITLE_FONT_BOLD_TYPE = Boolean.class;
+
+    public static final String PROPERTY_TITLE_FONT_ITALIC_KEY = PROPERTY_TITLE_ROOT_KEY + ".font.italic";
+    public static final String PROPERTY_TITLE_FONT_ITALIC_LABEL = "Title Font Italic";
+    public static final String PROPERTY_TITLE_FONT_ITALIC_TOOLTIP = "Format title parameter text font in italic";
+    public static final String PROPERTY_TITLE_FONT_ITALIC_ALIAS = PROPERTY_TITLE_ROOT_ALIAS + "FontItalic";
+    public static final boolean PROPERTY_TITLE_FONT_ITALIC_DEFAULT = false;
+    public static final Class PROPERTY_TITLE_FONT_ITALIC_TYPE = Boolean.class;
+
+    public static final String PROPERTY_TITLE_FONT_NAME_KEY = PROPERTY_TITLE_ROOT_KEY + ".font.name";
+    public static final String PROPERTY_TITLE_FONT_NAME_LABEL = "Title Font";
+    public static final String PROPERTY_TITLE_FONT_NAME_TOOLTIP = "Set the text font of the title parameter";
+    public static final String PROPERTY_TITLE_FONT_NAME_ALIAS = PROPERTY_TITLE_ROOT_ALIAS + "FontName";
+    public static final String PROPERTY_TITLE_FONT_NAME_DEFAULT = FONT_NAME_SANSERIF;
+    public static final Class PROPERTY_TITLE_FONT_NAME_TYPE = String.class;
+    public static final Object PROPERTY_TITLE_FONT_NAME_VALUE_SET[] = FONT_NAME_VALUE_SET;
+
+    public static final String PROPERTY_TITLE_COLOR_KEY = PROPERTY_TITLE_ROOT_KEY + "font.color";
+    public static final String PROPERTY_TITLE_COLOR_LABEL = "Title " + COLOR_MIXED_CASE;
+    public static final String PROPERTY_TITLE_COLOR_TOOLTIP = "Set " + COLOR_LOWER_CASE + " of the title";
+    private static final String PROPERTY_TITLE_COLOR_ALIAS = PROPERTY_TITLE_ROOT_ALIAS + "FontColor";
+    public static final Color PROPERTY_TITLE_COLOR_DEFAULT = Color.BLACK;
+    public static final Class PROPERTY_TITLE_COLOR_TYPE = Color.class;
+
+
+
+
+
+    // Units Section
+
+    private static final String PROPERTY_UNITS_ROOT_KEY = PROPERTY_ROOT_KEY + ".units";
+    private static final String PROPERTY_UNITS_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "Units";
+
+    public static final String PROPERTY_UNITS_SECTION_KEY = PROPERTY_UNITS_ROOT_KEY + ".section";
+    public static final String PROPERTY_UNITS_SECTION_LABEL = "Units Format";
+    public static final String PROPERTY_UNITS_SECTION_TOOLTIP = "Set units of " + COLOR_LOWER_CASE + " bar";
+    public static final String PROPERTY_UNITS_SECTION_ALIAS = PROPERTY_UNITS_ROOT_ALIAS + "Section";
+
+    public static final String PROPERTY_UNITS_SHOW_KEY = PROPERTY_UNITS_ROOT_KEY + ".show";
+    public static final String PROPERTY_UNITS_SHOW_LABEL = "Show Units";
+    public static final String PROPERTY_UNITS_SHOW_TOOLTIP = "Add units to the title of the " + COLOR_LOWER_CASE + " bar";
+    private static final String PROPERTY_UNITS_SHOW_ALIAS = PROPERTY_UNITS_ROOT_ALIAS + "Show";
+    public static final boolean PROPERTY_UNITS_SHOW_DEFAULT = true;
+    public static final Class PROPERTY_UNITS_SHOW_TYPE = Boolean.class;
+
+
+    public static final String PROPERTY_UNITS_FONT_SIZE_KEY = PROPERTY_UNITS_ROOT_KEY + ".font.size";
+    public static final String PROPERTY_UNITS_FONT_SIZE_LABEL = "Units Size";
+    public static final String PROPERTY_UNITS_FONT_SIZE_TOOLTIP = "Set size of the title units";
+    private static final String PROPERTY_UNITS_FONT_SIZE_ALIAS = PROPERTY_UNITS_ROOT_ALIAS + "FontSize";
+    public static final int PROPERTY_UNITS_FONT_SIZE_DEFAULT = 35;
+    public static final Class PROPERTY_UNITS_FONT_SIZE_TYPE = Integer.class;
+    public static final int PROPERTY_UNITS_FONT_SIZE_VALUE_MIN = 10;
+    public static final int PROPERTY_UNITS_FONT_SIZE_VALUE_MAX = 200;
+    public static final String PROPERTY_UNITS_FONT_SIZE_INTERVAL =
+            "[" + ColorBarLayerType.PROPERTY_UNITS_FONT_SIZE_VALUE_MIN +
+                    "," + ColorBarLayerType.PROPERTY_UNITS_FONT_SIZE_VALUE_MAX + "]";
+
+    public static final String PROPERTY_UNITS_FONT_BOLD_KEY = PROPERTY_UNITS_ROOT_KEY + ".font.bold";
+    public static final String PROPERTY_UNITS_FONT_BOLD_LABEL = "Units Bold Font";
+    public static final String PROPERTY_UNITS_FONT_BOLD_TOOLTIP = "Format title units text font in bold";
+    public static final String PROPERTY_UNITS_FONT_BOLD_ALIAS = PROPERTY_UNITS_ROOT_ALIAS + "FontBold";
+    public static final boolean PROPERTY_UNITS_FONT_BOLD_DEFAULT = false;
+    public static final Class PROPERTY_UNITS_FONT_BOLD_TYPE = Boolean.class;
+
+    public static final String PROPERTY_UNITS_FONT_ITALIC_KEY = PROPERTY_UNITS_ROOT_KEY + ".font.italic";
+    public static final String PROPERTY_UNITS_FONT_ITALIC_LABEL = "Units Italic Font";
+    public static final String PROPERTY_UNITS_FONT_ITALIC_TOOLTIP = "Format title units text font in italic";
+    public static final String PROPERTY_UNITS_FONT_ITALIC_ALIAS = PROPERTY_UNITS_ROOT_ALIAS + "FontItalic";
+    public static final boolean PROPERTY_UNITS_FONT_ITALIC_DEFAULT = false;
+    public static final Class PROPERTY_UNITS_FONT_ITALIC_TYPE = Boolean.class;
+
+    public static final String PROPERTY_UNITS_FONT_NAME_KEY = PROPERTY_UNITS_ROOT_KEY + ".font.name";
+    public static final String PROPERTY_UNITS_FONT_NAME_LABEL = "Units Font";
+    public static final String PROPERTY_UNITS_FONT_NAME_TOOLTIP = "Set the text font of the title units";
+    public static final String PROPERTY_UNITS_FONT_NAME_ALIAS = PROPERTY_UNITS_ROOT_ALIAS + "FontName";
+    public static final String PROPERTY_UNITS_FONT_NAME_DEFAULT = FONT_NAME_SANSERIF;
+    public static final Class PROPERTY_UNITS_FONT_NAME_TYPE = String.class;
+    public static final Object PROPERTY_UNITS_FONT_NAME_VALUE_SET[] = FONT_NAME_VALUE_SET;
+
+
+    public static final String PROPERTY_UNITS_FONT_COLOR_KEY = PROPERTY_UNITS_ROOT_KEY + ".font.color";
+    public static final String PROPERTY_UNITS_FONT_COLOR_LABEL = "Units " + COLOR_MIXED_CASE;
+    public static final String PROPERTY_UNITS_FONT_COLOR_TOOLTIP = "Set " + COLOR_LOWER_CASE + " of the title units";
+    private static final String PROPERTY_UNITS_FONT_COLOR_ALIAS = PROPERTY_UNITS_ROOT_ALIAS + "FontColor";
+    public static final Color PROPERTY_UNITS_FONT_COLOR_DEFAULT = Color.BLACK;
+    public static final Class PROPERTY_UNITS_FONT_COLOR_TYPE = Color.class;
+
+
+
+
+
+
+    // Tick-Mark Labels Section
+
+    private static final String PROPERTY_LABELS_ROOT_KEY = PROPERTY_ROOT_KEY + ".labels";
+    private static final String PROPERTY_LABELS_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "Labels";
+
+    public static final String PROPERTY_LABELS_SECTION_KEY = PROPERTY_LABELS_ROOT_KEY + ".section";
+    public static final String PROPERTY_LABELS_SECTION_LABEL = "Tick Label Format";
+    public static final String PROPERTY_LABELS_SECTION_TOOLTIP = "Configuration options for the labels";
+    public static final String PROPERTY_LABELS_SECTION_ALIAS = PROPERTY_LABELS_ROOT_ALIAS + "Section";
+
+    public static final String PROPERTY_LABELS_SHOW_KEY = PROPERTY_LABELS_ROOT_KEY + ".show";
+    public static final String PROPERTY_LABELS_SHOW_LABEL = "Show Tick Labels";
+    public static final String PROPERTY_LABELS_SHOW_TOOLTIP = "Show the tick-mark labels";
+    private static final String PROPERTY_LABELS_SHOW_ALIAS = PROPERTY_LABELS_ROOT_ALIAS + "Show";
+    public static final boolean PROPERTY_LABELS_SHOW_DEFAULT = true;
+    public static final Class PROPERTY_LABELS_SHOW_TYPE = Boolean.class;
+
+    public static final String PROPERTY_LABELS_FONT_SIZE_KEY = PROPERTY_LABELS_ROOT_KEY + ".font.size";
+    public static final String PROPERTY_LABELS_FONT_SIZE_LABEL = "Labels Size";
+    public static final String PROPERTY_LABELS_FONT_SIZE_TOOLTIP = "Set the size of the tick-mark labels";
+    private static final String PROPERTY_LABELS_FONT_SIZE_ALIAS = PROPERTY_LABELS_ROOT_ALIAS + "FontSize";
+    public static final int PROPERTY_LABELS_FONT_SIZE_DEFAULT = 35;
+    public static final Class PROPERTY_LABELS_FONT_SIZE_TYPE = Integer.class;
+    public static final int PROPERTY_LABELS_FONT_SIZE_VALUE_MIN = 10;
+    public static final int PROPERTY_LABELS_FONT_SIZE_VALUE_MAX = 200;
+    public static final String PROPERTY_LABELS_FONT_SIZE_VALUE_INTERVAL = "[" + ColorBarLayerType.PROPERTY_LABELS_FONT_SIZE_VALUE_MIN + "," + ColorBarLayerType.PROPERTY_LABELS_FONT_SIZE_VALUE_MAX + "]";
+
+    public static final String PROPERTY_LABELS_FONT_BOLD_KEY = PROPERTY_LABELS_ROOT_KEY + ".font.bold";
+    public static final String PROPERTY_LABELS_FONT_BOLD_LABEL = "Labels Font Bold";
+    public static final String PROPERTY_LABELS_FONT_BOLD_TOOLTIP = "Format tick-mark label text font in bold";
+    public static final String PROPERTY_LABELS_FONT_BOLD_ALIAS = PROPERTY_LABELS_ROOT_ALIAS + "FontBold";
+    public static final boolean PROPERTY_LABELS_FONT_BOLD_DEFAULT = false;
+    public static final Class PROPERTY_LABELS_FONT_BOLD_TYPE = Boolean.class;
+
+    public static final String PROPERTY_LABELS_FONT_ITALIC_KEY = PROPERTY_LABELS_ROOT_KEY + ".font.italic";
+    public static final String PROPERTY_LABELS_FONT_ITALIC_LABEL = "Labels Font Italic";
+    public static final String PROPERTY_LABELS_FONT_ITALIC_TOOLTIP = "Format tick-mark label text font in italic";
+    public static final String PROPERTY_LABELS_FONT_ITALIC_ALIAS = PROPERTY_LABELS_ROOT_ALIAS + "FontItalic";
+    public static final boolean PROPERTY_LABELS_FONT_ITALIC_DEFAULT = false;
+    public static final Class PROPERTY_LABELS_FONT_ITALIC_TYPE = Boolean.class;
+
+    public static final String PROPERTY_LABELS_FONT_NAME_KEY = PROPERTY_LABELS_ROOT_KEY + ".font.name";
+    public static final String PROPERTY_LABELS_FONT_NAME_LABEL = "Labels Font";
+    public static final String PROPERTY_LABELS_FONT_NAME_TOOLTIP = "Set the font of the tick-mark labels";
+    public static final String PROPERTY_LABELS_FONT_NAME_ALIAS = PROPERTY_LABELS_ROOT_ALIAS + "FontName";
+    public static final String PROPERTY_LABELS_FONT_NAME_DEFAULT = FONT_NAME_SANSERIF;
+    public static final Class PROPERTY_LABELS_FONT_NAME_TYPE = String.class;
+    public static final Object PROPERTY_LABELS_FONT_NAME_VALUE_SET[] = FONT_NAME_VALUE_SET;
+
+    public static final String PROPERTY_LABELS_FONT_COLOR_KEY = PROPERTY_LABELS_ROOT_KEY + ".font.color";
+    public static final String PROPERTY_LABELS_FONT_COLOR_LABEL = "Labels " + COLOR_MIXED_CASE;
+    public static final String PROPERTY_LABELS_FONT_COLOR_TOOLTIP = "Set the " + COLOR_LOWER_CASE + " of the tick-mark labels";
+    private static final String PROPERTY_LABELS_FONT_COLOR_ALIAS = PROPERTY_LABELS_ROOT_ALIAS + "FontColor";
+    public static final Color PROPERTY_LABELS_FONT_COLOR_DEFAULT = Color.BLACK;
+    public static final Class PROPERTY_LABELS_FONT_COLOR_TYPE = Color.class;
+
+
+
+
+
+
+
+
+
+    // Tickmarks Section
+
+    private static final String PROPERTY_TICKMARKS_ROOT_KEY = PROPERTY_ROOT_KEY + ".tickmarks";
+    private static final String PROPERTY_TICKMARKS_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "TickMarks";
+
+    public static final String PROPERTY_TICKMARKS_SECTION_KEY = PROPERTY_TICKMARKS_ROOT_KEY + ".section";
+    public static final String PROPERTY_TICKMARKS_SECTION_LABEL = "Tickmarks";
+    public static final String PROPERTY_TICKMARKS_SECTION_TOOLTIP = "Format options for the " + COLOR_LOWER_CASE + " bar legend tickmarks";
+    public static final String PROPERTY_TICKMARKS_SECTION_ALIAS = PROPERTY_TICKMARKS_ROOT_ALIAS + "Section";
+
+    public static final String PROPERTY_TICKMARKS_SHOW_KEY = PROPERTY_TICKMARKS_ROOT_KEY + ".show";
+    public static final String PROPERTY_TICKMARKS_SHOW_LABEL = "Show Tickmarks";
+    public static final String PROPERTY_TICKMARKS_SHOW_TOOLTIP = "Display tickmarks";
+    public static final String PROPERTY_TICKMARKS_SHOW_ALIAS = PROPERTY_TICKMARKS_ROOT_ALIAS + "Show";
+    public static final boolean PROPERTY_TICKMARKS_SHOW_DEFAULT = true;
+    public static final Class PROPERTY_TICKMARKS_SHOW_TYPE = Boolean.class;
+
+    public static final String PROPERTY_TICKMARKS_LENGTH_KEY = PROPERTY_TICKMARKS_ROOT_KEY + ".length";
+    public static final String PROPERTY_TICKMARKS_LENGTH_LABEL = "Tickmark Length";
+    public static final String PROPERTY_TICKMARKS_LENGTH_TOOLTIP = "Set length of tickmarks";
+    public static final String PROPERTY_TICKMARKS_LENGTH_ALIAS = PROPERTY_TICKMARKS_ROOT_ALIAS + "Length";
+    public static final int PROPERTY_TICKMARKS_LENGTH_DEFAULT = 12;
+    public static final Class PROPERTY_TICKMARKS_LENGTH_TYPE = Integer.class;
+
+    public static final String PROPERTY_TICKMARKS_WIDTH_KEY = PROPERTY_TICKMARKS_ROOT_KEY + ".width";
+    public static final String PROPERTY_TICKMARKS_WIDTH_LABEL = "Tickmark Width";
+    public static final String PROPERTY_TICKMARKS_WIDTH_TOOLTIP = "Set width of tickmarks";
+    public static final String PROPERTY_TICKMARKS_WIDTH_ALIAS = PROPERTY_TICKMARKS_ROOT_ALIAS + "Width";
+    public static final int PROPERTY_TICKMARKS_WIDTH_DEFAULT = 4;
+    public static final Class PROPERTY_TICKMARKS_WIDTH_TYPE = Integer.class;
+
+    public static final String PROPERTY_TICKMARKS_COLOR_KEY = PROPERTY_TICKMARKS_ROOT_KEY + ".color";
+    public static final String PROPERTY_TICKMARKS_COLOR_LABEL = "Tickmark " + COLOR_MIXED_CASE;
+    public static final String PROPERTY_TICKMARKS_COLOR_TOOLTIP = "Set " + COLOR_LOWER_CASE + " of the tick marks";
+    private static final String PROPERTY_TICKMARKS_COLOR_ALIAS = PROPERTY_TICKMARKS_ROOT_ALIAS + "Color";
+    public static final Color PROPERTY_TICKMARKS_COLOR_DEFAULT = Color.BLACK;
+    public static final Class PROPERTY_TICKMARKS_COLOR_TYPE = Color.class;
+
+
+
+
+    // Palette Border Section
+
+    private static final String PROPERTY_PALETTE_BORDER_ROOT_KEY = PROPERTY_ROOT_KEY + ".palette.border";
+    private static final String PROPERTY_PALETTE_BORDER_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "PaletteBorder";
+
+    public static final String PROPERTY_PALETTE_BORDER_SECTION_KEY = PROPERTY_PALETTE_BORDER_ROOT_KEY + ".section";
+    public static final String PROPERTY_PALETTE_BORDER_SECTION_ALIAS = PROPERTY_PALETTE_BORDER_ROOT_ALIAS + "Section";
+    public static final String PROPERTY_PALETTE_BORDER_SECTION_LABEL = "Palette Border";
+    public static final String PROPERTY_PALETTE_BORDER_SECTION_TOOLTIP = "Configuration options for adding a border around the palette (color bar)";
+
+    public static final String PROPERTY_PALETTE_BORDER_SHOW_KEY = PROPERTY_PALETTE_BORDER_ROOT_KEY + ".show";
+    public static final String PROPERTY_PALETTE_BORDER_SHOW_LABEL = "Show Palette Border";
+    public static final String PROPERTY_PALETTE_BORDER_SHOW_TOOLTIP = "Display a border around the palette (color bar) image";
+    private static final String PROPERTY_PALETTE_BORDER_SHOW_ALIAS = PROPERTY_PALETTE_BORDER_ROOT_ALIAS + "Show";
+    public static final boolean PROPERTY_PALETTE_BORDER_SHOW_DEFAULT = true;
+    public static final Class PROPERTY_PALETTE_BORDER_SHOW_TYPE = Boolean.class;
+
+    public static final String PROPERTY_PALETTE_BORDER_WIDTH_KEY = PROPERTY_PALETTE_BORDER_ROOT_KEY + ".width";
+    public static final String PROPERTY_PALETTE_BORDER_WIDTH_LABEL = "Palette Border Width";
+    public static final String PROPERTY_PALETTE_BORDER_WIDTH_TOOLTIP = "Width of palette (color bar) border line";
+    private static final String PROPERTY_PALETTE_BORDER_WIDTH_ALIAS = PROPERTY_PALETTE_BORDER_ROOT_ALIAS + "Width";
+    public static final int PROPERTY_PALETTE_BORDER_WIDTH_DEFAULT = 1;
+    public static final Class PROPERTY_PALETTE_BORDER_WIDTH_TYPE = Integer.class;
+
+    public static final String PROPERTY_PALETTE_BORDER_COLOR_KEY = PROPERTY_PALETTE_BORDER_ROOT_KEY + ".color";
+    public static final String PROPERTY_PALETTE_BORDER_COLOR_LABEL = "Palette Border " + COLOR_MIXED_CASE;
+    public static final String PROPERTY_PALETTE_BORDER_COLOR_TOOLTIP = COLOR_MIXED_CASE + " of the palette (color bar) border line";
+    private static final String PROPERTY_PALETTE_BORDER_COLOR_ALIAS = PROPERTY_PALETTE_BORDER_ROOT_ALIAS + "Color";
+    public static final Color PROPERTY_PALETTE_BORDER_COLOR_DEFAULT = Color.BLACK;
+    public static final Class PROPERTY_PALETTE_BORDER_COLOR_TYPE = Color.class;
+
+
+    // Legend Border Section
+
+    private static final String PROPERTY_LEGEND_BORDER_ROOT_KEY = PROPERTY_ROOT_KEY + ".legend.border";
+    private static final String PROPERTY_LEGEND_BORDER_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "LegendBorder";
+
+    public static final String PROPERTY_LEGEND_BORDER_SECTION_KEY = PROPERTY_LEGEND_BORDER_ROOT_KEY + ".section";
+    public static final String PROPERTY_LEGEND_BORDER_SECTION_ALIAS = PROPERTY_LEGEND_BORDER_ROOT_ALIAS + "Section";
+    public static final String PROPERTY_LEGEND_BORDER_SECTION_LABEL = "Legend Border";
+    public static final String PROPERTY_LEGEND_BORDER_SECTION_TOOLTIP = "Configuration options for adding a border around the full legend";
+
+    public static final String PROPERTY_LEGEND_BORDER_SHOW_KEY = PROPERTY_LEGEND_BORDER_ROOT_KEY + ".border.show";
+    public static final String PROPERTY_LEGEND_BORDER_SHOW_LABEL = "Show Legend Border";
+    public static final String PROPERTY_LEGEND_BORDER_SHOW_TOOLTIP = "Display a border around the full legend";
+    private static final String PROPERTY_LEGEND_BORDER_SHOW_ALIAS = PROPERTY_LEGEND_BORDER_ROOT_ALIAS + "BorderShow";
+    public static final boolean PROPERTY_LEGEND_BORDER_SHOW_DEFAULT = true;
+    public static final Class PROPERTY_LEGEND_BORDER_SHOW_TYPE = Boolean.class;
+
+    public static final String PROPERTY_LEGEND_BORDER_WIDTH_KEY = PROPERTY_LEGEND_BORDER_ROOT_KEY + ".border.width";
+    public static final String PROPERTY_LEGEND_BORDER_WIDTH_LABEL = "Legend Border Width";
+    public static final String PROPERTY_LEGEND_BORDER_WIDTH_TOOLTIP = "Width of border line around the full legend";
+    private static final String PROPERTY_LEGEND_BORDER_WIDTH_ALIAS = PROPERTY_LEGEND_BORDER_ROOT_ALIAS + "BorderWidth";
+    public static final int PROPERTY_LEGEND_BORDER_WIDTH_DEFAULT = 3;
+    public static final Class PROPERTY_LEGEND_BORDER_WIDTH_TYPE = Integer.class;
+
+    public static final String PROPERTY_LEGEND_BORDER_COLOR_KEY = PROPERTY_LEGEND_BORDER_ROOT_KEY + ".border.color";
+    public static final String PROPERTY_LEGEND_BORDER_COLOR_LABEL = "Legend Border " + COLOR_MIXED_CASE;
+    public static final String PROPERTY_LEGEND_BORDER_COLOR_TOOLTIP = COLOR_MIXED_CASE + " of border line around the full legend";
+    private static final String PROPERTY_LEGEND_BORDER_COLOR_ALIAS = PROPERTY_LEGEND_BORDER_ROOT_ALIAS + "BorderColor";
+    public static final Color PROPERTY_LEGEND_BORDER_COLOR_DEFAULT = Color.BLACK;
+    public static final Class PROPERTY_LEGEND_BORDER_COLOR_TYPE = Color.class;
+
+
+
+
+    // Backdrop Section
+
+    private static final String PROPERTY_BACKDROP_ROOT_KEY = PROPERTY_ROOT_KEY + ".backdrop";
+    private static final String PROPERTY_BACKDROP_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "Backdrop";
+
+    public static final String PROPERTY_BACKDROP_SECTION_KEY = PROPERTY_BACKDROP_ROOT_KEY + ".section";
+    public static final String PROPERTY_BACKDROP_SECTION_ALIAS = PROPERTY_BACKDROP_ROOT_ALIAS + "Section";
+    public static final String PROPERTY_BACKDROP_SECTION_LABEL = "Legend Backdrop";
+    public static final String PROPERTY_BACKDROP_SECTION_TOOLTIP = "Configuration options for the " + COLOR_LOWER_CASE + " bar legend backdrop";
+
+    public static final String PROPERTY_BACKDROP_SHOW_KEY = PROPERTY_BACKDROP_ROOT_KEY + ".show";
+    public static final String PROPERTY_BACKDROP_SHOW_LABEL = "Show Backdrop";
+    public static final String PROPERTY_BACKDROP_SHOW_TOOLTIP = "Show the " + COLOR_LOWER_CASE + " bar legend backdrop";
+    private static final String PROPERTY_BACKDROP_SHOW_ALIAS = PROPERTY_BACKDROP_ROOT_ALIAS + "Show";
+    public static final boolean PROPERTY_BACKDROP_SHOW_DEFAULT = true;
+    public static final Class PROPERTY_BACKDROP_SHOW_TYPE = Boolean.class;
+
+
+    public static final String PROPERTY_BACKDROP_TRANSPARENCY_KEY = PROPERTY_BACKDROP_ROOT_KEY + "transparency";
+    public static final String PROPERTY_BACKDROP_TRANSPARENCY_LABEL = "Backdrop Transparency";
+    public static final String PROPERTY_BACKDROP_TRANSPARENCY_TOOLTIP = "Set transparency of the " + COLOR_LOWER_CASE + " bar legend backdrop";
+    private static final String PROPERTY_BACKDROP_TRANSPARENCY_ALIAS = PROPERTY_BACKDROP_ROOT_ALIAS + "Transparency";
+    public static final double PROPERTY_BACKDROP_TRANSPARENCY_DEFAULT = 0.0;
+    public static final Class PROPERTY_BACKDROP_TRANSPARENCY_TYPE = Double.class;
+
+    public static final String PROPERTY_BACKDROP_COLOR_KEY = PROPERTY_BACKDROP_ROOT_KEY + ".color";
+    public static final String PROPERTY_BACKDROP_COLOR_LABEL = "Backdrop " + COLOR_MIXED_CASE;
+    public static final String PROPERTY_BACKDROP_COLOR_TOOLTIP = "Set " + COLOR_LOWER_CASE + " of the backdrop of the " + COLOR_LOWER_CASE + " bar legend backdrop";
+    private static final String PROPERTY_BACKDROP_COLOR_ALIAS = PROPERTY_BACKDROP_ROOT_ALIAS + "Color";
+    public static final Color PROPERTY_BACKDROP_COLOR_DEFAULT = Color.WHITE;
+    public static final Class PROPERTY_BACKDROP_COLOR_TYPE = Color.class;
+
+
+
+    //  Legend Export Section
+
+    private static final String PROPERTY_LEGEND_EXPORT_ROOT_KEY = PROPERTY_ROOT_KEY + ".legend.export";
+    private static final String PROPERTY_LEGEND_EXPORT_ROOT_ALIAS = PROPERTY_ROOT_ALIAS + "LegendExport";
+
+    public static final String PROPERTY_LEGEND_EXPORT_SECTION_KEY = PROPERTY_LEGEND_EXPORT_ROOT_KEY + ".section";
+    public static final String PROPERTY_LEGEND_EXPORT_SECTION_ALIAS = PROPERTY_LEGEND_EXPORT_ROOT_ALIAS + "Section";
+    public static final String PROPERTY_LEGEND_EXPORT_SECTION_LABEL = COLOR_MIXED_CASE + " Bar Export Tool";
+    public static final String PROPERTY_LEGEND_EXPORT_SECTION_TOOLTIP = "Configuration options for the " + COLOR_LOWER_CASE + " bar legend export tool";
+
+    public static final String PROPERTY_EXPORT_EDITOR_SHOW_KEY = PROPERTY_LEGEND_EXPORT_ROOT_KEY + ".editor.show";
+    public static final String PROPERTY_EXPORT_EDITOR_SHOW_LABEL = "Show Editor";
+    public static final String PROPERTY_EXPORT_EDITOR_SHOW_TOOLTIP = "Display editor for " + COLOR_LOWER_CASE + " bar export tool";
+    private static final String PROPERTY_EXPORT_EDITOR_SHOW_ALIAS = PROPERTY_LEGEND_EXPORT_ROOT_ALIAS + "EditorShow";
+    public static final boolean PROPERTY_EXPORT_EDITOR_SHOW_DEFAULT = false;
+    public static final Class PROPERTY_EXPORT_EDITOR_SHOW_TYPE = Boolean.class;
+
+    public static final String PROPERTY_EXPORT_USE_BW_COLOR_KEY = PROPERTY_LEGEND_EXPORT_ROOT_KEY + ".use.blackwhite.color";
+    public static final String PROPERTY_EXPORT_USE_BW_COLOR_LABEL = "Black/White " + COLOR_MIXED_CASE + " Override";
+    public static final String PROPERTY_EXPORT_USE_BW_COLOR_TOOLTIP = "Overrides " + COLOR_LOWER_CASE + "s and uses black & white";
+    private static final String PROPERTY_EXPORT_USE_BW_COLOR_ALIAS = PROPERTY_LEGEND_EXPORT_ROOT_ALIAS + "UseBlackWhiteColor";
+    public static final boolean PROPERTY_EXPORT_USE_BW_COLOR_DEFAULT = false;
+    public static final Class PROPERTY_EXPORT_USE_BW_COLOR_TYPE = Boolean.class;
+
+    public static final String PROPERTY_EXPORT_USE_LEGEND_WIDTH_KEY = PROPERTY_LEGEND_EXPORT_ROOT_KEY + "use.legend.size";
+    public static final String PROPERTY_EXPORT_USE_LEGEND_WIDTH_LABEL = "Scale to File Size";
+    public static final String PROPERTY_EXPORT_USE_LEGEND_WIDTH_TOOLTIP = "Resize to desired legend size";
+    private static final String PROPERTY_EXPORT_USE_LEGEND_WIDTH_ALIAS = PROPERTY_LEGEND_EXPORT_ROOT_ALIAS + "UseLegendSize";
+    public static final boolean PROPERTY_EXPORT_USE_LEGEND_WIDTH_DEFAULT = true;
+    public static final Class PROPERTY_EXPORT_USE_LEGEND_WIDTH_TYPE = Boolean.class;
+
+    public static final String PROPERTY_EXPORT_LEGEND_WIDTH_KEY = PROPERTY_LEGEND_EXPORT_ROOT_KEY + ".legend.size";
+    public static final String PROPERTY_EXPORT_LEGEND_WIDTH_LABEL = "File Size";
+    public static final String PROPERTY_EXPORT_LEGEND_WIDTH_TOOLTIP = "Width (in pixels) of legend image file (height if vertical image)";
+    private static final String PROPERTY_EXPORT_LEGEND_WIDTH_ALIAS = PROPERTY_LEGEND_EXPORT_ROOT_ALIAS + "LegendSize";
+    public static final int PROPERTY_EXPORT_LEGEND_WIDTH_DEFAULT = 1400;
+    public static final Class PROPERTY_EXPORT_LEGEND_WIDTH_TYPE = Integer.class;
+
+
+
+
+
+    // ---------------------------------------------------------
+
+    public static final String PROPERTY_NAME_RASTER = "raster";
+
+
+
+
+    // Property Setting: Restore Defaults
+
+    private static final String PROPERTY_RESTORE_KEY_SUFFIX = PROPERTY_ROOT_KEY + ".restore.defaults";
+
+    public static final String PROPERTY_RESTORE_SECTION_KEY = PROPERTY_RESTORE_KEY_SUFFIX + ".section";
+    public static final String PROPERTY_RESTORE_SECTION_LABEL = "Restore";
+    public static final String PROPERTY_RESTORE_SECTION_TOOLTIP = "Restores preferences to the package defaults";
+
+    public static final String PROPERTY_RESTORE_DEFAULTS_KEY = PROPERTY_RESTORE_KEY_SUFFIX + ".apply";
+    public static final String PROPERTY_RESTORE_DEFAULTS_LABEL = "Default (" + COLOR_MIXED_CASE + " Bar Legend Preferences)";
+    public static final String PROPERTY_RESTORE_DEFAULTS_TOOLTIP = "Restore all " + COLOR_LOWER_CASE + " bar legend preferences to the original default";
+    public static final boolean PROPERTY_RESTORE_DEFAULTS_DEFAULT = false;
+
+
+
+
+
+
+
+
+
+    /**
+     * @deprecated since BEAM 4.7, no replacement; kept for compatibility of sessions
+     */
+    @Deprecated
+    private static final String PROPERTY_NAME_TRANSFORM = "imageToModelTransform";
+
+
+    @Override
+    public boolean isValidFor(LayerContext ctx) {
+        return true;
+    }
+
+    @Override
+    public Layer createLayer(LayerContext ctx, PropertySet configuration) {
+        return new ColorBarLayer(this, (RasterDataNode) configuration.getValue(PROPERTY_NAME_RASTER),
+                configuration);
+    }
+
+    @Override
+    public PropertySet createLayerConfig(LayerContext ctx) {
+        final PropertyContainer vc = new PropertyContainer();
+
+
+        // Title Section
+//
+//        final Property titleSectionModel = Property.create(PROPERTY_TITLE_TEXT_SECTION_KEY, Boolean.class, true, true);
+//        titleSectionModel.getDescriptor().setAlias(PROPERTY_TITLE_TEXT_SECTION_ALIAS);
+//        vc.addProperty(titleSectionModel);
+
+        final Property titleParameterTextModel = Property.create(PROPERTY_TITLE_TEXT_KEY,
+                PROPERTY_TITLE_TEXT_TYPE,
+                PROPERTY_TITLE_TEXT_DEFAULT,
+                true);
+        titleParameterTextModel.getDescriptor().setAlias(PROPERTY_TITLE_TEXT_ALIAS);
+        vc.addProperty(titleParameterTextModel);
+
+
+        final Property titleUnitsTextModel = Property.create(PROPERTY_UNITS_TEXT_KEY,
+                PROPERTY_UNITS_TEXT_TYPE,
+                PROPERTY_UNITS_TEXT_DEFAULT,
+                true);
+        titleUnitsTextModel.getDescriptor().setAlias(PROPERTY_UNITS_TEXT_ALIAS);
+        vc.addProperty(titleUnitsTextModel);
+
+
+
+
+        // Orientation Section
+
+        final Property formattingSectionModel = Property.create(PROPERTY_ORIENTATION_SECTION_KEY, Boolean.class, true, true);
+        formattingSectionModel.getDescriptor().setAlias(PROPERTY_ORIENTATION_SECTION_ALIAS);
+        vc.addProperty(formattingSectionModel);
+
+        final Property formattingOrientationModel = Property.create(PROPERTY_ORIENTATION_KEY, PROPERTY_ORIENTATION_TYPE, true, true);
+        formattingOrientationModel.getDescriptor().setAlias(PROPERTY_ORIENTATION_ALIAS);
+        vc.addProperty(formattingOrientationModel);
+
+        final Property reversePaletteModel = Property.create(PROPERTY_ORIENTATION_REVERSE_PALETTE_KEY, PROPERTY_ORIENTATION_REVERSE_PALETTE_TYPE, true, true);
+        reversePaletteModel.getDescriptor().setAlias(PROPERTY_ORIENTATION_REVERSE_PALETTE_ALIAS);
+        vc.addProperty(reversePaletteModel);
+
+
+
+        // Tick Label Values
+
+        final Property labelValuesSectionModel = Property.create(PROPERTY_LABEL_VALUES_SECTION_KEY, Boolean.class, true, true);
+        labelValuesSectionModel.getDescriptor().setAlias(PROPERTY_LABEL_VALUES_SECTION_ALIAS);
+        vc.addProperty(labelValuesSectionModel);
+
+        final Property labelValuesModeModel = Property.create(PROPERTY_LABEL_VALUES_MODE_KEY, String.class, PROPERTY_LABEL_VALUES_MODE_DEFAULT, true);
+        labelValuesModeModel.getDescriptor().setAlias(PROPERTY_LABEL_VALUES_MODE_ALIAS);
+        vc.addProperty(labelValuesModeModel);
+
+        final Property labelValuesCountModel = Property.create(PROPERTY_LABEL_VALUES_COUNT_KEY, Integer.class, PROPERTY_LABEL_VALUES_COUNT_DEFAULT, true);
+        labelValuesCountModel.getDescriptor().setAlias(PROPERTY_LABEL_VALUES_COUNT_ALIAS);
+        vc.addProperty(labelValuesCountModel);
+
+        final Property labelValuesActualModel = Property.create(PROPERTY_LABEL_VALUES_ACTUAL_KEY, String.class, PROPERTY_LABEL_VALUES_ACTUAL_DEFAULT, true);
+        labelValuesActualModel.getDescriptor().setAlias(PROPERTY_LABEL_VALUES_ACTUAL_ALIAS);
+        vc.addProperty(labelValuesActualModel);
+
+        final Property populateLabelValesTextfieldModel = Property.create(PROPERTY_POPULATE_VALUES_TEXTFIELD_KEY, Boolean.class, PROPERTY_POPULATE_VALUES_TEXTFIELD_DEFAULT , true);
+        populateLabelValesTextfieldModel.getDescriptor().setAlias(PROPERTY_POPULATE_VALUES_TEXTFIELD_ALIAS);
+        vc.addProperty(populateLabelValesTextfieldModel);
+
+        final Property labelValuesScalingFactorModel = Property.create(PROPERTY_LABEL_VALUES_SCALING_KEY, Double.class, PROPERTY_LABEL_VALUES_SCALING_DEFAULT, true);
+        labelValuesScalingFactorModel.getDescriptor().setAlias(PROPERTY_LABEL_VALUES_SCALING_ALIAS);
+        vc.addProperty(labelValuesScalingFactorModel);
+
+        final Property labelValuesDecimalPlacesModel = Property.create(PROPERTY_LABEL_VALUES_DECIMAL_PLACES_KEY, Integer.class, PROPERTY_LABEL_VALUES_DECIMAL_PLACES_DEFAULT, true);
+        labelValuesDecimalPlacesModel.getDescriptor().setAlias(PROPERTY_LABEL_VALUES_DECIMAL_PLACES_ALIAS);
+        vc.addProperty(labelValuesDecimalPlacesModel);
+
+        final Property labelValuesForceDecimalPlacesModel = Property.create(PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_KEY, Boolean.class, PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_DEFAULT , true);
+        labelValuesForceDecimalPlacesModel.getDescriptor().setAlias(PROPERTY_LABEL_VALUES_FORCE_DECIMAL_PLACES_ALIAS);
+        vc.addProperty(labelValuesForceDecimalPlacesModel);
+
+
+
+        final Property weightToleranceModel = Property.create(PROPERTY_WEIGHT_TOLERANCE_KEY, Double.class, PROPERTY_WEIGHT_TOLERANCE_DEFAULT, true);
+        weightToleranceModel.getDescriptor().setAlias(PROPERTY_WEIGHT_TOLERANCE_ALIAS);
+        vc.addProperty(weightToleranceModel);
+
+
+        // Placement Section
+
+        final Property locationSectionModel = Property.create(PROPERTY_LOCATION_SECTION_KEY, Boolean.class, true, true);
+        locationSectionModel.getDescriptor().setAlias(PROPERTY_LOCATION_SECTION_ALIAS);
+        vc.addProperty(locationSectionModel);
+
+        final Property locationInsideModel = Property.create(PROPERTY_LOCATION_INSIDE_KEY, PROPERTY_LOCATION_INSIDE_TYPE, true, true);
+        locationInsideModel.getDescriptor().setAlias(PROPERTY_LOCATION_INSIDE_ALIAS);
+        vc.addProperty(locationInsideModel);
+
+        final Property locationEdgeModel = Property.create(PROPERTY_LOCATION_PLACEMENT_KEY,
+                PROPERTY_LOCATION_PLACEMENT_TYPE, true, true);
+        locationEdgeModel.getDescriptor().setAlias(PROPERTY_LOCATION_PLACEMENT_ALIAS);
+        vc.addProperty(locationEdgeModel);
+
+        final Property locationOffsetModel = Property.create(PROPERTY_LOCATION_OFFSET_KEY, PROPERTY_LOCATION_OFFSET_TYPE, true, true);
+        locationOffsetModel.getDescriptor().setAlias(PROPERTY_LOCATION_OFFSET_ALIAS);
+        vc.addProperty(locationOffsetModel);
+
+        final Property locationShiftModel = Property.create(PROPERTY_LOCATION_SHIFT_KEY, PROPERTY_LOCATION_SHIFT_TYPE, true, true);
+        locationShiftModel.getDescriptor().setAlias(PROPERTY_LOCATION_SHIFT_ALIAS);
+        vc.addProperty(locationShiftModel);
+
+        final Property titleVerticalAnchorModel = Property.create(PROPERTY_LOCATION_TITLE_VERTICAL_KEY,
+                PROPERTY_LOCATION_TITLE_VERTICAL_TYPE, true, true);
+        titleVerticalAnchorModel.getDescriptor().setAlias(PROPERTY_LOCATION_TITLE_VERTICAL_ALIAS);
+        vc.addProperty(titleVerticalAnchorModel);
+
+
+
+        // Size & Scaling Section
+
+        final Property scalingSectionModel = Property.create(PROPERTY_IMAGE_SCALING_SECTION_KEY, Boolean.class, true, true);
+        scalingSectionModel.getDescriptor().setAlias(PROPERTY_IMAGE_SCALING_SECTION_ALIAS);
+        vc.addProperty(scalingSectionModel);
+
+        final Property locationApplySizeScalingModel = Property.create(PROPERTY_IMAGE_SCALING_APPLY_SIZE_KEY, PROPERTY_IMAGE_SCALING_APPLY_SIZE_TYPE, true, true);
+        locationApplySizeScalingModel.getDescriptor().setAlias(PROPERTY_IMAGE_SCALING_APPLY_SIZE_ALIAS);
+        vc.addProperty(locationApplySizeScalingModel);
+
+        final Property locationSizeScalingModel = Property.create(PROPERTY_IMAGE_SCALING_SIZE_KEY, ColorBarLayerType.PROPERTY_IMAGE_SCALING_SIZE_TYPE, true, true);
+        locationSizeScalingModel.getDescriptor().setAlias(PROPERTY_IMAGE_SCALING_SIZE_ALIAS);
+        vc.addProperty(locationSizeScalingModel);
+
+        final Property colorbarLengthModel = Property.create(PROPERTY_COLORBAR_LENGTH_KEY, ColorBarLayerType.PROPERTY_COLORBAR_LENGTH_TYPE, true, true);
+        colorbarLengthModel.getDescriptor().setAlias(PROPERTY_COLORBAR_LENGTH_ALIAS);
+        vc.addProperty(colorbarLengthModel);
+
+        final Property colorbarWidthModel = Property.create(PROPERTY_COLORBAR_WIDTH_KEY, ColorBarLayerType.PROPERTY_COLORBAR_WIDTH_TYPE, true, true);
+        colorbarWidthModel.getDescriptor().setAlias(PROPERTY_COLORBAR_WIDTH_ALIAS);
+        vc.addProperty(colorbarWidthModel);
+
+
+
+
+        // Title Format Section
+
+        final Property titleParameterSectionModel = Property.create(PROPERTY_TITLE_SECTION_KEY,
+                Boolean.class,
+                true,
+                true);
+        titleParameterSectionModel.getDescriptor().setAlias(PROPERTY_TITLE_SECTION_ALIAS);
+        vc.addProperty(titleParameterSectionModel);
+
+
+        final Property titleParameterShowModel = Property.create(PROPERTY_TITLE_SHOW_KEY,
+                PROPERTY_TITLE_SHOW_TYPE,
+                PROPERTY_TITLE_SHOW_DEFAULT,
+                true);
+        titleParameterShowModel.getDescriptor().setAlias(PROPERTY_TITLE_SHOW_ALIAS);
+        vc.addProperty(titleParameterShowModel);
+
+
+        final Property titleParameterFontSizeModel = Property.create(PROPERTY_TITLE_FONT_SIZE_KEY,
+                PROPERTY_TITLE_FONT_SIZE_TYPE,
+                PROPERTY_TITLE_FONT_SIZE_DEFAULT,
+                true);
+        titleParameterFontSizeModel.getDescriptor().setAlias(PROPERTY_TITLE_FONT_SIZE_ALIAS);
+        vc.addProperty(titleParameterFontSizeModel);
+
+        final Property titleParameterBoldModel = Property.create(PROPERTY_TITLE_FONT_BOLD_KEY,
+                PROPERTY_TITLE_FONT_BOLD_TYPE,
+                PROPERTY_TITLE_FONT_BOLD_DEFAULT,
+                true);
+        titleParameterBoldModel.getDescriptor().setAlias(PROPERTY_TITLE_FONT_BOLD_ALIAS);
+        vc.addProperty(titleParameterBoldModel);
+
+
+        final Property titleParameterItalicModel = Property.create(PROPERTY_TITLE_FONT_ITALIC_KEY,
+                PROPERTY_TITLE_FONT_ITALIC_TYPE,
+                PROPERTY_TITLE_FONT_ITALIC_DEFAULT,
+                true);
+        titleParameterItalicModel.getDescriptor().setAlias(PROPERTY_TITLE_FONT_ITALIC_ALIAS);
+        vc.addProperty(titleParameterItalicModel);
+
+
+        final Property titleParameterFontNameModel = Property.create(PROPERTY_TITLE_FONT_NAME_KEY,
+                PROPERTY_TITLE_FONT_NAME_TYPE,
+                PROPERTY_TITLE_FONT_NAME_DEFAULT,
+                true);
+        titleParameterFontNameModel.getDescriptor().setAlias(PROPERTY_TITLE_FONT_NAME_ALIAS);
+        vc.addProperty(titleParameterFontNameModel);
+
+
+        final Property titleParameterColorModel = Property.create(PROPERTY_TITLE_COLOR_KEY,
+                PROPERTY_TITLE_COLOR_TYPE,
+                PROPERTY_TITLE_COLOR_DEFAULT,
+                true);
+        titleParameterColorModel.getDescriptor().setAlias(PROPERTY_TITLE_COLOR_ALIAS);
+        vc.addProperty(titleParameterColorModel);
+
+
+
+
+
+
+
+        // Units Section
+
+        final Property titleUnitsSectionModel = Property.create(PROPERTY_UNITS_SECTION_KEY,
+                Boolean.class,
+                true,
+                true);
+        titleUnitsSectionModel.getDescriptor().setAlias(PROPERTY_UNITS_SECTION_ALIAS);
+        vc.addProperty(titleUnitsSectionModel);
+
+
+        final Property titleUnitsShowModel = Property.create(PROPERTY_UNITS_SHOW_KEY,
+                PROPERTY_UNITS_SHOW_TYPE,
+                PROPERTY_UNITS_SHOW_DEFAULT,
+                true);
+        titleUnitsShowModel.getDescriptor().setAlias(PROPERTY_UNITS_SHOW_ALIAS);
+        vc.addProperty(titleUnitsShowModel);
+
+
+        final Property titleUnitsFontSizeModel = Property.create(PROPERTY_UNITS_FONT_SIZE_KEY,
+                PROPERTY_UNITS_FONT_SIZE_TYPE,
+                PROPERTY_UNITS_FONT_SIZE_DEFAULT,
+                true);
+        titleUnitsFontSizeModel.getDescriptor().setAlias(PROPERTY_UNITS_FONT_SIZE_ALIAS);
+        vc.addProperty(titleUnitsFontSizeModel);
+
+
+        final Property titleUnitsBoldModel = Property.create(PROPERTY_UNITS_FONT_BOLD_KEY,
+                PROPERTY_UNITS_FONT_BOLD_TYPE,
+                PROPERTY_UNITS_FONT_BOLD_DEFAULT,
+                true);
+        titleUnitsBoldModel.getDescriptor().setAlias(PROPERTY_UNITS_FONT_BOLD_ALIAS);
+        vc.addProperty(titleUnitsBoldModel);
+
+
+        final Property titleUnitsItalicModel = Property.create(PROPERTY_UNITS_FONT_ITALIC_KEY,
+                PROPERTY_UNITS_FONT_ITALIC_TYPE,
+                PROPERTY_UNITS_FONT_ITALIC_DEFAULT,
+                true);
+        titleUnitsItalicModel.getDescriptor().setAlias(PROPERTY_UNITS_FONT_ITALIC_ALIAS);
+        vc.addProperty(titleUnitsItalicModel);
+
+
+        final Property titleUnitsFontNameModel = Property.create(PROPERTY_UNITS_FONT_NAME_KEY,
+                PROPERTY_UNITS_FONT_NAME_TYPE,
+                PROPERTY_UNITS_FONT_NAME_DEFAULT,
+                true);
+        titleUnitsFontNameModel.getDescriptor().setAlias(PROPERTY_UNITS_FONT_NAME_ALIAS);
+        vc.addProperty(titleUnitsFontNameModel);
+
+
+        final Property titleUnitsColorModel = Property.create(PROPERTY_UNITS_FONT_COLOR_KEY,
+                PROPERTY_UNITS_FONT_COLOR_TYPE,
+                PROPERTY_UNITS_FONT_COLOR_DEFAULT,
+                true);
+        titleUnitsColorModel.getDescriptor().setAlias(PROPERTY_UNITS_FONT_COLOR_ALIAS);
+        vc.addProperty(titleUnitsColorModel);
+
+
+
+
+        // Tick Label Format Section
+
+        final Property labelsSectionModel = Property.create(PROPERTY_LABELS_SECTION_KEY, Boolean.class, true, true);
+        labelsSectionModel.getDescriptor().setAlias(PROPERTY_LABELS_SECTION_ALIAS);
+        vc.addProperty(labelsSectionModel);
+
+        final Property labelsShowModel = Property.create(PROPERTY_LABELS_SHOW_KEY,
+                PROPERTY_LABELS_SHOW_TYPE,
+                PROPERTY_LABELS_SHOW_DEFAULT,
+                true);
+        labelsShowModel.getDescriptor().setAlias(PROPERTY_LABELS_SHOW_ALIAS);
+        vc.addProperty(labelsShowModel);
+
+        final Property textFontSizeModel = Property.create(PROPERTY_LABELS_FONT_SIZE_KEY, Integer.class, PROPERTY_LABELS_FONT_SIZE_DEFAULT, true);
+        textFontSizeModel.getDescriptor().setAlias(PROPERTY_LABELS_FONT_SIZE_ALIAS);
+        vc.addProperty(textFontSizeModel);
+
+        final Property textFontBoldModel = Property.create(PROPERTY_LABELS_FONT_BOLD_KEY, Boolean.class, PROPERTY_LABELS_FONT_BOLD_DEFAULT, true);
+        textFontBoldModel.getDescriptor().setAlias(PROPERTY_LABELS_FONT_BOLD_ALIAS);
+        vc.addProperty(textFontBoldModel);
+        final Property textFontItalicModel = Property.create(PROPERTY_LABELS_FONT_ITALIC_KEY, Boolean.class, PROPERTY_LABELS_FONT_ITALIC_DEFAULT, true);
+        textFontItalicModel.getDescriptor().setAlias(PROPERTY_LABELS_FONT_ITALIC_ALIAS);
+        vc.addProperty(textFontItalicModel);
+
+        final Property textFontModel = Property.create(PROPERTY_LABELS_FONT_NAME_KEY, String.class, PROPERTY_LABELS_FONT_NAME_DEFAULT, true);
+        textFontModel.getDescriptor().setAlias(PROPERTY_LABELS_FONT_NAME_ALIAS);
+        vc.addProperty(textFontModel);
+
+        final Property textFgColorModel = Property.create(PROPERTY_LABELS_FONT_COLOR_KEY, Color.class, PROPERTY_LABELS_FONT_COLOR_DEFAULT, true);
+        textFgColorModel.getDescriptor().setAlias(PROPERTY_LABELS_FONT_COLOR_ALIAS);
+        vc.addProperty(textFgColorModel);
+
+
+
+        // Tickmarks Section
+
+        final Property tickmarksSectionModel = Property.create(PROPERTY_TICKMARKS_SECTION_KEY, Boolean.class, true, true);
+        tickmarksSectionModel.getDescriptor().setAlias(PROPERTY_TICKMARKS_SECTION_ALIAS);
+        vc.addProperty(tickmarksSectionModel);
+
+        final Property tickMarkEnabledModel = Property.create(PROPERTY_TICKMARKS_SHOW_KEY, PROPERTY_TICKMARKS_SHOW_TYPE, PROPERTY_TICKMARKS_SHOW_DEFAULT, true);
+        tickMarkEnabledModel.getDescriptor().setAlias(PROPERTY_TICKMARKS_SHOW_ALIAS);
+        vc.addProperty(tickMarkEnabledModel);
+
+        final Property tickMarkLengthModel = Property.create(PROPERTY_TICKMARKS_LENGTH_KEY, PROPERTY_TICKMARKS_LENGTH_TYPE, PROPERTY_TICKMARKS_LENGTH_DEFAULT, true);
+        tickMarkLengthModel.getDescriptor().setAlias(PROPERTY_TICKMARKS_LENGTH_ALIAS);
+        vc.addProperty(tickMarkLengthModel);
+
+        final Property tickMarkWidthModel = Property.create(PROPERTY_TICKMARKS_WIDTH_KEY, PROPERTY_TICKMARKS_WIDTH_TYPE, PROPERTY_TICKMARKS_LENGTH_DEFAULT, true);
+        tickMarkWidthModel.getDescriptor().setAlias(PROPERTY_TICKMARKS_WIDTH_ALIAS);
+        vc.addProperty(tickMarkWidthModel);
+
+        final Property tickmarkColorModel = Property.create(PROPERTY_TICKMARKS_COLOR_KEY, PROPERTY_TICKMARKS_COLOR_TYPE, PROPERTY_TICKMARKS_COLOR_DEFAULT, true);
+        tickmarkColorModel.getDescriptor().setAlias(PROPERTY_TICKMARKS_COLOR_ALIAS);
+        vc.addProperty(tickmarkColorModel);
+
+
+        // Palette Border Section
+
+        final Property borderSectionModel = Property.create(PROPERTY_PALETTE_BORDER_SECTION_KEY, Boolean.class, true, true);
+        borderSectionModel.getDescriptor().setAlias(PROPERTY_PALETTE_BORDER_SECTION_ALIAS);
+        vc.addProperty(borderSectionModel);
+
+        final Property borderEnabledModel = Property.create(PROPERTY_PALETTE_BORDER_SHOW_KEY, Boolean.class, PROPERTY_PALETTE_BORDER_SHOW_DEFAULT, true);
+        borderEnabledModel.getDescriptor().setAlias(PROPERTY_PALETTE_BORDER_SHOW_ALIAS);
+        vc.addProperty(borderEnabledModel);
+
+        final Property borderWidthModel = Property.create(PROPERTY_PALETTE_BORDER_WIDTH_KEY, PROPERTY_PALETTE_BORDER_WIDTH_TYPE, PROPERTY_PALETTE_BORDER_WIDTH_DEFAULT, true);
+        borderWidthModel.getDescriptor().setAlias(PROPERTY_PALETTE_BORDER_WIDTH_ALIAS);
+        vc.addProperty(borderWidthModel);
+
+        final Property borderColorModel = Property.create(PROPERTY_PALETTE_BORDER_COLOR_KEY, Color.class, PROPERTY_PALETTE_BORDER_COLOR_DEFAULT, true);
+        borderColorModel.getDescriptor().setAlias(PROPERTY_PALETTE_BORDER_COLOR_ALIAS);
+        vc.addProperty(borderColorModel);
+
+
+
+
+        // Backdrop Section
+
+        final Property insideLabelsSectionModel = Property.create(PROPERTY_BACKDROP_SECTION_KEY, Boolean.class, true, true);
+        insideLabelsSectionModel.getDescriptor().setAlias(PROPERTY_BACKDROP_SECTION_ALIAS);
+        vc.addProperty(insideLabelsSectionModel);
+
+        final Property backdropShowModel = Property.create(PROPERTY_BACKDROP_SHOW_KEY, Boolean.class, PROPERTY_BACKDROP_SHOW_DEFAULT, true);
+        backdropShowModel.getDescriptor().setAlias(PROPERTY_BACKDROP_SHOW_ALIAS);
+        vc.addProperty(backdropShowModel);
+
+        final Property backdropTransparencyModel = Property.create(PROPERTY_BACKDROP_TRANSPARENCY_KEY, Double.class, PROPERTY_BACKDROP_TRANSPARENCY_DEFAULT, true);
+        backdropTransparencyModel.getDescriptor().setAlias(PROPERTY_BACKDROP_TRANSPARENCY_ALIAS);
+        vc.addProperty(backdropTransparencyModel);
+
+        final Property backdropColorModel = Property.create(PROPERTY_BACKDROP_COLOR_KEY, Color.class, PROPERTY_BACKDROP_COLOR_DEFAULT, true);
+        backdropColorModel.getDescriptor().setAlias(PROPERTY_BACKDROP_COLOR_ALIAS);
+        vc.addProperty(backdropColorModel);
+
+
+
+        // Legend Border Section
+
+        final Property backdropBorderSectionModel = Property.create(PROPERTY_LEGEND_BORDER_SECTION_KEY, Boolean.class, true, true);
+        backdropBorderSectionModel.getDescriptor().setAlias(PROPERTY_LEGEND_BORDER_SECTION_ALIAS);
+        vc.addProperty(backdropBorderSectionModel);
+
+        final Property backdropBorderShowModel = Property.create(PROPERTY_LEGEND_BORDER_SHOW_KEY, Boolean.class, PROPERTY_LEGEND_BORDER_SHOW_DEFAULT, true);
+        backdropBorderShowModel.getDescriptor().setAlias(PROPERTY_LEGEND_BORDER_SHOW_ALIAS);
+        vc.addProperty(backdropBorderShowModel);
+
+        final Property backdropBorderWidthModel = Property.create(PROPERTY_LEGEND_BORDER_WIDTH_KEY, Integer.class, PROPERTY_LEGEND_BORDER_WIDTH_DEFAULT, true);
+        backdropBorderWidthModel.getDescriptor().setAlias(PROPERTY_LEGEND_BORDER_WIDTH_ALIAS);
+        vc.addProperty(backdropBorderWidthModel);
+
+        final Property backdropBorderColorModel = Property.create(PROPERTY_LEGEND_BORDER_COLOR_KEY, Color.class, PROPERTY_LEGEND_BORDER_COLOR_DEFAULT, true);
+        backdropBorderColorModel.getDescriptor().setAlias(PROPERTY_LEGEND_BORDER_COLOR_ALIAS);
+        vc.addProperty(backdropBorderColorModel);
+
+
+
+
+        // Legend Border Section
+
+        final Property exportSectionModel = Property.create(PROPERTY_LEGEND_EXPORT_SECTION_KEY, Boolean.class, true, true);
+        exportSectionModel.getDescriptor().setAlias(PROPERTY_LEGEND_EXPORT_SECTION_ALIAS);
+        vc.addProperty(exportSectionModel);
+
+        final Property exportEditorShowModel = Property.create(PROPERTY_EXPORT_EDITOR_SHOW_KEY, Boolean.class, PROPERTY_EXPORT_EDITOR_SHOW_DEFAULT, true);
+        exportEditorShowModel.getDescriptor().setAlias(PROPERTY_EXPORT_EDITOR_SHOW_ALIAS);
+        vc.addProperty(exportEditorShowModel);
+
+        final Property exportBWColorShowModel = Property.create(PROPERTY_EXPORT_USE_BW_COLOR_KEY, Boolean.class, PROPERTY_EXPORT_USE_BW_COLOR_DEFAULT, true);
+        exportBWColorShowModel.getDescriptor().setAlias(PROPERTY_EXPORT_USE_BW_COLOR_ALIAS);
+        vc.addProperty(exportBWColorShowModel);
+
+        final Property exportUseLegendWidthModel = Property.create(PROPERTY_EXPORT_USE_LEGEND_WIDTH_KEY, Boolean.class, PROPERTY_EXPORT_USE_LEGEND_WIDTH_DEFAULT, true);
+        exportUseLegendWidthModel.getDescriptor().setAlias(PROPERTY_EXPORT_USE_LEGEND_WIDTH_ALIAS);
+        vc.addProperty(exportUseLegendWidthModel);
+
+        final Property exportLegendWidthModel = Property.create(PROPERTY_EXPORT_LEGEND_WIDTH_KEY, Integer.class, PROPERTY_EXPORT_LEGEND_WIDTH_DEFAULT, true);
+        exportLegendWidthModel.getDescriptor().setAlias(PROPERTY_EXPORT_LEGEND_WIDTH_ALIAS);
+        vc.addProperty(exportLegendWidthModel);
+
+
+
+
+
+
+        // Other
+
+        final Property rasterModel = Property.create(PROPERTY_NAME_RASTER, RasterDataNode.class);
+        rasterModel.getDescriptor().setNotNull(true);
+        vc.addProperty(rasterModel);
+
+        final Property transformModel = Property.create(PROPERTY_NAME_TRANSFORM, new AffineTransform());
+        transformModel.getDescriptor().setTransient(true);
+        vc.addProperty(transformModel);
+
+
+
+
+        return vc;
+    }
+}

--- a/snap-core/src/main/resources/META-INF/services/com.bc.ceres.glayer.LayerType
+++ b/snap-core/src/main/resources/META-INF/services/com.bc.ceres.glayer.LayerType
@@ -1,4 +1,5 @@
 org.esa.snap.core.layer.GraticuleLayerType
+org.esa.snap.core.layer.ColorBarLayerType
 org.esa.snap.core.layer.NoDataLayerType
 org.esa.snap.core.layer.RasterImageLayerType
 org.esa.snap.core.layer.RgbImageLayerType


### PR DESCRIPTION
NOTE: this pull request contains files dependent on both snap-engine and snap-desktop, so both pull requests are needed.

Major update to the "Export Colour Legend Image" tool. The tool is now called "Colour Bar Legend" and features 3 components:

    Colour Bar Legend Layer Tool - adds the color bar legend as a layer onto the image in the currently active "View Window". Accessible via an icon shortcut in the "Overlay" Toolbar and also in "Menu > Layer > Colour Bar Legend Overlay".
    Colour Bar Legend Export Tool - exports to a file the color bar legend of the image in the currently active "View Window". Accessible by right clicking on the image in the "View Window" and also in "Menu > Other > Colour Bar Legend".
    (Note: if the color bar legend layer has already been created then this will have the same initial settings as that of the layer.)
    Colour Bar Legend Preferences Tool - enable users to set preferences for all color bar legend settings (except the actual text of the color bar title which is band dependent. Accessible in the menu "Preferences > Layer > Colour Bar Layer" tab.

A large selection of user customization options are available.

The labels can be manually entered and text can also be inserted for labels (for example "0:LOW, 5:MEDIUM, 10:HIGH" would place "LOW" where the value "0" would normally be place, etc.).

A single help page has been written to be accessed by all the Colour Bar Legend GUI components.

A limitation is that for the layer tool, the color bar image is a raster overlay without vector components for the text and labels (so images with a small number of total pixel may result in blurry color bar legends). Thoughts could be given to future revisions which place the text and labels directly on the layer as vector, however, this is not currently planned.
