### PR TITLE
[SNAP-3631] Removed product name check

### DIFF
--- a/snap-bigtiff/src/test/java/org/esa/snap/dataio/bigtiff/BigGeoTiffWriterTest.java
+++ b/snap-bigtiff/src/test/java/org/esa/snap/dataio/bigtiff/BigGeoTiffWriterTest.java
@@ -3,8 +3,9 @@
  */
 package org.esa.snap.dataio.bigtiff;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -40,6 +41,9 @@ public class BigGeoTiffWriterTest {
         final Band bandInt16 = outProduct.addBand("B1", ProductData.TYPE_INT16);
         bandInt16.setDataElems(createShortData(getProductSize(), 23));
         ImageManager.getInstance().getSourceImage(bandInt16, 0);
+        final Band bandInt16_2 = outProduct.addBand("B2", ProductData.TYPE_INT16);
+        bandInt16_2.setDataElems(createShortData(getProductSize(), 23));
+        ImageManager.getInstance().getSourceImage(bandInt16_2, 0);
     }
 
     @After
@@ -57,6 +61,22 @@ public class BigGeoTiffWriterTest {
     public void testWriteProductIssue3631() {
     	// verify the name of the product
     	assertEquals("P", outProduct.getName());
+    	// check that the product has two bands named B1 and B2
+    	final String[] bandNames = outProduct.getBandNames();
+    	assertArrayEquals(new String[] {"B1", "B2"}, bandNames);
+
+    	// verify that two bands with the same name cannot be defined.
+    	final Band b2 = outProduct.getBand("B2");
+    	assertNotNull(b2);
+
+    	try {
+    		b2.setName("B1");
+    		fail("Two bands with the same name were defined!");
+    	} catch(Exception ex) {
+    		if (!(ex instanceof IllegalArgumentException)) {
+        		fail("Invalid exception thrown when setting the same name for a band: " + ex.getClass().getName());
+    		}
+    	}
     	
         // save the product with the name of a band
     	final File location = new File(TEST_DIR, "B1.tif");

--- a/snap-bigtiff/src/test/java/org/esa/snap/dataio/bigtiff/BigGeoTiffWriterTest.java
+++ b/snap-bigtiff/src/test/java/org/esa/snap/dataio/bigtiff/BigGeoTiffWriterTest.java
@@ -1,0 +1,94 @@
+/**
+ * 
+ */
+package org.esa.snap.dataio.bigtiff;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.esa.snap.core.dataio.ProductIO;
+import org.esa.snap.core.datamodel.Band;
+import org.esa.snap.core.datamodel.Product;
+import org.esa.snap.core.datamodel.ProductData;
+import org.esa.snap.core.image.ImageManager;
+import org.esa.snap.core.util.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the BigGeoTiff writter
+ */
+public class BigGeoTiffWriterTest {
+
+    private final static File TEST_DIR = new File("test_data_biggeotiff_writer");
+
+    private Product outProduct;
+
+    @Before
+    public void setup() {
+        if (!TEST_DIR.mkdirs()) {
+            fail("unable to create test directory");
+        }
+        final int width = 14;
+        final int height = 14;
+        outProduct = new Product("P", "T", width, height);
+        final Band bandInt16 = outProduct.addBand("B1", ProductData.TYPE_INT16);
+        bandInt16.setDataElems(createShortData(getProductSize(), 23));
+        ImageManager.getInstance().getSourceImage(bandInt16, 0);
+    }
+
+    @After
+    public void tearDown() {
+        if (!FileUtils.deleteTree(TEST_DIR)) {
+            fail("unable to delete test directory");
+        }
+    }
+
+    
+    /**
+     * Verify SNAP-3631
+     */
+    @Test
+    public void testWriteProductIssue3631() {
+    	// verify the name of the product
+    	assertEquals("P", outProduct.getName());
+    	
+        // save the product with the name of a band
+    	final File location = new File(TEST_DIR, "B1.tif");
+        final String bigGeoTiffFormatName = BigGeoTiffProductReaderPlugIn.FORMAT_NAME;
+        try {
+			ProductIO.writeProduct(outProduct, location.getAbsolutePath(), bigGeoTiffFormatName);
+		} catch (IOException e) {
+			fail("Error writing product: " + e.getMessage());
+		}
+
+        try(final Product readProd = ProductIO.readProduct(location, bigGeoTiffFormatName)) {
+			
+			// check that the name was updated
+			assertEquals("B1", readProd.getName());
+			
+		} catch (IOException e) {
+			fail("Error reading product: " + e.getMessage());
+		}
+    }
+    
+
+    private int getProductSize() {
+        final int w = outProduct.getSceneRasterWidth();
+        final int h = outProduct.getSceneRasterHeight();
+        return w * h;
+    }
+    
+    private static short[] createShortData(final int size, final int offset) {
+        final short[] shorts = new short[size];
+        for (int i = 0; i < shorts.length; i++) {
+            shorts[i] = (short) (i + offset);
+        }
+        return shorts;
+    }
+}

--- a/snap-bigtiff/src/test/java/org/esa/snap/dataio/bigtiff/BigGeoTiffWriterTest.java
+++ b/snap-bigtiff/src/test/java/org/esa/snap/dataio/bigtiff/BigGeoTiffWriterTest.java
@@ -21,6 +21,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.bc.ceres.annotation.STTM;
+
 /**
  * Tests for the BigGeoTiff writter
  */
@@ -58,6 +60,7 @@ public class BigGeoTiffWriterTest {
      * Verify SNAP-3631
      */
     @Test
+    @STTM("SNAP-3631")
     public void testWriteProductIssue3631() {
     	// verify the name of the product
     	assertEquals("P", outProduct.getName());

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/Product.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/Product.java
@@ -2874,9 +2874,22 @@ public class Product extends ProductNode implements Closeable {
         };
         acceptVisitor(productVisitorAdapter);
     }
-
+    
 
     /**
+     * Sets this product's name. 
+     * 
+     * <p> The name can be identical to a band name.
+     *
+     * @param name The name.
+     */
+    @Override
+    public void setName(final String name) {
+        Guardian.assertNotNull("name", name);
+        setNodeName(name.trim(), false, true);
+    }
+
+	/**
      * AutoGrouping can be used by an application to auto-group a long list of product nodes (e.g. bands)
      * as a tree of product nodes.
      *

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ProductNode.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ProductNode.java
@@ -99,19 +99,30 @@ public abstract class ProductNode extends ExtensibleObject {
      */
     public void setName(final String name) {
         Guardian.assertNotNull("name", name);
-        setNodeName(name.trim(), false);
+        setNodeName(name.trim(), false, false);
     }
 
-    private void setNodeName(String trimmedName, boolean silent) {
+    /**
+     * Perform various checks and set the new name . 
+     * 
+     * @param trimmedName the name
+     * @param silent signal or not the change
+     * @param allowSameName allow the name to be identical to another item's name 
+     */
+    protected void setNodeName(String trimmedName, boolean silent, boolean allowSameName) {
+    	// The method is made protected in order to be called from the Product class to 
+    	// allow the name of the product to be identical to the name of a band
+    	// This was needed for issue SNAP-3631
         Guardian.assertNotNullOrEmpty("name contains only spaces", trimmedName);
         if (!ObjectUtils.equalObjects(name, trimmedName)) {
-//			  Removed check in order to fix issue SNAP-3631
-//            Product product = getProduct();
-//            if (product != null) {
-//                Assert.argument(!product.containsRasterDataNode(trimmedName),
-//                                "The Product '" + product.getName() + "' already contains " +
-//                                "a raster data node with the name '" + trimmedName + "'.");
-//            }
+        	if (!allowSameName) {
+                Product product = getProduct();
+                if (product != null) {
+                    Assert.argument(!product.containsRasterDataNode(trimmedName),
+                                    "The Product '" + product.getName() + "' already contains " +
+                                    "a raster data node with the name '" + trimmedName + "'.");
+                }
+        	}
             if (!isValidNodeName(trimmedName)) {
                 throw new IllegalArgumentException("The given name '" + trimmedName + "' is not a valid node name.");
             }

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/ProductNode.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/ProductNode.java
@@ -105,12 +105,13 @@ public abstract class ProductNode extends ExtensibleObject {
     private void setNodeName(String trimmedName, boolean silent) {
         Guardian.assertNotNullOrEmpty("name contains only spaces", trimmedName);
         if (!ObjectUtils.equalObjects(name, trimmedName)) {
-            Product product = getProduct();
-            if (product != null) {
-                Assert.argument(!product.containsRasterDataNode(trimmedName),
-                                "The Product '" + product.getName() + "' already contains " +
-                                "a raster data node with the name '" + trimmedName + "'.");
-            }
+//			  Removed check in order to fix issue SNAP-3631
+//            Product product = getProduct();
+//            if (product != null) {
+//                Assert.argument(!product.containsRasterDataNode(trimmedName),
+//                                "The Product '" + product.getName() + "' already contains " +
+//                                "a raster data node with the name '" + trimmedName + "'.");
+//            }
             if (!isValidNodeName(trimmedName)) {
                 throw new IllegalArgumentException("The given name '" + trimmedName + "' is not a valid node name.");
             }


### PR DESCRIPTION
The check that didn't allow the name of the product to be identical to the name of a band was removed