### PR TITLE
[SCM-141] Add gitlab-ci.yaml to build & run UT on new CI platform

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+# Generated thanks to https://to-be-continuous.gitlab.io/kicker/ by frederick BALDO frederick.baldo@csgroup.eu 
+
+# included templates
+include:
+  # Maven template
+  - project: "to-be-continuous/maven"
+    ref: "3.2"
+    file: "templates/gitlab-ci-maven.yml"
+
+
+# variables
+variables:
+  MAVEN_IMAGE: "registry.hub.docker.com/library/maven:3.8-eclipse-temurin-8"
+
+
+# your pipeline stages
+stages:
+  - build
+  - test
+  - package-build
+  - package-test
+  - infra
+  - deploy
+  - acceptance
+  - publish
+  - infra-prod
+  - production

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,9 +19,8 @@ stages:
   - test
   - package-build
   - package-test
-  - infra
-  - deploy
-  - acceptance
-  - publish
-  - infra-prod
-  - production
+  # - deploy
+  # - acceptance
+  # - publish
+  # - infra-prod
+  # - production

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,12 +6,19 @@ include:
   - project: "to-be-continuous/maven"
     ref: "3.2"
     file: "templates/gitlab-ci-maven.yml"
+  # SonarQube template
+  - project: "to-be-continuous/sonar"
+    ref: "3.1"
+    file: "templates/gitlab-ci-sonar.yml"
 
+# secret variables
+# (define the variables below in your GitLab project variables)
+# SONAR_TOKEN: SonarQube authentication [token](https://docs.sonarqube.org/latest/user-guide/user-token/) (depends on your authentication method)
 
 # variables
 variables:
   MAVEN_IMAGE: "registry.hub.docker.com/library/maven:3.8-eclipse-temurin-8"
-
+  SONAR_HOST_URL: "http://sonarqube-sonarqube-lts.sonarqube.svc.cluster.local:9000"
 
 # your pipeline stages
 stages:
@@ -19,6 +26,7 @@ stages:
   - test
   - package-build
   - package-test
+  # - infra
   # - deploy
   # - acceptance
   # - publish

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
         <jide.version>3.6.1</jide.version>
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <buildDate>${maven.build.timestamp}</buildDate>
+        <sonar.projectKey>senbox-org_snap-engine_AYYxoTV6fae61wO2F_gz</sonar.projectKey>
+        <sonar.qualitygate.wait>true</sonar.qualitygate.wait>
     </properties>
 
     <modules>


### PR DESCRIPTION
Add first version of `.gitlab-ci.yaml` file.
Relative gitlab-ci project is [here](https://gitlab.com/senbox-org/snap-engine)
At the moment a runner will just pull the code and build the project.
More will come asap