### PR TITLE
fixed dependency issues with imageio/jai

### DIFF
--- a/ceres-jai/pom.xml
+++ b/ceres-jai/pom.xml
@@ -20,17 +20,12 @@
             <artifactId>ceres-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>eu.esa.snap</groupId>
-            <artifactId>sun-image-classes</artifactId>
-            <version>1.0.0</version>
+            <groupId>javax.media.jai</groupId>
+            <artifactId>jai-core-openjdk</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.media</groupId>
-            <artifactId>jai_core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.media</groupId>
-            <artifactId>jai_codec</artifactId>
+            <groupId>javax.media.jai</groupId>
+            <artifactId>jai-codec-openjdk</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.media</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
                 <artifactId>lib-gdal</artifactId>
                 <version>${snap.version}</version>
             </dependency>
-          
+
             <dependency>
                 <groupId>org.esa.snap</groupId>
                 <artifactId>snap-gdal-reader</artifactId>
@@ -345,14 +345,14 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.media</groupId>
-                <artifactId>jai_core</artifactId>
-                <version>1.1.3</version>
+                <groupId>javax.media.jai</groupId>
+                <artifactId>jai-core-openjdk</artifactId>
+                <version>1.1.4</version>
             </dependency>
             <dependency>
-                <groupId>javax.media</groupId>
-                <artifactId>jai_codec</artifactId>
-                <version>1.1.3</version>
+                <groupId>javax.media.jai</groupId>
+                <artifactId>jai-codec-openjdk</artifactId>
+                <version>1.1.4</version>
             </dependency>
             <dependency>
                 <groupId>javax.media</groupId>
@@ -409,6 +409,16 @@
                 <groupId>it.geosolutions.imageio-ext</groupId>
                 <artifactId>imageio-ext-tiff</artifactId>
                 <version>1.3.3.2-SNAP</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>xerces</groupId>
+                        <artifactId>xercesImpl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -423,53 +433,130 @@
                         <groupId>org.ejml</groupId>
                         <artifactId>ejml-ddense</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-main</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-opengis</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-epsg-hsql</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-xml</artifactId>
+                <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-wms</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-shapefile</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-render</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-coverage</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
-
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-geotiff</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- this would pull in version 1.4.7, which is not compatible with our imageio-ext-tiff:1.3.3.2-SNAP-->
+                        <groupId>it.geosolutions.imageio-ext</groupId>
+                        <artifactId>imageio-ext-cog-reader</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools.xsd</groupId>
                 <artifactId>gt-xsd-gml3</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
 

--- a/snap-core/pom.xml
+++ b/snap-core/pom.xml
@@ -181,12 +181,6 @@
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-wms</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/snap-remote-products-repository/pom.xml
+++ b/snap-remote-products-repository/pom.xml
@@ -16,7 +16,8 @@
     <packaging>nbm</packaging>
 
     <name>SNAP Remote Products Repository</name>
-    <description>The Remote Products Repository allows downloading the products from a list of repositories.</description>
+    <description>The Remote Products Repository allows downloading the products from a list of repositories.
+    </description>
 
     <properties>
         <tao.version>1.0.4.7</tao.version>
@@ -61,7 +62,6 @@
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-hsql</artifactId>
-            <version>${geotools.version}</version>
         </dependency>
         <!-- Add the 'org.ejml:ejml-ddense' dependency here used by the TAO modules. -->
         <dependency>
@@ -73,6 +73,14 @@
             <artifactId>tao-data-model</artifactId>
             <version>${tao.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.persistence</groupId>
                     <artifactId>org.eclipse.persistence.moxy</artifactId>
@@ -123,6 +131,12 @@
             <groupId>ro.cs.tao</groupId>
             <artifactId>tao-datasources-aws</artifactId>
             <version>${tao.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
I did the PR again.

Please don't merge the PR before everyone has approve it. Only test and approve the PR.

Please note that I had to exclude imageio-ext-cog-reader, it is not compatible with the 1.1.3 version. So, no COG support with Imageio/JAI.
Please test supported data formats with special focus on GeoTiff.
•	using jai-core-openjdk:1.1.4 and jai-codec-openjdk:1.1.4
•	excluded jai_core:1.1.3 and jai_codec:1.1.3 from transitive dependencies
•	had to remove imageio-ext-cog-reader too because it is not compatible with the old 1.1.3 libs
•	excluded transitive dependencies to geotools modules from tao, pulled in old geotools version
•	removed sun-image-classes dependency; not needed when using our jai-core-openjdk dependency
