### PR TITLE
Switch to unified Mockito version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
             ${project.basedir}/snap-engine-coverage/target/site/
             jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
+        <mockito.version>5.3.1</mockito.version>
     </properties>
 
     <modules>
@@ -664,7 +665,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>5.3.1</version>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/snap-stac/pom.xml
+++ b/snap-stac/pom.xml
@@ -17,7 +17,6 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mockito.version>3.4.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -70,7 +69,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Updated to a single Mockito version property across modules. Replaced mockito-inline with mockito-core dependency for consistency.