### PR TITLE
[SCM-141]: Turn to custom file instead of to-be-continuous

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,34 +1,187 @@
-# Generated thanks to https://to-be-continuous.gitlab.io/kicker/ by frederick BALDO frederick.baldo@csgroup.eu 
-
-# included templates
 include:
-  # Maven template
-  - project: "to-be-continuous/maven"
-    ref: "3.2"
-    file: "templates/gitlab-ci-maven.yml"
-  # SonarQube template
-  - project: "to-be-continuous/sonar"
-    ref: "3.1"
-    file: "templates/gitlab-ci-sonar.yml"
+  - template: Security/Dependency-Scanning.gitlab-ci.yml
+  - template: Security/License-Scanning.gitlab-ci.yml
+  - template: Security/SAST.gitlab-ci.yml
+  - template: Security/Secret-Detection.gitlab-ci.yml
+# To contribute improvements to CI/CD templates, please follow the Development guide at:
+# https://docs.gitlab.com/ee/development/cicd/templates.html
+# This specific template is located at:
+# https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Maven.gitlab-ci.yml
 
-# secret variables
-# (define the variables below in your GitLab project variables)
-# SONAR_TOKEN: SonarQube authentication [token](https://docs.sonarqube.org/latest/user-guide/user-token/) (depends on your authentication method)
+# Build JAVA applications using Apache Maven (http://maven.apache.org)
+# For docker image tags see https://hub.docker.com/_/maven/
+#
+# For general lifecycle information see https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html
 
-# variables
+# This template will build and test your projects
+# * Caches downloaded dependencies and plugins between invocation.
+# * Verify but don't deploy merge requests.
+# * Deploy built artifacts from master branch only.
+
 variables:
-  MAVEN_IMAGE: "registry.hub.docker.com/library/maven:3.8-eclipse-temurin-8"
-  SONAR_HOST_URL: "http://sonarqube-sonarqube-lts.sonarqube.svc.cluster.local:9000"
+  # `showDateTime` will show the passed time in milliseconds. You need to specify `--batch-mode` to make this work.
+  MAVEN_OPTS: >-
+    -Dhttps.protocols=TLSv1.2
+    -Dmaven.repo.local=${CI_PROJECT_DIR}/.m2/repository
+    -Dorg.slf4j.simpleLogger.showDateTime=true
+    -Djava.awt.headless=true
 
-# your pipeline stages
+  # As of Maven 3.3.0 instead of this you MAY define these options in `.mvn/maven.config` so the same config is used
+  # when running from the command line.
+  # As of Maven 3.6.1, the use of `--no-tranfer-progress` (or `-ntp`) suppresses download and upload messages. The use
+  # of the `Slf4jMavenTransferListener` is no longer necessary.
+  # `installAtEnd` and `deployAtEnd` are only effective with recent version of the corresponding plugins.
+  MAVEN_CLI_OPTS: >-
+    --batch-mode
+    --errors
+    --fail-at-end
+    --show-version
+    --no-transfer-progress
+    -DinstallAtEnd=true
+    -DdeployAtEnd=true
+
+# This template uses the latest Maven 3 release, e.g., 3.8.6, and OpenJDK 8 (LTS)
+# for verifying and deploying images
+# Maven 3.8.x REQUIRES HTTPS repositories.
+# See https://maven.apache.org/docs/3.8.1/release-notes.html#how-to-fix-when-i-get-a-http-repository-blocked for more.
+image: maven:3.6.3-jdk-8
+
+# Cache downloaded dependencies and plugins between builds.
+# To keep cache across branches add 'key: "$CI_JOB_NAME"'
+# Be aware that `mvn deploy` will install the built jar into this repository. If you notice your cache size
+# increasing, consider adding `-Dmaven.install.skip=true` to `MAVEN_OPTS` or in `.mvn/maven.config`
+cache:
+  key: ${CI_COMMIT_REF_SLUG}
+  paths:
+    - ${CI_PROJECT_DIR}/.m2/repository
+    - ${CI_PROJECT_DIR}/.sonar/cache
+    
+# For merge requests do not `deploy` but only run `verify`.
+# See https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html
+.verify:
+  stage: test
+  script:
+    - 'mvn $MAVEN_CLI_OPTS verify'
+  except:
+    variables:
+      - $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+# Verify merge requests using JDK8
+verify:jdk8:
+  extends:
+    - .verify
+
 stages:
   - build
   - test
-  - package-build
-  - package-test
-  # - infra
-  # - deploy
-  # - acceptance
-  # - publish
-  # - infra-prod
-  # - production
+  - quality
+  - package
+  - deploy
+  - release
+
+Build:
+  tags: 
+    - build
+  stage: build 
+  script:
+    - mvn --batch-mode compile
+
+Test:
+  tags: 
+    - build 
+  stage: test 
+  script:
+    - find . -name "*.class" -exec touch {} \+
+    - mvn $MAVEN_CLI_OPTS org.apache.maven.plugins:maven-surefire-report-plugin:2.7.2:report
+    - echo "The code has been tested"
+  artifacts: 
+    paths: 
+      - "target/site/*.html"
+    reports:
+      junit: "target/site/*.html"
+
+Sonarqube:
+  tags: 
+    - build
+  stage: quality
+  variables:
+    SONAR_USER_HOME: "${CI_PROJECT_DIR}/.sonar"  # Defines the location of the analysis task cache
+    GIT_DEPTH: "0"  # Tells git to fetch all the branches of the project, required by the analysis task
+    MAVEN_CLI_OPTS: >-
+      -Dsonar.projectKey=senbox-org_snap-engine_AYY6yA9CkzLi54DzsgCJ
+      -Dsonar.host.url=${SONAR_HOST_URL}
+      -Dsonar.login=${SONAR_TOKEN}
+  script:
+    - find . -name "*.class" -exec touch {} \+
+    - mvn $MAVEN_CLI_OPTS sonar:sonar
+  allow_failure: true
+  only:
+    - master # or the name of your main branch
+    - merge_requests
+
+Package: 
+  tags: 
+    - build 
+  stage: test 
+  script:
+    - mvn $MAVEN_CLI_OPTS package -Dmaven.test.skip=true 
+    - echo "Packaging the code" 
+  artifacts: 
+    paths: 
+      - "target/*.jar" 
+  only: 
+    - master
+    - tags
+
+Deploy:
+  tags: 
+    - build 
+  stage: deploy 
+  script: 
+    - mvn $MAVEN_CLI_OPTS deploy -Dmaven.test.skip=true -s ci_settings.xml
+    - echo "installing the package in Nexus repository" 
+  dependencies:
+    - Package
+  only: 
+    - master
+    - tags
+  when: manual
+
+Docker:
+  image: docker:20.10.16
+  services:
+    - docker:20.10.16-dind
+  tags: 
+    - build 
+  stage: release
+  rules:
+    - if: $CI_COMMIT_TAG                 # Run this job when a tag is created
+  before_script:
+    - echo "Connect to registry as" ${CI_REGISTRY_USER}
+    - echo ${CI_REGISTRY_PASSWORD} | docker login -u ${CI_REGISTRY_USER} --password-stdin ${CI_REGISTRY}
+  variables:
+    CONTAINER_RELEASE_IMAGE: $CI_REGISTRY_IMAGE:latest
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ""
+  script:
+    - echo "push to docker registry"
+    - docker build -t ${CONTAINER_RELEASE_IMAGE} ${CI_PROJECT_DIR}
+    - docker push ${CONTAINER_RELEASE_IMAGE}
+  dependencies:
+    - Package
+
+Release:
+  tags: 
+    - build 
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  rules:
+    - if: $CI_COMMIT_TAG                 # Run this job when a tag is created
+  script:
+    - echo "Create release $CI_COMMIT_TAG"
+  release:                               # See https://docs.gitlab.com/ee/ci/yaml/#release for available properties
+    tag_name: '$CI_COMMIT_TAG'
+    description: '$CI_COMMIT_TAG'
+  dependencies:
+    - Package


### PR DESCRIPTION
We were using to-be-continuous for convinience & best practices respect but there was an issue for SonarQube