### PR TITLE
NO_JIRA-snap-remote-products-repository_update_tao_version_14092023

### DIFF
--- a/snap-remote-products-repository/pom.xml
+++ b/snap-remote-products-repository/pom.xml
@@ -19,7 +19,7 @@
     <description>The Remote Products Repository allows downloading the products from a list of repositories.</description>
 
     <properties>
-        <tao.version>1.4.5</tao.version>
+        <tao.version>1.4.6</tao.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Update the TAO dependency version to fix the Maven build errors.