### PR TITLE
SEADAS: Color Manipulation User Color Schemes (9.x)

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorManipulationDefaults.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ColorManipulationDefaults.java
@@ -33,7 +33,9 @@ public class ColorManipulationDefaults {
 
     // xml files used by the color scheme manager
     public static final String COLOR_SCHEME_LOOKUP_FILENAME = "color_palette_scheme_lookup.xml";
+    public static final String COLOR_SCHEME_LOOKUP_USER_FILENAME = "color_palette_scheme_lookup_user.xml";
     public static final String COLOR_SCHEMES_FILENAME = "color_palette_schemes.xml";
+    public static final String COLOR_SCHEMES_USER_FILENAME = "color_palette_schemes_user.xml";
 
     // Indicates which color palette contained within the color scheme xml to use
     public static final String OPTION_COLOR_STANDARD_SCHEME = "From Scheme STANDARD";

--- a/snap-core/src/main/java/org/esa/snap/core/util/ResourceInstaller.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/ResourceInstaller.java
@@ -51,6 +51,8 @@ public class ResourceInstaller {
     private final Path sourceBasePath;
     private final Path targetDirPath;
 
+    private boolean keepExistingResource = false;
+
     /**
      * Creates an instance with a given source to a given target.
      *
@@ -122,6 +124,11 @@ public class ResourceInstaller {
         if (!Files.exists(targetFile)) {
             return true;
         }
+
+        if (Files.exists(targetFile) && isKeepExistingResource()) {
+            return false;
+        }
+
         final Path realTargetFile = targetFile.toRealPath();
         final Path realResource = resource.toRealPath();
         final boolean sizeIsDifferent = Files.size(realTargetFile) != Files.size(realResource) && Files.size(realResource) != 0;
@@ -175,4 +182,11 @@ public class ResourceInstaller {
         }
     }
 
+    public boolean isKeepExistingResource() {
+        return keepExistingResource;
+    }
+
+    public void setKeepExistingResource(boolean keepExistingResource) {
+        this.keepExistingResource = keepExistingResource;
+    }
 }


### PR DESCRIPTION
Note: Spans both the snap-desktop and snap-engine repositories

Added the capability for users to edit a preferences text file which adds custom user color schemes to the Color Manipulation Tool.