### PR TITLE
Support for paths as operator parameters and in GUI

### DIFF
--- a/ceres-binding/src/main/java/com/bc/ceres/binding/ConverterRegistry.java
+++ b/ceres-binding/src/main/java/com/bc/ceres/binding/ConverterRegistry.java
@@ -31,6 +31,7 @@ import com.bc.ceres.binding.converters.FontConverter;
 import com.bc.ceres.binding.converters.IntegerConverter;
 import com.bc.ceres.binding.converters.IntervalConverter;
 import com.bc.ceres.binding.converters.LongConverter;
+import com.bc.ceres.binding.converters.PathConverter;
 import com.bc.ceres.binding.converters.PatternConverter;
 import com.bc.ceres.binding.converters.ShortConverter;
 import com.bc.ceres.binding.converters.StringConverter;
@@ -41,6 +42,7 @@ import java.awt.Font;
 import java.awt.geom.AffineTransform;
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -84,6 +86,7 @@ public class ConverterRegistry {
         setConverter(Color.class, new ColorConverter());
         setConverter(Date.class, new DateFormatConverter());
         setConverter(File.class, new FileConverter());
+        setConverter(Path.class, new PathConverter());
         setConverter(URL.class, new UrlConverter());
         setConverter(Font.class, new FontConverter());
         setConverter(Pattern.class, new PatternConverter());
@@ -139,7 +142,7 @@ public class ConverterRegistry {
         }
         return (Converter<T>) converter;
     }
-    
+
     // Initialization on demand holder idiom
     private static class Holder {
         private static final ConverterRegistry instance = new ConverterRegistry();

--- a/ceres-binding/src/main/java/com/bc/ceres/binding/converters/PathConverter.java
+++ b/ceres-binding/src/main/java/com/bc/ceres/binding/converters/PathConverter.java
@@ -1,0 +1,29 @@
+package com.bc.ceres.binding.converters;
+
+import com.bc.ceres.binding.Converter;
+
+import java.nio.file.Path;
+
+public class PathConverter implements Converter<Path> {
+
+  @Override
+  public Class<Path> getValueType() {
+    return Path.class;
+  }
+
+  @Override
+  public Path parse(String text) {
+    if (text.isEmpty()) {
+      return null;
+    }
+    return Path.of(text);
+  }
+
+  @Override
+  public String format(Path value) {
+    if (value == null) {
+      return "";
+    }
+    return value.toAbsolutePath().toString();
+  }
+}

--- a/ceres-binding/src/test/java/com/bc/ceres/binding/converters/PathConverterTest.java
+++ b/ceres-binding/src/test/java/com/bc/ceres/binding/converters/PathConverterTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2010 Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
+
+package com.bc.ceres.binding.converters;
+
+import com.bc.ceres.binding.ConversionException;
+import com.bc.ceres.binding.Converter;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+public class PathConverterTest extends AbstractConverterTest {
+
+    private PathConverter converter;
+
+    @Override
+    public Converter getConverter() {
+        if (converter == null) {
+            converter = new PathConverter();
+        }
+        return converter;
+    }
+
+    @Test
+    public void testConverter() throws ConversionException {
+        testValueType(Path.class);
+
+        Path value = Path.of("/usr/local");
+
+        testParseSuccess(value, "/usr/local");
+        testParseSuccess(null, "");
+
+        testFormatSuccess(value.toAbsolutePath().toString(), value);
+        testFormatSuccess("", null);
+
+        assertNullCorrectlyHandled();
+    }
+}

--- a/ceres-ui/src/main/java/com/bc/ceres/swing/binding/internal/PathEditor.java
+++ b/ceres-ui/src/main/java/com/bc/ceres/swing/binding/internal/PathEditor.java
@@ -1,0 +1,53 @@
+package com.bc.ceres.swing.binding.internal;
+
+import com.bc.ceres.binding.PropertyDescriptor;
+import com.bc.ceres.swing.binding.Binding;
+import com.bc.ceres.swing.binding.BindingContext;
+import com.bc.ceres.swing.binding.ComponentAdapter;
+import com.bc.ceres.swing.binding.PropertyEditor;
+
+import javax.swing.*;
+import java.awt.*;
+import java.nio.file.Path;
+
+/**
+ * An editor for {@link Path}s using a file chooser dialog. It is registered as service in the file
+ * <code>META-INF/services/com.bc.ceres.swing.binding.PropertyEditor</code>.
+ */
+public class PathEditor extends PropertyEditor {
+
+  @Override
+  public boolean isValidFor(PropertyDescriptor propertyDescriptor) {
+    return Path.class.isAssignableFrom(propertyDescriptor.getType())
+        && !Boolean.TRUE.equals(propertyDescriptor.getAttribute("directory"));
+  }
+
+  @Override
+  public JComponent createEditorComponent(PropertyDescriptor propertyDescriptor, BindingContext bindingContext) {
+    final JTextField textField = new JTextField();
+    final ComponentAdapter adapter = new TextComponentAdapter(textField);
+    final Binding binding = bindingContext.bind(propertyDescriptor.getName(), adapter);
+    final JPanel editorPanel = new JPanel(new BorderLayout(2, 2));
+    editorPanel.add(textField, BorderLayout.CENTER);
+    final JButton etcButton = new JButton("...");
+    final Dimension size = new Dimension(26, 16);
+    etcButton.setPreferredSize(size);
+    etcButton.setMinimumSize(size);
+    etcButton.addActionListener(e -> {
+      final JFileChooser fileChooser = new JFileChooser();
+      Path currentFile = (Path) binding.getPropertyValue();
+      if (currentFile != null) {
+        fileChooser.setSelectedFile(currentFile.toFile());
+      } else {
+        Path selectedFile = (Path) propertyDescriptor.getDefaultValue();
+        fileChooser.setSelectedFile(selectedFile.toFile());
+      }
+      int i = fileChooser.showDialog(editorPanel, "Select");
+      if (i == JFileChooser.APPROVE_OPTION && fileChooser.getSelectedFile() != null) {
+        binding.setPropertyValue(fileChooser.getSelectedFile());
+      }
+    });
+    editorPanel.add(etcButton, BorderLayout.EAST);
+    return editorPanel;
+  }
+}

--- a/ceres-ui/src/main/resources/META-INF/services/com.bc.ceres.swing.binding.PropertyEditor
+++ b/ceres-ui/src/main/resources/META-INF/services/com.bc.ceres.swing.binding.PropertyEditor
@@ -2,6 +2,7 @@ com.bc.ceres.swing.binding.internal.CheckBoxEditor
 com.bc.ceres.swing.binding.internal.NumericEditor
 com.bc.ceres.swing.binding.internal.TextFieldEditor
 com.bc.ceres.swing.binding.internal.FileEditor
+com.bc.ceres.swing.binding.internal.PathEditor
 com.bc.ceres.swing.binding.internal.DirectoryEditor
 com.bc.ceres.swing.binding.internal.SingleSelectionEditor
 com.bc.ceres.swing.binding.internal.MultiSelectionEditor

--- a/ceres-ui/src/test/java/com/bc/ceres/swing/binding/internal/PathEditorTest.java
+++ b/ceres-ui/src/test/java/com/bc/ceres/swing/binding/internal/PathEditorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2010 Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
+package com.bc.ceres.swing.binding.internal;
+
+import com.bc.ceres.binding.PropertyContainer;
+import com.bc.ceres.binding.PropertyDescriptor;
+import com.bc.ceres.swing.binding.BindingContext;
+import org.junit.Test;
+
+import javax.swing.*;
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+public class PathEditorTest {
+
+  @Test
+  public void testIsApplicable() {
+    PathEditor pathEditor = new PathEditor();
+
+    PropertyDescriptor fileDescriptor = new PropertyDescriptor("test", Path.class);
+    assertTrue(pathEditor.isValidFor(fileDescriptor));
+
+    PropertyDescriptor doubleDescriptor = new PropertyDescriptor("test", Double.TYPE);
+    assertFalse(pathEditor.isValidFor(doubleDescriptor));
+  }
+
+  @Test
+  public void testCreateEditorComponent() {
+    PathEditor pathEditor = new PathEditor();
+
+    PropertyContainer propertyContainer = PropertyContainer.createValueBacked(V.class);
+    BindingContext bindingContext = new BindingContext(propertyContainer);
+    PropertyDescriptor propertyDescriptor = propertyContainer.getDescriptor("filePath");
+    assertSame(Path.class, propertyDescriptor.getType());
+
+    assertTrue(pathEditor.isValidFor(propertyDescriptor));
+    JComponent editorComponent = pathEditor.createEditorComponent(propertyDescriptor, bindingContext);
+    assertNotNull(editorComponent);
+    assertSame(JPanel.class, editorComponent.getClass());
+    assertEquals(2, editorComponent.getComponentCount());
+
+    JComponent[] components = bindingContext.getBinding("filePath").getComponents();
+    assertEquals(1, components.length);
+    assertSame(JTextField.class, components[0].getClass());
+  }
+
+  private static class V {
+
+    Path filePath;
+  }
+}


### PR DESCRIPTION
I've added a converter and editor for Path objects. Both are like their File counterparts.
Tests are included. It should be a step away from the old file API.
