### PR TITLE
Get offset and subsampling from the stored values of the GeoRaster

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@
 include:
   # Maven template
   - project: "to-be-continuous/maven"
-    ref: "3.9.1"
+    ref: "3.11.1"
     file: "templates/gitlab-ci-maven.yml"
 
 # secret variables
@@ -33,18 +33,6 @@ variables:
     -Djava.awt.headless=true
     -Dnetbeans.verify.integrity=false
     -Denable.long.tests=true
-# your pipeline stages
-stages:
-  - build
-  - test
-  - package-build
-  - package-test
-  - infra
-  - deploy
-  - acceptance
-  - publish
-  - infra-prod
-  - production
 
 mvn-build:
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,13 +47,16 @@ mvn-build:
       - "${MAVEN_PROJECT_DIR}/LICENSE.html"
 
 mvn-sonar:
-  image: "registry.hub.docker.com/library/maven:3.9.1-eclipse-temurin-11"
+  variables:
+    MAVEN_IMAGE: "registry.hub.docker.com/library/maven:3.9.1-eclipse-temurin-11"
   allow_failure: true
   rules:
     - if: '$BUILD_FOR_INSTALLER == "false"'
 
 # Used to publish release on Github (only manual action & non blocking)
 mvn-release:
+  variables:
+    MAVEN_IMAGE: "registry.hub.docker.com/library/maven:3.9.1-eclipse-temurin-11"
   rules:
     - when: manual
       allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,8 @@ macos:
   needs: []
   script:
     - mvn clean package
+  # should be removed once macos pipeline will run on more recent version (actual is 10.14 an gdal-3-7-2)
+  allow_failure: true
 
 # Report on Github cf https://ecp-ci.gitlab.io/docs/guides/build-status-gitlab.html
 .report-status:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,133 +1,14 @@
 # included templates
 include:
-  # Maven template
-  - project: "to-be-continuous/maven"
-    ref: "3.11.1"
-    file: "templates/gitlab-ci-maven.yml"
+  - 'https://gitlab.com/senbox-org/snap-engine/raw/master/.gitlab-ci.yml'
 
-# secret variables
-# (define the variables below in your GitLab group/project variables)
-# SONAR_TOKEN: SonarQube authentication [token](https://docs.sonarqube.org/latest/user-guide/user-token/) (depends on your authentication method)
-# SONAR_LOGIN: SonarQube login (depends on your authentication method)
-# SONAR_PASSWORD: SonarQube password (depends on your authentication method)
-# MVN_SETTINGS_FILE: File variable at Group level. It is the Maven settings.xml file
-
-# variables
 variables:
   MAVEN_IMAGE: "ghcr.io/carlossg/maven:3.9.2-azulzulu-11"
-  MVN_FORBID_SNAPSHOT_DEPENDENCIES_DISABLED: "true"
-  MAVEN_DEPLOY_SNAPSHOT_WITH_SLUG_ENABLED: "false"
-  BUILD_FOR_INSTALLER: "false"
-  MAVEN_DEPLOY_ENABLED: "true"
-  MAVEN_DEPLOY_ARGS: "deploy"
-  MVN_SEMREL_RELEASE_DISABLED: "true"
-  MAVEN_SETTINGS_FILE: $MVN_SETTINGS_FILE
-  SONAR_BASE_ARGS: |
-    sonar:sonar -Dsonar.projectKey=${CI_PROJECT_NAME}
-    -Dsonar.exclusions=${CI_PROJECT_NAME}-coverage
-    -Dsonar.coverage.jacoco.xmlReportPaths=${CI_PROJECT_NAME}-coverage/target/site/jacoco-aggregate/jacoco.xml
-  MAVEN_OPTS: >-
-    -Dhttps.protocols=TLSv1.2
-    -Dmaven.repo.local=${MAVEN_CFG_DIR}/repository
-    -Dorg.slf4j.simpleLogger.showDateTime=true
-    -Djava.awt.headless=true
-    -Dnetbeans.verify.integrity=false
-    -Denable.long.tests=true
-
-mvn-build:
-  artifacts:
-    paths:
-      - "${MAVEN_PROJECT_DIR}/**/target/*.jar"
-      - "${MAVEN_PROJECT_DIR}/**/target/classes"
-      - "${MAVEN_PROJECT_DIR}/**/target/*.nbm"
-      #- "${MAVEN_PROJECT_DIR}/**/target/site/jacoco/jacoco.csv"
-      - "${MAVEN_PROJECT_DIR}/**/target/site"
-      - "${MAVEN_PROJECT_DIR}/**/target/surefire-reports"
-      - "${MAVEN_PROJECT_DIR}/etc"
-      - "${MAVEN_PROJECT_DIR}/LICENSE.html"
-
-mvn-sonar:
-  variables:
-    MAVEN_IMAGE: "registry.hub.docker.com/library/maven:3.9.1-eclipse-temurin-11"
-  allow_failure: true
-  rules:
-    - if: '$BUILD_FOR_INSTALLER == "false"'
-
-# Used to publish release on Github (only manual action & non blocking)
-mvn-release:
-  variables:
-    MAVEN_IMAGE: "registry.hub.docker.com/library/maven:3.9.1-eclipse-temurin-11"
-  rules:
-    - when: manual
-      allow_failure: true
 
 windows:
-  stage: test
-  tags: [windows]
-  rules:
-    - if: '$BUILD_FOR_INSTALLER == "false"'
   variables:
-    GIT_STRATEGY: clone
-    FF_ENABLE_JOB_CLEANUP: 'true'
-    FF_USE_WINDOWS_LEGACY_PROCESS_STRATEGY: 'false'
-    MAVEN_CFG_DIR: C:\\Windows\\System32\\config\\systemprofile\\.m2
     JAVA_HOME: C:\\Program Files\\Zulu\\zulu-11
-  allow_failure: false
-  needs: []
-  script:
-    - mvn clean package
 
 macos:
-  stage: test
-  tags: [mac]
-  image: "registry.hub.docker.com/library/maven:3.9.1-eclipse-temurin-11"
-  rules:
-    - if: '$BUILD_FOR_INSTALLER == "false"'
   variables:
-    # JAVA_HOME: /Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home
-    # JAVA_HOME: /Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
-    JAVA_HOME: /Library/Java/JavaVirtualMachines/liberica-jdk-11-full.jdk/Contents/Home 
-    TESTDATA_ROOT: "/Users/csro/testData"
-  needs: []
-  script:
-    - mvn clean package
-  # should be removed once macos pipeline will run on more recent version (actual is 10.14 an gdal-3-7-2)
-  allow_failure: true
-
-# Report on Github cf https://ecp-ci.gitlab.io/docs/guides/build-status-gitlab.html
-.report-status:
-  image: curlimages/curl
-  variables:
-    URL: "https://api.github.com/repos/${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}"
-    STATUS_NAME: snap-ci
-  script:
-    # For complete details on the GitHub API please see:
-    # https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
-    - |-
-      curl -X POST $URL -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" -d '{"state": "'$CI_JOB_NAME'", "context": "'$STATUS_NAME'", "target_url": "'$CI_PIPELINE_URL'", "description": "The build status"}'
-  environment:
-    name: reporting-github
-  dependencies: []
-
-pending:
-  stage: .pre
-  extends:
-    - .report-status
-  rules:
-    - if: '$BUILD_FOR_INSTALLER == "false"'
-
-success:
-  stage: .post
-  extends:
-    - .report-status
-  rules:
-    - if: '$BUILD_FOR_INSTALLER == "false"'
-  when: on_success
-
-failure:
-  stage: .post
-  extends:
-    - .report-status
-  rules:
-    - if: '$BUILD_FOR_INSTALLER == "false"'
-  when: on_failure
+    JAVA_HOME: /Library/Java/JavaVirtualMachines/liberica-jdk-11-full.jdk/Contents/Home

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,8 @@ macos:
     - if: '$BUILD_FOR_INSTALLER == "false"'
   variables:
     # JAVA_HOME: /Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home
-    JAVA_HOME: /Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
+    # JAVA_HOME: /Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
+    JAVA_HOME: /Library/Java/JavaVirtualMachines/liberica-jdk-11-full.jdk/Contents/Home 
     TESTDATA_ROOT: "/Users/otb/testData"
   needs: []
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,7 +87,7 @@ macos:
     # JAVA_HOME: /Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home
     # JAVA_HOME: /Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
     JAVA_HOME: /Library/Java/JavaVirtualMachines/liberica-jdk-11-full.jdk/Contents/Home 
-    TESTDATA_ROOT: "/Users/otb/testData"
+    TESTDATA_ROOT: "/Users/csro/testData"
   needs: []
   script:
     - mvn clean package

--- a/blue-marble-worldmap/pom.xml
+++ b/blue-marble-worldmap/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>blue-marble-worldmap</artifactId>

--- a/blue-marble-worldmap/pom.xml
+++ b/blue-marble-worldmap/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>blue-marble-worldmap</artifactId>

--- a/blue-marble-worldmap/pom.xml
+++ b/blue-marble-worldmap/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>blue-marble-worldmap</artifactId>

--- a/blue-marble-worldmap/pom.xml
+++ b/blue-marble-worldmap/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>blue-marble-worldmap</artifactId>

--- a/ceres-binding/pom.xml
+++ b/ceres-binding/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>ceres-binding</artifactId>

--- a/ceres-binding/pom.xml
+++ b/ceres-binding/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>ceres-binding</artifactId>

--- a/ceres-binding/pom.xml
+++ b/ceres-binding/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-binding</artifactId>

--- a/ceres-binding/pom.xml
+++ b/ceres-binding/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-binding</artifactId>

--- a/ceres-binio/pom.xml
+++ b/ceres-binio/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-binio</artifactId>

--- a/ceres-binio/pom.xml
+++ b/ceres-binio/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-binio</artifactId>

--- a/ceres-binio/pom.xml
+++ b/ceres-binio/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>ceres-binio</artifactId>

--- a/ceres-binio/pom.xml
+++ b/ceres-binio/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>ceres-binio</artifactId>

--- a/ceres-core/pom.xml
+++ b/ceres-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>ceres-core</artifactId>

--- a/ceres-core/pom.xml
+++ b/ceres-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-core</artifactId>

--- a/ceres-core/pom.xml
+++ b/ceres-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-core</artifactId>

--- a/ceres-core/pom.xml
+++ b/ceres-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>ceres-core</artifactId>

--- a/ceres-glayer/pom.xml
+++ b/ceres-glayer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>ceres-glayer</artifactId>

--- a/ceres-glayer/pom.xml
+++ b/ceres-glayer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>ceres-glayer</artifactId>

--- a/ceres-glayer/pom.xml
+++ b/ceres-glayer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-glayer</artifactId>

--- a/ceres-glayer/pom.xml
+++ b/ceres-glayer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-glayer</artifactId>

--- a/ceres-jai/pom.xml
+++ b/ceres-jai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>ceres-jai</artifactId>

--- a/ceres-jai/pom.xml
+++ b/ceres-jai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>ceres-jai</artifactId>

--- a/ceres-jai/pom.xml
+++ b/ceres-jai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-jai</artifactId>

--- a/ceres-jai/pom.xml
+++ b/ceres-jai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-jai</artifactId>

--- a/ceres-metadata/pom.xml
+++ b/ceres-metadata/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>ceres-metadata</artifactId>

--- a/ceres-metadata/pom.xml
+++ b/ceres-metadata/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-metadata</artifactId>

--- a/ceres-metadata/pom.xml
+++ b/ceres-metadata/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-metadata</artifactId>

--- a/ceres-metadata/pom.xml
+++ b/ceres-metadata/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>ceres-metadata</artifactId>

--- a/ceres-ui/pom.xml
+++ b/ceres-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-ui</artifactId>

--- a/ceres-ui/pom.xml
+++ b/ceres-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>ceres-ui</artifactId>

--- a/ceres-ui/pom.xml
+++ b/ceres-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ceres-ui</artifactId>

--- a/ceres-ui/pom.xml
+++ b/ceres-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>ceres-ui</artifactId>

--- a/ceres-ui/src/main/java/com/bc/ceres/swing/binding/internal/PathEditor.java
+++ b/ceres-ui/src/main/java/com/bc/ceres/swing/binding/internal/PathEditor.java
@@ -9,6 +9,7 @@ import com.bc.ceres.swing.binding.PropertyEditor;
 import javax.swing.*;
 import java.awt.*;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * An editor for {@link Path}s using a file chooser dialog. It is registered as service in the file
@@ -16,38 +17,41 @@ import java.nio.file.Path;
  */
 public class PathEditor extends PropertyEditor {
 
-  @Override
-  public boolean isValidFor(PropertyDescriptor propertyDescriptor) {
-    return Path.class.isAssignableFrom(propertyDescriptor.getType())
-        && !Boolean.TRUE.equals(propertyDescriptor.getAttribute("directory"));
-  }
+    @Override
+    public boolean isValidFor(PropertyDescriptor propertyDescriptor) {
+        return Path.class.isAssignableFrom(propertyDescriptor.getType())
+                && !Boolean.TRUE.equals(propertyDescriptor.getAttribute("directory"));
+    }
 
-  @Override
-  public JComponent createEditorComponent(PropertyDescriptor propertyDescriptor, BindingContext bindingContext) {
-    final JTextField textField = new JTextField();
-    final ComponentAdapter adapter = new TextComponentAdapter(textField);
-    final Binding binding = bindingContext.bind(propertyDescriptor.getName(), adapter);
-    final JPanel editorPanel = new JPanel(new BorderLayout(2, 2));
-    editorPanel.add(textField, BorderLayout.CENTER);
-    final JButton etcButton = new JButton("...");
-    final Dimension size = new Dimension(26, 16);
-    etcButton.setPreferredSize(size);
-    etcButton.setMinimumSize(size);
-    etcButton.addActionListener(e -> {
-      final JFileChooser fileChooser = new JFileChooser();
-      Path currentFile = (Path) binding.getPropertyValue();
-      if (currentFile != null) {
-        fileChooser.setSelectedFile(currentFile.toFile());
-      } else {
-        Path selectedFile = (Path) propertyDescriptor.getDefaultValue();
-        fileChooser.setSelectedFile(selectedFile.toFile());
-      }
-      int i = fileChooser.showDialog(editorPanel, "Select");
-      if (i == JFileChooser.APPROVE_OPTION && fileChooser.getSelectedFile() != null) {
-        binding.setPropertyValue(fileChooser.getSelectedFile());
-      }
-    });
-    editorPanel.add(etcButton, BorderLayout.EAST);
-    return editorPanel;
-  }
+    @Override
+    public JComponent createEditorComponent(PropertyDescriptor propertyDescriptor, BindingContext bindingContext) {
+        final JTextField textField = new JTextField();
+        final ComponentAdapter adapter = new TextComponentAdapter(textField);
+        final Binding binding = bindingContext.bind(propertyDescriptor.getName(), adapter);
+        final JPanel editorPanel = new JPanel(new BorderLayout(2, 2));
+        editorPanel.add(textField, BorderLayout.CENTER);
+        final JButton etcButton = new JButton("...");
+        final Dimension size = new Dimension(26, 16);
+        etcButton.setPreferredSize(size);
+        etcButton.setMinimumSize(size);
+        etcButton.addActionListener(e -> {
+            final JFileChooser fileChooser = new JFileChooser();
+            Optional<Path> currentPath = getCurrentPath(propertyDescriptor, binding);
+            currentPath.ifPresent(path -> fileChooser.setSelectedFile(path.toFile()));
+            int i = fileChooser.showDialog(editorPanel, "Select");
+            if (i == JFileChooser.APPROVE_OPTION && fileChooser.getSelectedFile() != null) {
+                binding.setPropertyValue(fileChooser.getSelectedFile().toPath());
+            }
+        });
+        editorPanel.add(etcButton, BorderLayout.EAST);
+        return editorPanel;
+    }
+
+    static Optional<Path> getCurrentPath(PropertyDescriptor propertyDescriptor, Binding binding) {
+        Path currentFile = (Path) binding.getPropertyValue();
+        if (currentFile == null) {
+            currentFile = (Path) propertyDescriptor.getDefaultValue();
+        }
+        return Optional.ofNullable(currentFile);
+    }
 }

--- a/ceres-ui/src/test/java/com/bc/ceres/swing/binding/internal/PathEditorTest.java
+++ b/ceres-ui/src/test/java/com/bc/ceres/swing/binding/internal/PathEditorTest.java
@@ -17,49 +17,66 @@ package com.bc.ceres.swing.binding.internal;
 
 import com.bc.ceres.binding.PropertyContainer;
 import com.bc.ceres.binding.PropertyDescriptor;
+import com.bc.ceres.swing.binding.Binding;
 import com.bc.ceres.swing.binding.BindingContext;
+import com.bc.ceres.swing.binding.ComponentAdapter;
 import org.junit.Test;
 
 import javax.swing.*;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import static org.junit.Assert.*;
 
 public class PathEditorTest {
 
-  @Test
-  public void testIsApplicable() {
-    PathEditor pathEditor = new PathEditor();
+    @Test
+    public void testIsApplicable() {
+        PathEditor pathEditor = new PathEditor();
 
-    PropertyDescriptor fileDescriptor = new PropertyDescriptor("test", Path.class);
-    assertTrue(pathEditor.isValidFor(fileDescriptor));
+        PropertyDescriptor fileDescriptor = new PropertyDescriptor("test", Path.class);
+        assertTrue(pathEditor.isValidFor(fileDescriptor));
 
-    PropertyDescriptor doubleDescriptor = new PropertyDescriptor("test", Double.TYPE);
-    assertFalse(pathEditor.isValidFor(doubleDescriptor));
-  }
+        PropertyDescriptor doubleDescriptor = new PropertyDescriptor("test", Double.TYPE);
+        assertFalse(pathEditor.isValidFor(doubleDescriptor));
+    }
 
-  @Test
-  public void testCreateEditorComponent() {
-    PathEditor pathEditor = new PathEditor();
+    @Test
+    public void testCreateEditorComponent() {
+        PathEditor pathEditor = new PathEditor();
 
-    PropertyContainer propertyContainer = PropertyContainer.createValueBacked(V.class);
-    BindingContext bindingContext = new BindingContext(propertyContainer);
-    PropertyDescriptor propertyDescriptor = propertyContainer.getDescriptor("filePath");
-    assertSame(Path.class, propertyDescriptor.getType());
+        PropertyContainer propertyContainer = PropertyContainer.createValueBacked(V.class);
+        BindingContext bindingContext = new BindingContext(propertyContainer);
+        PropertyDescriptor propertyDescriptor = propertyContainer.getDescriptor("filePath");
+        assertSame(Path.class, propertyDescriptor.getType());
 
-    assertTrue(pathEditor.isValidFor(propertyDescriptor));
-    JComponent editorComponent = pathEditor.createEditorComponent(propertyDescriptor, bindingContext);
-    assertNotNull(editorComponent);
-    assertSame(JPanel.class, editorComponent.getClass());
-    assertEquals(2, editorComponent.getComponentCount());
+        assertTrue(pathEditor.isValidFor(propertyDescriptor));
+        JComponent editorComponent = pathEditor.createEditorComponent(propertyDescriptor, bindingContext);
+        assertNotNull(editorComponent);
+        assertSame(JPanel.class, editorComponent.getClass());
+        assertEquals(2, editorComponent.getComponentCount());
 
-    JComponent[] components = bindingContext.getBinding("filePath").getComponents();
-    assertEquals(1, components.length);
-    assertSame(JTextField.class, components[0].getClass());
-  }
+        JComponent[] components = bindingContext.getBinding("filePath").getComponents();
+        assertEquals(1, components.length);
+        assertSame(JTextField.class, components[0].getClass());
+    }
 
-  private static class V {
+    @Test
+    public void testGetCurrentPath() {
+        PropertyContainer propertyContainer = PropertyContainer.createValueBacked(V.class);
+        BindingContext bindingContext = new BindingContext(propertyContainer);
+        PropertyDescriptor propertyDescriptor = propertyContainer.getDescriptor("filePath");
 
-    Path filePath;
-  }
+        final JTextField textField = new JTextField();
+        final ComponentAdapter adapter = new TextComponentAdapter(textField);
+        final Binding binding = bindingContext.bind(propertyDescriptor.getName(), adapter);
+        Optional<Path> currentPath = PathEditor.getCurrentPath(propertyDescriptor, binding);
+        assertNotNull(currentPath);
+        assertFalse(currentPath.isPresent());
+    }
+
+    private static class V {
+
+        Path filePath;
+    }
 }

--- a/globcover-worldmap/pom.xml
+++ b/globcover-worldmap/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>globcover-worldmap</artifactId>

--- a/globcover-worldmap/pom.xml
+++ b/globcover-worldmap/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>globcover-worldmap</artifactId>

--- a/globcover-worldmap/pom.xml
+++ b/globcover-worldmap/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>globcover-worldmap</artifactId>

--- a/globcover-worldmap/pom.xml
+++ b/globcover-worldmap/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>globcover-worldmap</artifactId>

--- a/lib-gdal/pom.xml
+++ b/lib-gdal/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>lib-gdal</artifactId>

--- a/lib-gdal/pom.xml
+++ b/lib-gdal/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>lib-gdal</artifactId>

--- a/lib-gdal/pom.xml
+++ b/lib-gdal/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>lib-gdal</artifactId>

--- a/lib-gdal/pom.xml
+++ b/lib-gdal/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>lib-gdal</artifactId>

--- a/lib-hdf/pom.xml
+++ b/lib-hdf/pom.xml
@@ -29,6 +29,7 @@
 
     <properties>
         <snap.version>11.0.1</snap.version>
+        <hdf.version>2.7</hdf.version>
     </properties>
 
 
@@ -50,12 +51,22 @@
         <dependency>
             <groupId>ncsa.hdf</groupId>
             <artifactId>jhdf</artifactId>
-            <version>2.7</version>
+            <version>${hdf.version}</version>
         </dependency>
         <dependency>
             <groupId>ncsa.hdf</groupId>
             <artifactId>jhdf5</artifactId>
-            <version>2.7</version>
+            <version>${hdf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ncsa.hdf</groupId>
+            <artifactId>jhdfobj</artifactId>
+            <version>${hdf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ncsa.hdf</groupId>
+            <artifactId>jhdf5obj</artifactId>
+            <version>${hdf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>

--- a/lib-hdf/pom.xml
+++ b/lib-hdf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <groupId>ncsa.hdf</groupId>
@@ -28,7 +28,7 @@
     <packaging>nbm</packaging>
 
     <properties>
-        <snap.version>11.0.0-SNAPSHOT</snap.version>
+        <snap.version>11.0.0</snap.version>
     </properties>
 
 

--- a/lib-hdf/pom.xml
+++ b/lib-hdf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>ncsa.hdf</groupId>
@@ -28,7 +28,7 @@
     <packaging>nbm</packaging>
 
     <properties>
-        <snap.version>11.0.0</snap.version>
+        <snap.version>11.0.1-SNAPSHOT</snap.version>
     </properties>
 
 

--- a/lib-hdf/pom.xml
+++ b/lib-hdf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <groupId>ncsa.hdf</groupId>
@@ -28,7 +28,7 @@
     <packaging>nbm</packaging>
 
     <properties>
-        <snap.version>11.0.1-SNAPSHOT</snap.version>
+        <snap.version>11.0.1</snap.version>
     </properties>
 
 

--- a/lib-hdf/pom.xml
+++ b/lib-hdf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <groupId>ncsa.hdf</groupId>
@@ -28,7 +28,7 @@
     <packaging>nbm</packaging>
 
     <properties>
-        <snap.version>11.0.1</snap.version>
+        <snap.version>11.0.2-SNAPSHOT</snap.version>
         <hdf.version>2.7</hdf.version>
     </properties>
 

--- a/lib-openjpeg/pom.xml
+++ b/lib-openjpeg/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>lib-openjpeg</artifactId>

--- a/lib-openjpeg/pom.xml
+++ b/lib-openjpeg/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>lib-openjpeg</artifactId>

--- a/lib-openjpeg/pom.xml
+++ b/lib-openjpeg/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>lib-openjpeg</artifactId>

--- a/lib-openjpeg/pom.xml
+++ b/lib-openjpeg/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>lib-openjpeg</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.esa.snap</groupId>
     <artifactId>snap-engine</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
 
     <name>SNAP Engine Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.esa.snap</groupId>
     <artifactId>snap-engine</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>SNAP Engine Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.esa.snap</groupId>
     <artifactId>snap-engine</artifactId>
-    <version>11.0.1</version>
+    <version>11.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>SNAP Engine Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.esa.snap</groupId>
     <artifactId>snap-engine</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0</version>
     <packaging>pom</packaging>
 
     <name>SNAP Engine Project</name>
@@ -67,7 +67,6 @@
         <module>ceres-metadata</module>
 
         <!-- SNAP System Modules -->
-
         <module>snap-runtime</module>
         <module>snap-core</module>
         <!--<module>snap-config</module>-->
@@ -76,7 +75,6 @@
         <module>snap-gpf</module>
 
         <!-- SNAP Extension Modules -->
-
         <module>snap-arcbingrid-reader</module>
         <module>snap-bigtiff</module>
         <module>snap-binning</module>
@@ -155,7 +153,6 @@
         <dependencies>
 
             <!-- Ceres System Level Modules -->
-
             <dependency>
                 <groupId>org.esa.snap</groupId>
                 <artifactId>ceres-core</artifactId>
@@ -206,7 +203,6 @@
             </dependency>
 
             <!-- SNAP Engine System Level Modules -->
-
             <dependency>
                 <groupId>org.esa.snap</groupId>
                 <artifactId>snap-runtime</artifactId>
@@ -241,7 +237,6 @@
             </dependency>
 
             <!-- SNAP Extension Modules -->
-
             <dependency>
                 <groupId>org.esa.snap</groupId>
                 <artifactId>snap-csv-dataio</artifactId>
@@ -270,8 +265,8 @@
                 <artifactId>snap-help-system</artifactId>
                 <version>${snap-help-system.version}</version>
             </dependency>
-            <!-- Miscellaneous 3rd party libraries ############################################# -->
 
+            <!-- Miscellaneous 3rd party libraries ############################################# -->
             <dependency>
                 <groupId>javax.help</groupId>
                 <artifactId>javahelp</artifactId>
@@ -311,16 +306,6 @@
                 <version>${snap.version}</version>
             </dependency>
 
-            <!-- from toniof-netcdf-change_validation branch, not sure whether it is required
-
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jdk14</artifactId>
-                <version>1.7.30</version>
-            </dependency>
-            -->
-
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
@@ -331,6 +316,7 @@
                 <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.htmlparser</groupId>
                 <artifactId>htmlparser</artifactId>
@@ -346,7 +332,6 @@
             </dependency>
 
             <!-- JDOM Library ############################################# -->
-
             <dependency>
                 <groupId>org.jdom</groupId>
                 <artifactId>jdom2</artifactId>
@@ -370,7 +355,6 @@
             </dependency>
 
             <!-- Apache ############################################# -->
-
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
@@ -438,7 +422,6 @@
             </dependency>
 
             <!-- ImageioIO-Ext ############################################# -->
-
             <dependency>
                 <groupId>it.geosolutions.imageio-ext</groupId>
                 <artifactId>imageio-ext-tiff</artifactId>
@@ -595,7 +578,6 @@
 
 
             <!-- BC Neural Network Library ############################################# -->
-
             <dependency>
                 <groupId>com.bc.jnn</groupId>
                 <artifactId>jnn</artifactId>
@@ -603,7 +585,6 @@
             </dependency>
 
             <!-- Jama Matrix Algebra Library ############################################# -->
-
             <dependency>
                 <groupId>Jama</groupId>
                 <artifactId>Jama</artifactId>
@@ -611,7 +592,6 @@
             </dependency>
 
             <!-- XML helper ############################################# -->
-
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
@@ -639,7 +619,6 @@
             </dependency>
 
             <!-- Test Libraries ############################################# -->
-
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
@@ -669,7 +648,6 @@
             </dependency>
 
             <!-- Jimfs - Ram Disk File System ############################################# -->
-
             <dependency>
                 <groupId>com.google.jimfs</groupId>
                 <artifactId>jimfs</artifactId>
@@ -686,7 +664,6 @@
             </dependency>
 
             <!-- JIDE Swing Libraries ############################################# -->
-
             <dependency>
                 <!-- jidesoft is not providing releases anymore. So we take a recent (Jun 2021) version build by someone else -->
                 <!--<groupId>com.jidesoft</groupId>-->
@@ -703,7 +680,6 @@
             </dependency>
 
             <!-- XStream Libraries ############################################# -->
-
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
@@ -716,7 +692,6 @@
             </dependency>
 
             <!-- JFreeChart Libraries ############################################# -->
-
             <dependency>
                 <groupId>org.jfree</groupId>
                 <artifactId>jfreechart</artifactId>
@@ -739,7 +714,6 @@
             </dependency>
 
             <!-- Smart configurator support ######################################## -->
-
             <dependency>
                 <groupId>org.esa.snap</groupId>
                 <artifactId>snap-smart-configurator</artifactId>
@@ -747,7 +721,6 @@
             </dependency>
 
             <!-- JSoup -->
-
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
@@ -1307,6 +1280,15 @@
             <id>tonio</id>
             <name>Tonio Fincke</name>
             <email>tonio.fincke@brockmann-consult.de</email>
+            <organization>Brockmann Consult</organization>
+            <roles>
+                <role>Java Developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>benny</id>
+            <name>Benjamin Lutz</name>
+            <email>benjamin.lutz@brockmann-consult.de</email>
             <organization>Brockmann Consult</organization>
             <roles>
                 <role>Java Developer</role>

--- a/pom.xml
+++ b/pom.xml
@@ -684,7 +684,7 @@
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.20</version>
+                <version>1.4.21</version>
             </dependency>
             <dependency>
                 <groupId>xpp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
             ${project.basedir}/snap-engine-coverage/target/site/
             jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
+        <mockito.version>5.3.1</mockito.version>
     </properties>
 
     <modules>
@@ -664,7 +665,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>5.3.1</version>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/snap-arcbingrid-reader/pom.xml
+++ b/snap-arcbingrid-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-arcbingrid-reader</artifactId>

--- a/snap-arcbingrid-reader/pom.xml
+++ b/snap-arcbingrid-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-arcbingrid-reader</artifactId>

--- a/snap-arcbingrid-reader/pom.xml
+++ b/snap-arcbingrid-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-arcbingrid-reader</artifactId>

--- a/snap-arcbingrid-reader/pom.xml
+++ b/snap-arcbingrid-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-arcbingrid-reader</artifactId>

--- a/snap-bigtiff/pom.xml
+++ b/snap-bigtiff/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-bigtiff</artifactId>

--- a/snap-bigtiff/pom.xml
+++ b/snap-bigtiff/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-bigtiff</artifactId>

--- a/snap-bigtiff/pom.xml
+++ b/snap-bigtiff/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-bigtiff</artifactId>

--- a/snap-bigtiff/pom.xml
+++ b/snap-bigtiff/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-bigtiff</artifactId>

--- a/snap-binning/pom.xml
+++ b/snap-binning/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-binning</artifactId>

--- a/snap-binning/pom.xml
+++ b/snap-binning/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-binning</artifactId>

--- a/snap-binning/pom.xml
+++ b/snap-binning/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-binning</artifactId>

--- a/snap-binning/pom.xml
+++ b/snap-binning/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-binning</artifactId>

--- a/snap-change-detection/pom.xml
+++ b/snap-change-detection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>SNAP Change Detection</name>

--- a/snap-change-detection/pom.xml
+++ b/snap-change-detection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>SNAP Change Detection</name>

--- a/snap-change-detection/pom.xml
+++ b/snap-change-detection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>SNAP Change Detection</name>

--- a/snap-change-detection/pom.xml
+++ b/snap-change-detection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>SNAP Change Detection</name>

--- a/snap-classification/pom.xml
+++ b/snap-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <name>SNAP Classification</name>

--- a/snap-classification/pom.xml
+++ b/snap-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <name>SNAP Classification</name>

--- a/snap-classification/pom.xml
+++ b/snap-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <name>SNAP Classification</name>

--- a/snap-classification/pom.xml
+++ b/snap-classification/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <name>SNAP Classification</name>

--- a/snap-cluster-analysis/pom.xml
+++ b/snap-cluster-analysis/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-cluster-analysis</artifactId>

--- a/snap-cluster-analysis/pom.xml
+++ b/snap-cluster-analysis/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-cluster-analysis</artifactId>

--- a/snap-cluster-analysis/pom.xml
+++ b/snap-cluster-analysis/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-cluster-analysis</artifactId>

--- a/snap-cluster-analysis/pom.xml
+++ b/snap-cluster-analysis/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-cluster-analysis</artifactId>

--- a/snap-collocation/pom.xml
+++ b/snap-collocation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-collocation</artifactId>

--- a/snap-collocation/pom.xml
+++ b/snap-collocation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-collocation</artifactId>

--- a/snap-collocation/pom.xml
+++ b/snap-collocation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-collocation</artifactId>

--- a/snap-collocation/pom.xml
+++ b/snap-collocation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-collocation</artifactId>

--- a/snap-core/pom.xml
+++ b/snap-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-core</artifactId>

--- a/snap-core/pom.xml
+++ b/snap-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-core</artifactId>

--- a/snap-core/pom.xml
+++ b/snap-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-core</artifactId>

--- a/snap-core/pom.xml
+++ b/snap-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-core</artifactId>

--- a/snap-core/src/main/java/eu/esa/snap/core/datamodel/group/BandGroupIO.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/datamodel/group/BandGroupIO.java
@@ -64,8 +64,16 @@ public class BandGroupIO {
             final int numPaths = grouping.size();
             for (int i = 0; i < numPaths; i++) {
                 final String[] paths = grouping.get(i);
+                String[] modifiedPaths = new String[paths.length];
+                for (int j = 0; j < paths.length; j++) {
+                    if (paths[j].contains("#") || paths[j].contains("*")) {
+                        modifiedPaths[j] = paths[j];
+                    } else {
+                        modifiedPaths[j] = paths[j] + "#" + paths[j];
+                    }
+                }
                 JSONArray path = new JSONArray();
-                Collections.addAll(path, paths);
+                Collections.addAll(path, modifiedPaths);
                 pathsArray.add(path);
             }
 

--- a/snap-core/src/main/java/eu/esa/snap/core/datamodel/group/BandGroupImpl.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/datamodel/group/BandGroupImpl.java
@@ -45,7 +45,7 @@ public class BandGroupImpl extends AbstractList<String[]> implements BandGroup {
         return bandNamesList.toArray(new String[0]);
     }
 
-    protected BandGroupImpl(String[][] inputPaths) {
+    public BandGroupImpl(String[][] inputPaths) {
         autoGroupingPaths = new BandGroupingPath[inputPaths.length];
         indexes = new Index[inputPaths.length];
         for (int i = 0; i < inputPaths.length; i++) {

--- a/snap-core/src/main/java/eu/esa/snap/core/datamodel/group/BandGroupingPath.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/datamodel/group/BandGroupingPath.java
@@ -1,5 +1,7 @@
 package eu.esa.snap.core.datamodel.group;
 
+import org.esa.snap.core.util.StringUtils;
+
 public class BandGroupingPath {
 
     private final String[] groups;
@@ -9,10 +11,16 @@ public class BandGroupingPath {
         this.groups = groups;
         entries = new Entry[groups.length];
         for (int i = 0; i < groups.length; i++) {
-            if (groups[i].contains("*") || groups[i].contains("?")) {
-                entries[i] = new WildCardEntry(groups[i]);
+            final String groupPattern = groups[i];
+            if (groupPattern.contains("*") || groupPattern.contains("?")) {
+                entries[i] = new WildCardEntry(groupPattern);
+            } else if (groupPattern.contains("#")) {
+                final String[] split = StringUtils.split(groupPattern, new char[]{'#'}, true);
+                final String groupName = split[0];
+                this.groups[i] = groupName;
+                entries[i] = new BandNamesEntry(groupName, split[1]);
             } else {
-                entries[i] = new EntryImpl(groups[i]);
+                entries[i] = new EntryImpl(groupPattern);
             }
         }
     }

--- a/snap-core/src/main/java/eu/esa/snap/core/datamodel/group/BandGroupsManager.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/datamodel/group/BandGroupsManager.java
@@ -98,7 +98,7 @@ public class BandGroupsManager {
         return allGroups;
     }
 
-    public BandGroup[] getMatchingProduct(Product product) {
+    public BandGroup[] getGroupsMatchingProduct(Product product) {
         final ArrayList<BandGroup> resultList = new ArrayList<>();
         for (final BandGroup group : userGroups) {
             String[] names = group.getMatchingBandNames(product);

--- a/snap-core/src/main/java/eu/esa/snap/core/datamodel/group/BandNamesEntry.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/datamodel/group/BandNamesEntry.java
@@ -1,0 +1,24 @@
+package eu.esa.snap.core.datamodel.group;
+
+import org.esa.snap.core.util.StringUtils;
+
+public class BandNamesEntry implements Entry {
+
+    final String[] bandNames;
+    final String groupName;
+
+    public BandNamesEntry(String groupName, String bandNames) {
+        this.groupName = groupName;
+        this.bandNames = StringUtils.split(bandNames, new char[]{','}, true);
+    }
+
+    @Override
+    public boolean matches(String name) {
+        for (final String bandName : bandNames) {
+            if (bandName.equals(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/snap-core/src/main/java/org/esa/snap/core/dataio/AbstractProductBuilder.java
+++ b/snap-core/src/main/java/org/esa/snap/core/dataio/AbstractProductBuilder.java
@@ -75,6 +75,9 @@ public abstract class AbstractProductBuilder extends AbstractProductReader {
         Guardian.assertNotNull("sourceProduct", sourceProduct);
         setNewProductName(name != null ? name : sourceProduct.getName());
         setNewProductDesc(desc != null ? desc : sourceProduct.getDescription());
+        if (subsetDef != null) {
+            subsetDef.setValidSubsetRegionMaps();
+        }
         final Product product = readProductNodes(sourceProduct, subsetDef);
         product.setModified(true);
         return product;

--- a/snap-core/src/main/java/org/esa/snap/core/dataio/ProductSubsetDef.java
+++ b/snap-core/src/main/java/org/esa/snap/core/dataio/ProductSubsetDef.java
@@ -21,10 +21,7 @@ import org.esa.snap.core.util.Guardian;
 
 import java.awt.Dimension;
 import java.awt.Rectangle;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * The <code>ProductSubsetDef</code> class describes a subset or portion of a remote sensing data product.
@@ -427,5 +424,26 @@ public class ProductSubsetDef {
 
     public void setSubsetRegion(AbstractSubsetRegion subsetRegion) {
         this.subsetRegion = subsetRegion;
+    }
+
+    /**
+     * Remove regions from non overlapping bands for multi-size products
+     */
+    public void setValidSubsetRegionMaps() {
+        if (this.regionMap == null || this.nodeNameList == null) {
+            return;
+        }
+
+        Iterator<Map.Entry<String, Rectangle>> iterator = this.regionMap.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, Rectangle> entry = iterator.next();
+            String nodeName = entry.getKey();
+            Rectangle rect = entry.getValue();
+
+            if (rect.height == 0 || rect.width == 0) {
+                iterator.remove();
+                this.nodeNameList.remove(nodeName);
+            }
+        }
     }
 }

--- a/snap-core/src/main/java/org/esa/snap/core/datamodel/RasterDataNode.java
+++ b/snap-core/src/main/java/org/esa/snap/core/datamodel/RasterDataNode.java
@@ -393,6 +393,15 @@ public abstract class RasterDataNode extends DataNode implements Scaling, SceneT
     }
 
     /**
+     * Check if raster has its own geocoding.
+     *
+     * @return true if raster has its own geocoding.
+     */
+    public boolean hasGeoCoding() {
+        return geoCoding != null;
+    }
+
+    /**
      * Returns the geo-coding of this {@link RasterDataNode}.
      *
      * @return the geo-coding, or {@code null} if not available.

--- a/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandGroupIOTest.java
+++ b/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandGroupIOTest.java
@@ -138,7 +138,7 @@ public class BandGroupIOTest {
         BandGroupIO.write(new BandGroupImpl[]{bandGrouping}, jsonStream);
 
         final String jsonContent = jsonStream.toString();
-        assertEquals("{\"bandGroups\":[{\"paths\":[[\"L1B\"],[\"dim\",\"rad\"]],\"name\":\"Argonaut\"}]}", jsonContent);
+        assertEquals("{\"bandGroups\":[{\"paths\":[[\"L1B#L1B\"],[\"dim#dim\",\"rad#rad\"]],\"name\":\"Argonaut\"}]}", jsonContent);
     }
 
     @Test
@@ -174,7 +174,7 @@ public class BandGroupIOTest {
         BandGroupIO.write(new BandGroupImpl[]{grouping_1, grouping_2, grouping_3}, jsonStream);
 
         final String jsonContent = jsonStream.toString();
-        assertEquals("{\"bandGroups\":[{\"paths\":[[\"L1B\"],[\"dim\",\"rad\"]],\"name\":\"Anna\"},{\"paths\":[[\"_err\",\"_unc\"],[\"geo_\",\"in-situ_\"]],\"name\":\"Bert\"},{\"paths\":[[\"sensor_sync\"]],\"name\":\"Christa\"}]}",
+        assertEquals("{\"bandGroups\":[{\"paths\":[[\"L1B#L1B\"],[\"dim#dim\",\"rad#rad\"]],\"name\":\"Anna\"},{\"paths\":[[\"_err#_err\",\"_unc#_unc\"],[\"geo_#geo_\",\"in-situ_#in-situ_\"]],\"name\":\"Bert\"},{\"paths\":[[\"sensor_sync#sensor_sync\"]],\"name\":\"Christa\"}]}",
                 jsonContent);
     }
 
@@ -237,7 +237,7 @@ public class BandGroupIOTest {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         BandGroupIO.write(bandGroups, outStream);
 
-        assertEquals("{\"bandGroups\":[{\"paths\":[[\"the\",\"duck\"]],\"name\":\"Tick\"},{\"paths\":[[\"another\",\"duck\"],[\"Faehnlein\",\"Fieselschweif\"]],\"name\":\"Trick\"},{\"paths\":[[\"young\",\"duck\"],[\"living\",\"Entenhausen\"]],\"name\":\"Track\"}]}",
+        assertEquals("{\"bandGroups\":[{\"paths\":[[\"the#the\",\"duck#duck\"]],\"name\":\"Tick\"},{\"paths\":[[\"another#another\",\"duck#duck\"],[\"Faehnlein#Faehnlein\",\"Fieselschweif#Fieselschweif\"]],\"name\":\"Trick\"},{\"paths\":[[\"young#young\",\"duck#duck\"],[\"living#living\",\"Entenhausen#Entenhausen\"]],\"name\":\"Track\"}]}",
                 outStream.toString());
     }
 
@@ -249,6 +249,6 @@ public class BandGroupIOTest {
         final ByteArrayOutputStream jsonStream = new ByteArrayOutputStream();
         BandGroupIO.write(new BandGroup[] {bandGroup}, jsonStream);
 
-        assertEquals("{\"bandGroups\":[{\"paths\":[[\"OGVI\",\"OTCI\",\"FAPAR\"]],\"name\":\"hannimoon\"}]}", jsonStream.toString());
+        assertEquals("{\"bandGroups\":[{\"paths\":[[\"OGVI#OGVI\",\"OTCI#OTCI\",\"FAPAR#FAPAR\"]],\"name\":\"hannimoon\"}]}", jsonStream.toString());
     }
 }

--- a/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandGroupImplTest.java
+++ b/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandGroupImplTest.java
@@ -138,6 +138,26 @@ public class BandGroupImplTest {
     }
 
     @Test
+    @STTM("SNAP-3728")
+    public void testParse_bandNames() {
+        final BandGroup bandGroup = BandGroupImpl.parse("L_1:TOA#acdom_443,bbp_443,kd_490,bbp_slope:L_2/err");
+        assertEquals(3, bandGroup.size());
+
+        String[] patternList = bandGroup.get(0);
+        assertEquals(1, patternList.length);
+        assertEquals("L_1", patternList[0]);
+
+        patternList = bandGroup.get(1);
+        assertEquals(1, patternList.length);
+        assertEquals("TOA", patternList[0]);
+
+        patternList = bandGroup.get(2);
+        assertEquals(2, patternList.length);
+        assertEquals("L_2", patternList[0]);
+        assertEquals("err", patternList[1]);
+    }
+
+    @Test
     @STTM("SNAP-3702")
     public void testSetGetName() {
         final BandGroupImpl bandGrouping = new BandGroupImpl(new String[0][]);

--- a/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandGroupPathTest.java
+++ b/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandGroupPathTest.java
@@ -28,6 +28,19 @@ public class BandGroupPathTest {
     }
 
     @Test
+    @STTM("SNAP-3728")
+    public void testConstruction_bandNames() {
+        final String[] strings = {"TOA#acdom_443,bbp_443,kd_490,bbp_slope"};
+        final BandGroupingPath bandGroupingPath = new BandGroupingPath(strings);
+
+        assertTrue(bandGroupingPath.matchesGrouping("bbp_slope"));
+        assertTrue(bandGroupingPath.matchesGrouping("acdom_443"));
+
+        assertFalse(bandGroupingPath.matchesGrouping("Oa10_reflectance"));
+        assertFalse(bandGroupingPath.matchesGrouping("latitude"));
+    }
+
+    @Test
     @STTM("SNAP-3702")
     public void testContains() {
         final String[] strings = {"test"};

--- a/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandGroupsManagerTest.java
+++ b/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandGroupsManagerTest.java
@@ -368,7 +368,7 @@ public class BandGroupsManagerTest {
         final File configFile = new File(targetDir, CONFIG_FILE_NAME);
         try (FileInputStream fileInputStream = new FileInputStream(configFile)) {
             final byte[] bytes = fileInputStream.readAllBytes();
-            assertEquals("{\"bandGroups\":[{\"paths\":[[\"FAPAR\",\"LAI\"]],\"name\":\"veggie\"},{\"paths\":[[\"Oa*_radiance\"],[\"Oa*_radiance_unc\"],[\"Oa*_radiance_err\"]],\"name\":\"\"}]}", new String(bytes, StandardCharsets.UTF_8));
+            assertEquals("{\"bandGroups\":[{\"paths\":[[\"FAPAR#FAPAR\",\"LAI#LAI\"]],\"name\":\"veggie\"},{\"paths\":[[\"Oa*_radiance\"],[\"Oa*_radiance_unc\"],[\"Oa*_radiance_err\"]],\"name\":\"\"}]}", new String(bytes, StandardCharsets.UTF_8));
         }
     }
 

--- a/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandGroupsManagerTest.java
+++ b/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandGroupsManagerTest.java
@@ -201,7 +201,7 @@ public class BandGroupsManagerTest {
         product.addBand("dat_03", ProductData.TYPE_UINT8);
         product.addBand("dat_04", ProductData.TYPE_UINT8);
 
-        final BandGroup[] bandGroups = bandGroupsManager.getMatchingProduct(product);
+        final BandGroup[] bandGroups = bandGroupsManager.getGroupsMatchingProduct(product);
         assertEquals(1, bandGroups.length);
 
         assertEquals("new_data", bandGroups[0].getName());
@@ -223,7 +223,7 @@ public class BandGroupsManagerTest {
         product.addBand("dat_03", ProductData.TYPE_UINT8);
         product.addBand("dat_04", ProductData.TYPE_UINT8);
 
-        final BandGroup[] bandGroups = bandGroupsManager.getMatchingProduct(product);
+        final BandGroup[] bandGroups = bandGroupsManager.getGroupsMatchingProduct(product);
         assertEquals(0, bandGroups.length);
     }
 
@@ -240,7 +240,7 @@ public class BandGroupsManagerTest {
         product.addBand("dat_03", ProductData.TYPE_UINT8);
         product.addBand("dat_04", ProductData.TYPE_UINT8);
 
-        final BandGroup[] bandGroups = bandGroupsManager.getMatchingProduct(product);
+        final BandGroup[] bandGroups = bandGroupsManager.getGroupsMatchingProduct(product);
         assertEquals(0, bandGroups.length);
     }
 

--- a/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandNamesEntryTest.java
+++ b/snap-core/src/test/java/eu/esa/snap/core/datamodel/group/BandNamesEntryTest.java
@@ -1,0 +1,23 @@
+package eu.esa.snap.core.datamodel.group;
+
+import com.bc.ceres.annotation.STTM;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BandNamesEntryTest {
+
+    @Test
+    @STTM("SNAP-3728")
+    public void testMatches() {
+        final BandNamesEntry iopGrouping = new BandNamesEntry("IOP", "anw_443,acdm_443,aphy_443");
+
+        assertTrue(iopGrouping.matches("acdm_443"));
+        assertTrue(iopGrouping.matches("aphy_443"));
+
+        assertFalse(iopGrouping.matches("Oa10_reflectance"));
+        assertFalse(iopGrouping.matches(""));
+        assertFalse(iopGrouping.matches(null));
+    }
+}

--- a/snap-core/src/test/java/org/esa/snap/core/dataio/ProductSubsetDefTest.java
+++ b/snap-core/src/test/java/org/esa/snap/core/dataio/ProductSubsetDefTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.awt.*;
+import java.util.HashMap;
 
 import static org.junit.Assert.*;
 
@@ -293,5 +294,38 @@ public class ProductSubsetDefTest {
         assertTrue(subsetInfo.isIgnoreMetadata());
         subsetInfo.setIgnoreMetadata(false);
         assertFalse(subsetInfo.isIgnoreMetadata());
+    }
+
+    @Test
+    public void testSetValidSubsetRegionMaps() {
+        ProductSubsetDef subsetDef = new ProductSubsetDef();
+        HashMap<String, Rectangle> map = new HashMap<>();
+        Rectangle validRectangle = new Rectangle(0,0,4,23);
+        Rectangle invalidRectangle1 = new Rectangle(0,0,0,0);
+        Rectangle invalidRectangle2 = new Rectangle(0,0,4,0);
+        Rectangle invalidRectangle3 = new Rectangle(0,0,0,23);
+
+        map.put("valid_rectangle", validRectangle);
+        map.put("invalid_rectangle1", invalidRectangle1);
+        map.put("invalid_rectangle2", invalidRectangle2);
+        map.put("invalid_rectangle3", invalidRectangle3);
+
+        subsetDef.setRegionMap(map);
+        subsetDef.setNodeNames(new String[] {"valid_rectangle", "invalid_rectangle1", "invalid_rectangle2", "invalid_rectangle3"});
+        HashMap<String, Rectangle> updatedMap = subsetDef.getRegionMap();
+        String[] nodeNames = subsetDef.getNodeNames();
+
+        assertEquals(4, updatedMap.size());
+        assertEquals(4, nodeNames.length);
+
+        subsetDef.setValidSubsetRegionMaps();
+
+        assertEquals(1, updatedMap.size());
+        assertTrue(updatedMap.containsKey("valid_rectangle"));
+        assertEquals(validRectangle, updatedMap.get("valid_rectangle"));
+
+        nodeNames = subsetDef.getNodeNames();
+        assertEquals(1, nodeNames.length);
+        assertEquals("valid_rectangle", nodeNames[0]);
     }
 }

--- a/snap-core/src/test/java/org/esa/snap/core/dataio/geocoding/ComponentGeoCodingPersistableTest.java
+++ b/snap-core/src/test/java/org/esa/snap/core/dataio/geocoding/ComponentGeoCodingPersistableTest.java
@@ -112,7 +112,7 @@ public class ComponentGeoCodingPersistableTest {
     public void testToAndFromXML_withTiePointGrids() {
         final boolean bilinear = true;
         final boolean antimeridian = true;
-        final ComponentGeoCoding initialGeocoding = initializeWithTiePoints(product, bilinear, antimeridian);
+        final ComponentGeoCoding initialGeocoding = initializeWithTiePoints(product, bilinear, antimeridian, 0.5, 0.5, 5, 5);
         assertThat(initialGeocoding.isCrossingMeridianAt180(), is(true));
 
         final Element xmlFromObject = persistable.createXmlFromObject(initialGeocoding);

--- a/snap-core/src/test/java/org/esa/snap/core/dataio/geocoding/ComponentGeoCodingTestUtils.java
+++ b/snap-core/src/test/java/org/esa/snap/core/dataio/geocoding/ComponentGeoCodingTestUtils.java
@@ -59,7 +59,7 @@ public class ComponentGeoCodingTestUtils {
         return geoCoding;
     }
 
-    public static ComponentGeoCoding initializeWithTiePoints(Product srcProduct, boolean bilinear, boolean antimeridian) {
+    public static ComponentGeoCoding initializeWithTiePoints(Product srcProduct, boolean bilinear, boolean antimeridian, double offsetX, double offsetY, int subsamplingX, int subsamplingY) {
         float[][] tiePointFloats = createTiePointFloats(antimeridian);
         float[] lons = tiePointFloats[0];
         float[] lats = tiePointFloats[1];
@@ -67,7 +67,7 @@ public class ComponentGeoCodingTestUtils {
         srcProduct.getTiePointGrid("tpLat").setData(ProductData.createInstance(lats));
         final GeoRaster geoRaster = new GeoRaster(toD(lons), toD(lats), "tpLon", "tpLat",
                                                   TP_WIDTH, TP_HEIGHT, SCENE_WIDTH, SCENE_HEIGHT,
-                                                  300.0, 0.5, 0.5, 5, 5);
+                                                  300.0, offsetX, offsetY, subsamplingX, subsamplingY);
         final ForwardCoding forwardCoding;
         if (bilinear) {
             forwardCoding = ComponentFactory.getForward(TiePointBilinearForward.KEY);

--- a/snap-core/src/test/java/org/esa/snap/core/dataio/geocoding/ComponentGeoCodingTest_transferGeoCoding.java
+++ b/snap-core/src/test/java/org/esa/snap/core/dataio/geocoding/ComponentGeoCodingTest_transferGeoCoding.java
@@ -31,7 +31,7 @@ public class ComponentGeoCodingTest_transferGeoCoding {
         //preparation
         final boolean bilinear = true;
         boolean antimeridian = false;
-        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian);
+        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian, 0.5, 0.5, 5, 5);
 
         final ProductSubsetDef subsetDef = null;
 
@@ -66,7 +66,7 @@ public class ComponentGeoCodingTest_transferGeoCoding {
         //preparation
         final boolean bilinear = true;
         boolean antimeridian = false;
-        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian);
+        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian, 0.5, 0.5, 5, 5);
 
         final ProductSubsetDef subsetDef = new ProductSubsetDef();
         subsetDef.addNodeName("dummy");
@@ -102,7 +102,7 @@ public class ComponentGeoCodingTest_transferGeoCoding {
         //preparation
         final boolean bilinear = true;
         boolean antimeridian = false;
-        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian);
+        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian, 0.5, 0.5, 5, 5);
 
         final ProductSubsetDef subsetDef = new ProductSubsetDef();
         final int subSampling = 3;
@@ -140,7 +140,7 @@ public class ComponentGeoCodingTest_transferGeoCoding {
         //preparation
         final boolean bilinear = true;
         boolean antimeridian = true;
-        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian);
+        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian, 0.5, 0.5, 5, 5);
 
         final ProductSubsetDef subsetDef = new ProductSubsetDef();
         subsetDef.addNodeName("dummy");
@@ -176,7 +176,7 @@ public class ComponentGeoCodingTest_transferGeoCoding {
         //preparation
         final boolean bilinear = false; // = SPLINE instead
         boolean antimeridian = false;
-        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian);
+        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian, 0.5, 0.5, 5, 5);
 
         final ProductSubsetDef subsetDef = new ProductSubsetDef();
         subsetDef.addNodeName("dummy");
@@ -212,7 +212,7 @@ public class ComponentGeoCodingTest_transferGeoCoding {
         //preparation
         final boolean bilinear = false; // = SPLINE instead
         boolean antimeridian = false;
-        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian);
+        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian, 0.5, 0.5, 5, 5);
 
         final ProductSubsetDef subsetDef = new ProductSubsetDef();
         final int subSampling = 4;
@@ -250,7 +250,7 @@ public class ComponentGeoCodingTest_transferGeoCoding {
         //preparation
         final boolean bilinear = false; // = SPLINE instead
         boolean antimeridian = true;
-        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian);
+        final ComponentGeoCoding geoCoding = initializeWithTiePoints(srcProduct, bilinear, antimeridian, 0.5, 0.5, 5, 5);
 
         final ProductSubsetDef subsetDef = new ProductSubsetDef();
         subsetDef.addNodeName("dummy");

--- a/snap-csv-dataio/pom.xml
+++ b/snap-csv-dataio/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-csv-dataio</artifactId>

--- a/snap-csv-dataio/pom.xml
+++ b/snap-csv-dataio/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-csv-dataio</artifactId>

--- a/snap-csv-dataio/pom.xml
+++ b/snap-csv-dataio/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-csv-dataio</artifactId>

--- a/snap-csv-dataio/pom.xml
+++ b/snap-csv-dataio/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-csv-dataio</artifactId>

--- a/snap-dem/pom.xml
+++ b/snap-dem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-dem</artifactId>

--- a/snap-dem/pom.xml
+++ b/snap-dem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-dem</artifactId>

--- a/snap-dem/pom.xml
+++ b/snap-dem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-dem</artifactId>

--- a/snap-dem/pom.xml
+++ b/snap-dem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-dem</artifactId>

--- a/snap-dem/src/main/java/org/esa/snap/dem/gpf/ComputeSlopeAspectOp.java
+++ b/snap-dem/src/main/java/org/esa/snap/dem/gpf/ComputeSlopeAspectOp.java
@@ -38,6 +38,7 @@ import org.esa.snap.engine_utilities.eo.Constants;
 import org.esa.snap.engine_utilities.gpf.OperatorUtils;
 import org.esa.snap.engine_utilities.gpf.TileGeoreferencing;
 import org.esa.snap.engine_utilities.gpf.TileIndex;
+import org.esa.snap.engine_utilities.eo.GeoUtils;
 
 import java.awt.Rectangle;
 import java.io.File;
@@ -133,16 +134,42 @@ public final class ComputeSlopeAspectOp extends Operator {
     private void getPixelSpacings() throws Exception {
 
         final MetadataElement absRoot = AbstractMetadata.getAbstractedMetadata(sourceProduct);
+        rangeSpacing = absRoot.getAttributeDouble(AbstractMetadata.range_spacing);
+        azimuthSpacing = absRoot.getAttributeDouble(AbstractMetadata.azimuth_spacing);
 
-        rangeSpacing = AbstractMetadata.getAttributeDouble(absRoot, AbstractMetadata.range_spacing);
-        if (rangeSpacing <= 0.0) {
-            throw new OperatorException("Invalid range pixel spacing: " + rangeSpacing);
+        if (rangeSpacing == AbstractMetadata.NO_METADATA || azimuthSpacing == AbstractMetadata.NO_METADATA ||
+                rangeSpacing == 0 || azimuthSpacing == 0) {
+            rangeSpacing = getResolutionXAtCentre(sourceProduct);
+            azimuthSpacing = getResolutionYAtCentre(sourceProduct);
         }
+    }
 
-        azimuthSpacing = AbstractMetadata.getAttributeDouble(absRoot, AbstractMetadata.azimuth_spacing);
-        if (azimuthSpacing <= 0.0) {
-            throw new OperatorException("Invalid azimuth pixel spacing: " + azimuthSpacing);
-        }
+    public static double getResolutionXAtCentre(final Product product) {
+        final int numPixelsX = Math.min(400, product.getSceneRasterWidth());
+        final int halfX = numPixelsX / 2;
+        final int centreX = product.getSceneRasterWidth() / 2;
+        final int centreY = product.getSceneRasterHeight() / 2;
+
+        final GeoCoding geoCoding = product.getSceneGeoCoding();
+        final GeoPos geoPosX1 = geoCoding.getGeoPos(new PixelPos(centreX - halfX, centreY), null);
+        final GeoPos geoPosX2 = geoCoding.getGeoPos(new PixelPos(centreX + halfX, centreY), null);
+        final GeoUtils.DistanceHeading distX = GeoUtils.vincenty_inverse(geoPosX1, geoPosX2);
+
+        return distX.distance / numPixelsX;
+    }
+
+    public static double getResolutionYAtCentre(final Product product) {
+        final int numPixelsY = Math.min(400, product.getSceneRasterHeight());
+        final int halfY = numPixelsY / 2;
+        final int centreX = product.getSceneRasterWidth() / 2;
+        final int centreY = product.getSceneRasterHeight() / 2;
+
+        final GeoCoding geoCoding = product.getSceneGeoCoding();
+        final GeoPos geoPosY1 = geoCoding.getGeoPos(new PixelPos(centreX, centreY - halfY), null);
+        final GeoPos geoPosY2 = geoCoding.getGeoPos(new PixelPos(centreX, centreY + halfY), null);
+        final GeoUtils.DistanceHeading distY = GeoUtils.vincenty_inverse(geoPosY1, geoPosY2);
+
+        return distY.distance / numPixelsY;
     }
 
     private void checkDEM() throws Exception {

--- a/snap-dem/src/main/java/org/esa/snap/dem/gpf/ComputeSlopeAspectOp.java
+++ b/snap-dem/src/main/java/org/esa/snap/dem/gpf/ComputeSlopeAspectOp.java
@@ -134,11 +134,13 @@ public final class ComputeSlopeAspectOp extends Operator {
     private void getPixelSpacings() throws Exception {
 
         final MetadataElement absRoot = AbstractMetadata.getAbstractedMetadata(sourceProduct);
-        rangeSpacing = absRoot.getAttributeDouble(AbstractMetadata.range_spacing);
-        azimuthSpacing = absRoot.getAttributeDouble(AbstractMetadata.azimuth_spacing);
+        if (absRoot != null) {
+            rangeSpacing = absRoot.getAttributeDouble(AbstractMetadata.range_spacing);
+            azimuthSpacing = absRoot.getAttributeDouble(AbstractMetadata.azimuth_spacing);
+        }
 
         if (rangeSpacing == AbstractMetadata.NO_METADATA || azimuthSpacing == AbstractMetadata.NO_METADATA ||
-                rangeSpacing == 0 || azimuthSpacing == 0) {
+                rangeSpacing == 0.0 || azimuthSpacing == 0.0) {
             rangeSpacing = getResolutionXAtCentre(sourceProduct);
             azimuthSpacing = getResolutionYAtCentre(sourceProduct);
         }

--- a/snap-dem/src/test/java/org/esa/snap/gpf/ComputeSlopeAspectOpTest.java
+++ b/snap-dem/src/test/java/org/esa/snap/gpf/ComputeSlopeAspectOpTest.java
@@ -1,0 +1,60 @@
+package org.esa.snap.gpf;
+
+import com.bc.ceres.annotation.STTM;
+import com.bc.ceres.test.LongTestRunner;
+import org.esa.snap.core.datamodel.*;
+import org.esa.snap.dem.gpf.ComputeSlopeAspectOp;
+import org.esa.snap.engine_utilities.datamodel.AbstractMetadata;
+import org.esa.snap.engine_utilities.gpf.OperatorUtils;
+import org.esa.snap.engine_utilities.gpf.ReaderUtils;
+import org.esa.snap.engine_utilities.util.TestUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assume.assumeTrue;
+
+public class ComputeSlopeAspectOpTest {
+
+    @Test
+    @STTM("SNAP-3894")
+    public void testComputeXYResolutions() {
+        Product product = createProduct("type", 7731, 7851);
+
+        ComputeSlopeAspectOp op = new ComputeSlopeAspectOp();
+        op.setSourceProduct(product);
+        final double xRes = op.getResolutionXAtCentre(product);
+        final double yRes = op.getResolutionYAtCentre(product);
+
+        final double xResExp = 29.98405034556281;
+        final double yResExp = 30.05407836258074;
+        assumeTrue(Math.abs(xRes - xResExp) <= 1e-3);
+        assumeTrue(Math.abs(yRes - yResExp) <= 1e-3);
+    }
+
+    public static Product createProduct(final String type, final int w, final int h) {
+        final Product product = new Product("name", type, w, h);
+
+        final ProductData.UTC startTime = AbstractMetadata.parseUTC("10-MAY-2008 20:30:46.890683");
+        final ProductData.UTC endTime = AbstractMetadata.parseUTC("10-MAY-2008 20:35:46.890683");
+        product.setStartTime(startTime);
+        product.setEndTime(endTime);
+        product.setDescription("description");
+
+        final TiePointGrid latGrid = new TiePointGrid(OperatorUtils.TPG_LATITUDE, 2, 2, 0.0f, 0.0f,
+                product.getSceneRasterWidth(), product.getSceneRasterHeight(), new float[]{44.243f, 44.220f, 42.123f, 42.101f});
+        final TiePointGrid lonGrid = new TiePointGrid(OperatorUtils.TPG_LONGITUDE, 2, 2, 0.0f, 0.0f,
+                product.getSceneRasterWidth(), product.getSceneRasterHeight(),
+                new float[]{-81.544f, -78.640f, -81.525f, -78.720f}, TiePointGrid.DISCONT_AT_180);
+        final TiePointGeoCoding tpGeoCoding = new TiePointGeoCoding(latGrid, lonGrid);
+        product.addTiePointGrid(latGrid);
+        product.addTiePointGrid(lonGrid);
+        product.setSceneGeoCoding(tpGeoCoding);
+
+        final MetadataElement absRoot = AbstractMetadata.addAbstractedMetadataHeader(product.getMetadataRoot());
+        absRoot.setAttributeUTC(AbstractMetadata.first_line_time, startTime);
+        absRoot.setAttributeUTC(AbstractMetadata.last_line_time, endTime);
+        absRoot.setAttributeDouble(AbstractMetadata.line_time_interval, ReaderUtils.getLineTimeInterval(startTime, endTime, h));
+
+        return product;
+    }
+
+}

--- a/snap-engine-coverage/pom.xml
+++ b/snap-engine-coverage/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>snap-engine</artifactId>
     <groupId>org.esa.snap</groupId>
-    <version>11.0.1</version>
+    <version>11.0.2-SNAPSHOT</version>
   </parent>
 
   <groupId>org.esa.snap</groupId>
   <artifactId>snap-engine-coverage</artifactId>
-  <version>11.0.1</version>
+  <version>11.0.2-SNAPSHOT</version>
 
   <name>snap-engine-coverage</name>
   <!-- FIXME change it to the project's website -->

--- a/snap-engine-coverage/pom.xml
+++ b/snap-engine-coverage/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>snap-engine</artifactId>
     <groupId>org.esa.snap</groupId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.1</version>
   </parent>
 
   <groupId>org.esa.snap</groupId>
   <artifactId>snap-engine-coverage</artifactId>
-  <version>11.0.1-SNAPSHOT</version>
+  <version>11.0.1</version>
 
   <name>snap-engine-coverage</name>
   <!-- FIXME change it to the project's website -->

--- a/snap-engine-coverage/pom.xml
+++ b/snap-engine-coverage/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>snap-engine</artifactId>
     <groupId>org.esa.snap</groupId>
-    <version>11.0.0</version>
+    <version>11.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.esa.snap</groupId>
   <artifactId>snap-engine-coverage</artifactId>
-  <version>11.0.0</version>
+  <version>11.0.1-SNAPSHOT</version>
 
   <name>snap-engine-coverage</name>
   <!-- FIXME change it to the project's website -->

--- a/snap-engine-coverage/pom.xml
+++ b/snap-engine-coverage/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>snap-engine</artifactId>
     <groupId>org.esa.snap</groupId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0</version>
   </parent>
 
   <groupId>org.esa.snap</groupId>
   <artifactId>snap-engine-coverage</artifactId>
-  <version>11.0.0-SNAPSHOT</version>
+  <version>11.0.0</version>
 
   <name>snap-engine-coverage</name>
   <!-- FIXME change it to the project's website -->

--- a/snap-engine-kit/pom.xml
+++ b/snap-engine-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-engine-kit</artifactId>

--- a/snap-engine-kit/pom.xml
+++ b/snap-engine-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-engine-kit</artifactId>

--- a/snap-engine-kit/pom.xml
+++ b/snap-engine-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-engine-kit</artifactId>

--- a/snap-engine-kit/pom.xml
+++ b/snap-engine-kit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-engine-kit</artifactId>

--- a/snap-engine-utilities/pom.xml
+++ b/snap-engine-utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-engine-utilities</artifactId>

--- a/snap-engine-utilities/pom.xml
+++ b/snap-engine-utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-engine-utilities</artifactId>

--- a/snap-engine-utilities/pom.xml
+++ b/snap-engine-utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-engine-utilities</artifactId>

--- a/snap-engine-utilities/pom.xml
+++ b/snap-engine-utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-engine-utilities</artifactId>

--- a/snap-engine-utilities/pom.xml
+++ b/snap-engine-utilities/pom.xml
@@ -31,15 +31,21 @@
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/datamodel/AbstractMetadata.java
+++ b/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/datamodel/AbstractMetadata.java
@@ -152,6 +152,7 @@ public final class AbstractMetadata {
     public static final String coregistered_stack = "coregistered_stack";
     public static final String collocated_stack = "collocated_stack";
     public static final String bistatic_stack = "bistatic_stack";
+    public static final String multi_reference_ifg = "multi_reference_ifg";
 
     public static final String external_calibration_file = "external_calibration_file";
     public static final String orbit_state_vector_file = "orbit_state_vector_file";

--- a/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/gpf/OperatorUtils.java
+++ b/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/gpf/OperatorUtils.java
@@ -593,7 +593,7 @@ public final class OperatorUtils {
 
                 targetProduct.addBand(targetBand);
 
-                if(srcBand.getGeoCoding() != null) {
+                if(srcBand.hasGeoCoding()) {
                     // copy band geocoding after target band added to target product
                     ProductUtils.copyGeoCoding(srcBand, targetBand);
                 }

--- a/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/gpf/OperatorUtils.java
+++ b/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/gpf/OperatorUtils.java
@@ -571,6 +571,11 @@ public final class OperatorUtils {
                 }
             }
 
+            double ratioW = sourceProduct.getSceneRasterWidth() / (double) targetProduct.getSceneRasterWidth();
+            double ratioH = sourceProduct.getSceneRasterHeight() / (double) targetProduct.getSceneRasterHeight();
+            int targetWidth = srcBand.getRasterWidth() / (int) ratioW;
+            int targetHeight = srcBand.getRasterHeight() / (int) ratioH;
+
             if (targetProduct.getBand(targetBandName) == null) {
                 int dataType = srcBand.getDataType();
                 if (outputFloat)
@@ -580,10 +585,7 @@ public final class OperatorUtils {
                 if (outputIntensity && (dataType == ProductData.TYPE_UINT8 || dataType == ProductData.TYPE_UINT16))
                     dataType = ProductData.TYPE_UINT32;
 
-                final Band targetBand = new Band(targetBandName,
-                        dataType,
-                        targetProduct.getSceneRasterWidth(),
-                        targetProduct.getSceneRasterHeight());
+                final Band targetBand = new Band(targetBandName, dataType, targetWidth, targetHeight);
 
                 targetBand.setUnit(targetUnit);
                 targetBand.setDescription(srcBand.getDescription());
@@ -591,6 +593,11 @@ public final class OperatorUtils {
                 targetBand.setNoDataValueUsed(srcBand.isNoDataValueUsed());
 
                 targetProduct.addBand(targetBand);
+
+                if(srcBand.getGeoCoding() != null) {
+                    // copy band geocoding after target band added to target product
+                    ProductUtils.copyGeoCoding(srcBand, targetBand);
+                }
             }
         }
 

--- a/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/gpf/OperatorUtils.java
+++ b/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/gpf/OperatorUtils.java
@@ -571,10 +571,9 @@ public final class OperatorUtils {
                 }
             }
 
-            double ratioW = sourceProduct.getSceneRasterWidth() / (double) targetProduct.getSceneRasterWidth();
-            double ratioH = sourceProduct.getSceneRasterHeight() / (double) targetProduct.getSceneRasterHeight();
-            int targetWidth = srcBand.getRasterWidth() / (int) ratioW;
-            int targetHeight = srcBand.getRasterHeight() / (int) ratioH;
+            Dimension targetDim = getTargetDimensions(sourceProduct.getSceneRasterWidth(), sourceProduct.getSceneRasterHeight(),
+                    targetProduct.getSceneRasterWidth(), targetProduct.getSceneRasterHeight(),
+                    srcBand.getRasterWidth(), srcBand.getRasterHeight());
 
             if (targetProduct.getBand(targetBandName) == null) {
                 int dataType = srcBand.getDataType();
@@ -585,7 +584,7 @@ public final class OperatorUtils {
                 if (outputIntensity && (dataType == ProductData.TYPE_UINT8 || dataType == ProductData.TYPE_UINT16))
                     dataType = ProductData.TYPE_UINT32;
 
-                final Band targetBand = new Band(targetBandName, dataType, targetWidth, targetHeight);
+                final Band targetBand = new Band(targetBandName, dataType, targetDim.width, targetDim.height);
 
                 targetBand.setUnit(targetUnit);
                 targetBand.setDescription(srcBand.getDescription());
@@ -604,6 +603,16 @@ public final class OperatorUtils {
         if(targetProduct.getNumBands() == 0) {
             throw new OperatorException("Target product has no bands");
         }
+    }
+
+    static Dimension getTargetDimensions(int srcProductWidth, int srcProductHeight,
+                                                int trgProductWidth, int trgProductHeight,
+                                                int srcBandWidth, int srcBandHeight) {
+        double ratioW = srcProductWidth / (double) trgProductWidth;
+        double ratioH = srcProductHeight / (double) trgProductHeight;
+        int targetWidth = (int) (srcBandWidth / ratioW);
+        int targetHeight = (int) (srcBandHeight / ratioH);
+        return new Dimension(targetWidth, targetHeight);
     }
 
     /**

--- a/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/gpf/StackUtils.java
+++ b/snap-engine-utilities/src/main/java/org/esa/snap/engine_utilities/gpf/StackUtils.java
@@ -139,7 +139,24 @@ public final class StackUtils {
             value.append(name);
             value.append(' ');
         }
-        elem.setAttributeString(AbstractMetadata.SLAVE_BANDS, value.toString().trim());
+
+        String slaveBands = value.toString().trim();
+        if (elem.containsAttribute(AbstractMetadata.SLAVE_BANDS)) {
+            final String savedSlaveBands = elem.getAttributeString(AbstractMetadata.SLAVE_BANDS);
+            final String[] savedSlaveBandArray = savedSlaveBands.split(" ");
+            boolean allValid = true;
+            for (String slvBandName : savedSlaveBandArray) {
+                if (targetProduct.getBand(slvBandName) == null || slaveBands.contains(slvBandName)) {
+                    allValid = false;
+                    break;
+                }
+            }
+
+            if (allValid) {
+                slaveBands = savedSlaveBands + " " + slaveBands;
+            }
+        }
+        elem.setAttributeString(AbstractMetadata.SLAVE_BANDS, slaveBands);
     }
 
     public static String findOriginalSlaveProductName(final Product sourceProduct, final Band slvBand) {

--- a/snap-engine-utilities/src/test/java/org/esa/snap/engine_utilities/gpf/TestOperatorUtils.java
+++ b/snap-engine-utilities/src/test/java/org/esa/snap/engine_utilities/gpf/TestOperatorUtils.java
@@ -12,6 +12,7 @@ import org.esa.snap.engine_utilities.datamodel.Unit;
 import org.esa.snap.engine_utilities.util.TestUtils;
 import org.junit.Test;
 
+import java.awt.*;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -125,5 +126,30 @@ public class TestOperatorUtils {
         when(sourceProduct.getSceneGeoCoding()).thenReturn(null);
 
         OperatorUtils.computeImageGeoBoundary(sourceProduct);
+    }
+
+    @Test
+    public void testGetTargetDimensions() {
+        Dimension dim;
+        dim = OperatorUtils.getTargetDimensions(
+                100, 100,
+                100, 100,
+                100, 100);
+        assertEquals(100, dim.width);
+        assertEquals(100, dim.height);
+
+        dim = OperatorUtils.getTargetDimensions(
+                100, 100,
+                200, 200,
+                100, 100);
+        assertEquals(200, dim.width);
+        assertEquals(200, dim.height);
+
+        dim = OperatorUtils.getTargetDimensions(
+                200, 200,
+                100, 100,
+                100, 100);
+        assertEquals(50, dim.width);
+        assertEquals(50, dim.height);
     }
 }

--- a/snap-engine-utilities/src/test/java/org/esa/snap/engine_utilities/gpf/TestOperatorUtils.java
+++ b/snap-engine-utilities/src/test/java/org/esa/snap/engine_utilities/gpf/TestOperatorUtils.java
@@ -1,11 +1,23 @@
 package org.esa.snap.engine_utilities.gpf;
 
+import com.bc.ceres.annotation.STTM;
+import org.esa.snap.core.datamodel.Band;
+import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.core.datamodel.Product;
+import org.esa.snap.core.datamodel.ProductData;
 import org.esa.snap.core.datamodel.TiePointGrid;
+import org.esa.snap.core.gpf.OperatorException;
+import org.esa.snap.engine_utilities.datamodel.AbstractMetadata;
+import org.esa.snap.engine_utilities.datamodel.Unit;
 import org.esa.snap.engine_utilities.util.TestUtils;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestOperatorUtils {
 
@@ -19,6 +31,25 @@ public class TestOperatorUtils {
 
         String newName2 = OperatorUtils.createProductName(productName, suffix);
         assertEquals(newName, newName2);
+    }
+
+    // createProductName returns original name if suffix is present
+    @Test
+    public void test_createProductName_returns_original_name() {
+        String productName = "product_suffix";
+        String suffix = "_suffix";
+        String result = OperatorUtils.createProductName(productName, suffix);
+        assertEquals("product_suffix", result);
+    }
+
+    // getIncidenceAngle retrieves the correct tie point grid
+    @Test
+    public void test_getIncidenceAngle_retrieves_correct_tie_point_grid() {
+        Product mockProduct = mock(Product.class);
+        TiePointGrid mockTPG = mock(TiePointGrid.class);
+        when(mockProduct.getTiePointGrid(OperatorUtils.TPG_INCIDENT_ANGLE)).thenReturn(mockTPG);
+        TiePointGrid result = OperatorUtils.getIncidenceAngle(mockProduct);
+        assertEquals(mockTPG, result);
     }
 
     @Test
@@ -37,5 +68,62 @@ public class TestOperatorUtils {
         TiePointGrid lonTPG = OperatorUtils.getLongitude(product);
         assertNotNull(lonTPG);
         assertEquals(OperatorUtils.TPG_LONGITUDE, lonTPG.getName());
+    }
+
+    // getPolarizationFromBandName throws exception for multiple polarizations
+    @Test(expected = OperatorException.class)
+    public void test_getPolarizationFromBandName_throws_exception_for_multiple_polarizations() {
+        String bandName = "x_HH_times_VV_conj";
+        OperatorUtils.getPolarizationFromBandName(bandName);
+    }
+
+    // getBandPolarization handles null metadata element
+    @Test
+    public void test_getBandPolarization_handles_null_metadata_element() {
+        String bandName = "band_HH";
+        MetadataElement absRoot = null;
+        String result = OperatorUtils.getBandPolarization(bandName, absRoot);
+        assertEquals("hh", result);
+    }
+
+    // getSourceBands handles null or empty sourceBandNames
+    @Test
+    public void test_getSourceBands_handles_null_or_empty_sourceBandNames() {
+        Product mockProduct = mock(Product.class);
+        Band[] bands = new Band[0];
+        when(mockProduct.getBands()).thenReturn(bands);
+        Band[] result = OperatorUtils.getSourceBands(mockProduct, null, false);
+        assertArrayEquals(bands, result);
+    }
+
+    // addSelectedBands handles mismatched real and imaginary bands
+    @Test(expected = OperatorException.class)
+    @STTM("SRM-147")
+    public void test_addSelectedBands_handles_mismatched_real_and_imaginary_bands() {
+        Product sourceProduct = mock(Product.class);
+        Product targetProduct = new Product("target", "type", 100, 100);
+        Map<String, String[]> targetBandNameToSourceBandName = new HashMap<>();
+        Band realBand = new Band("real_band", ProductData.TYPE_FLOAT32, 100, 100);
+        realBand.setUnit(Unit.REAL);
+        Band[] bands = {realBand};
+        when(sourceProduct.getBands()).thenReturn(bands);
+        when(sourceProduct.getNumBands()).thenReturn(1);
+
+        MetadataElement absRoot = mock(MetadataElement.class);
+        when(absRoot.getAttributeInt(AbstractMetadata.polsarData, 0)).thenReturn(0);
+
+        AbstractMetadata absMetaMock = mock(AbstractMetadata.class);
+        when(absMetaMock.getAbstractedMetadata(sourceProduct)).thenReturn(absRoot);
+
+        OperatorUtils.addSelectedBands(sourceProduct, new String[]{"real_band"}, targetProduct, targetBandNameToSourceBandName, true, false);
+    }
+
+    // computeImageGeoBoundary throws exception for missing geocoding
+    @Test(expected = OperatorException.class)
+    public void test_computeImageGeoBoundary_throws_exception_for_missing_geocoding() {
+        Product sourceProduct = mock(Product.class);
+        when(sourceProduct.getSceneGeoCoding()).thenReturn(null);
+
+        OperatorUtils.computeImageGeoBoundary(sourceProduct);
     }
 }

--- a/snap-engine-utilities/src/test/java/org/esa/snap/engine_utilities/gpf/TestStackUtils.java
+++ b/snap-engine-utilities/src/test/java/org/esa/snap/engine_utilities/gpf/TestStackUtils.java
@@ -15,6 +15,7 @@
  */
 package org.esa.snap.engine_utilities.gpf;
 
+import com.bc.ceres.annotation.STTM;
 import org.esa.snap.core.datamodel.Band;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.core.datamodel.Product;
@@ -183,6 +184,25 @@ public class TestStackUtils {
 
         String[] bandNames = StackUtils.bandsToStringArray(product.getBands());
         assertArrayEquals(new String[] {"band_mst1_01Jan21", "band_slv2_01Feb21", "band_slv3_01Feb21"}, bandNames);
+    }
+
+    @Test
+    @STTM("SNAP-3651")
+    public void testSaveSlaveProductBandNames_appendNames() throws Exception {
+        final Product product = createStackProduct(4);
+
+        String[] bandNames = new String[] {"band1","band2"};
+        StackUtils.saveSlaveProductBandNames(product, "product2_01Feb21", bandNames);
+
+        final MetadataElement targetSlaveMetadataRoot = AbstractMetadata.getSlaveMetadata(product.getMetadataRoot());
+        assertNotNull(targetSlaveMetadataRoot);
+        final String masterBands = targetSlaveMetadataRoot.getAttributeString(AbstractMetadata.MASTER_BANDS);
+        assertEquals("band_mst1_01Jan21", masterBands);
+
+        final MetadataElement slaveProductElem = targetSlaveMetadataRoot.getElement("product2_01Feb21");
+        assertNotNull(slaveProductElem);
+        final String slaveBands = slaveProductElem.getAttributeString(AbstractMetadata.SLAVE_BANDS);
+        assertEquals("band_slv2_01Feb21 band_slv3_01Feb21 band1 band2", slaveBands);
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/snap-engine-utilities/src/test/java/org/esa/snap/engine_utilities/gpf/TileGeoreferencingTest.java
+++ b/snap-engine-utilities/src/test/java/org/esa/snap/engine_utilities/gpf/TileGeoreferencingTest.java
@@ -1,0 +1,171 @@
+package org.esa.snap.engine_utilities.gpf;
+
+import org.esa.snap.core.datamodel.Band;
+import org.esa.snap.core.datamodel.CrsGeoCoding;
+import org.esa.snap.core.datamodel.GeoCoding;
+import org.esa.snap.core.datamodel.GeoPos;
+import org.esa.snap.core.datamodel.PixelPos;
+import org.esa.snap.core.datamodel.Product;
+import org.esa.snap.core.datamodel.TiePointGrid;
+
+import org.esa.snap.engine_utilities.util.TestUtils;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TileGeoreferencingTest {
+
+
+    // Initialize TileGeoreferencing with valid Product and dimensions
+    @Test
+    public void initialize_with_valid_product_and_dimensions() {
+        Product product = mock(Product.class);
+        GeoCoding geoCoding = mock(GeoCoding.class);
+        when(product.getSceneGeoCoding()).thenReturn(geoCoding);
+        when(geoCoding.isCrossingMeridianAt180()).thenReturn(false);
+        TiePointGrid latTPG = mock(TiePointGrid.class);
+        TiePointGrid lonTPG = mock(TiePointGrid.class);
+        when(OperatorUtils.getLatitude(product)).thenReturn(latTPG);
+        when(OperatorUtils.getLongitude(product)).thenReturn(lonTPG);
+
+        TileGeoreferencing tileGeoreferencing = new TileGeoreferencing(product, 0, 0, 10, 10);
+
+        assertNotNull(tileGeoreferencing);
+    }
+
+    // Retrieve GeoPos using getGeoPos with valid x, y coordinates
+    @Test
+    public void get_geopos_with_valid_coordinates() {
+        Product product = mock(Product.class);
+        GeoCoding geoCoding = mock(GeoCoding.class);
+        when(product.getSceneGeoCoding()).thenReturn(geoCoding);
+        when(geoCoding.isCrossingMeridianAt180()).thenReturn(false);
+        TiePointGrid latTPG = mock(TiePointGrid.class);
+        TiePointGrid lonTPG = mock(TiePointGrid.class);
+        when(OperatorUtils.getLatitude(product)).thenReturn(latTPG);
+        when(OperatorUtils.getLongitude(product)).thenReturn(lonTPG);
+
+        TileGeoreferencing tileGeoreferencing = new TileGeoreferencing(product, 0, 0, 10, 10);
+        GeoPos geoPos = new GeoPos();
+
+        tileGeoreferencing.getGeoPos(5, 5, geoPos);
+
+        assertNotNull(geoPos);
+    }
+
+    // Retrieve GeoPos using getGeoPos with valid PixelPos
+    @Test
+    public void get_geopos_with_valid_pixelpos() {
+        Product product = mock(Product.class);
+        GeoCoding geoCoding = mock(GeoCoding.class);
+        when(product.getSceneGeoCoding()).thenReturn(geoCoding);
+        when(geoCoding.isCrossingMeridianAt180()).thenReturn(false);
+        TiePointGrid latTPG = mock(TiePointGrid.class);
+        TiePointGrid lonTPG = mock(TiePointGrid.class);
+        when(OperatorUtils.getLatitude(product)).thenReturn(latTPG);
+        when(OperatorUtils.getLongitude(product)).thenReturn(lonTPG);
+
+        TileGeoreferencing tileGeoreferencing = new TileGeoreferencing(product, 0, 0, 10, 10);
+        GeoPos geoPos = new GeoPos();
+        PixelPos pixelPos = new PixelPos(5, 5);
+
+        tileGeoreferencing.getGeoPos(pixelPos, geoPos);
+
+        assertNotNull(geoPos);
+    }
+
+    // Retrieve PixelPos using getPixelPos with valid GeoPos
+    @Test
+    public void get_pixelpos_with_valid_geopos() {
+        Product product = mock(Product.class);
+        GeoCoding geoCoding = mock(GeoCoding.class);
+        when(product.getSceneGeoCoding()).thenReturn(geoCoding);
+        when(geoCoding.isCrossingMeridianAt180()).thenReturn(false);
+
+        TileGeoreferencing tileGeoreferencing = new TileGeoreferencing(product, 0, 0, 10, 10);
+        GeoPos geoPos = new GeoPos(45.0, 45.0);
+        PixelPos pixelPos = new PixelPos();
+
+        tileGeoreferencing.getPixelPos(geoPos, pixelPos);
+
+        assertNotNull(pixelPos);
+    }
+
+    // Handle CrsGeoCoding correctly during initialization
+    @Test
+    public void handle_crsgeocoding_during_initialization() {
+        Product product = mock(Product.class);
+        CrsGeoCoding crsGeoCoding = mock(CrsGeoCoding.class);
+        when(product.getSceneGeoCoding()).thenReturn(crsGeoCoding);
+        when(crsGeoCoding.isCrossingMeridianAt180()).thenReturn(false);
+
+        TileGeoreferencing tileGeoreferencing = new TileGeoreferencing(product, 0, 0, 10, 10);
+
+        assertNotNull(tileGeoreferencing);
+    }
+
+    // Handle non-CrsGeoCoding correctly during initialization
+    @Test
+    public void handle_non_crsgeocoding_during_initialization() {
+        Product product = mock(Product.class);
+        GeoCoding geoCoding = mock(GeoCoding.class);
+        when(product.getSceneGeoCoding()).thenReturn(geoCoding);
+        when(geoCoding.isCrossingMeridianAt180()).thenReturn(false);
+
+        TileGeoreferencing tileGeoreferencing = new TileGeoreferencing(product, 0, 0, 10, 10);
+
+        assertNotNull(tileGeoreferencing);
+    }
+
+    // Retrieve GeoPos with coordinates outside the tile bounds
+    @Test
+    public void get_geopos_outside_tile_bounds() {
+        Product product = mock(Product.class);
+        GeoCoding geoCoding = mock(GeoCoding.class);
+        when(product.getSceneGeoCoding()).thenReturn(geoCoding);
+
+        TileGeoreferencing tileGeoreferencing = new TileGeoreferencing(product, 0, 0, 10, 10);
+        GeoPos geoPos = new GeoPos();
+
+        tileGeoreferencing.getGeoPos(20, 20, geoPos);
+
+        assertNotNull(geoPos);
+    }
+
+    // Retrieve PixelPos with GeoPos crossing the 180-degree meridian
+    @Test
+    public void get_pixelpos_crossing_180_meridian() {
+        Product product = mock(Product.class);
+        GeoCoding geoCoding = mock(GeoCoding.class);
+        when(product.getSceneGeoCoding()).thenReturn(geoCoding);
+        when(geoCoding.isCrossingMeridianAt180()).thenReturn(true);
+
+        TileGeoreferencing tileGeoreferencing = new TileGeoreferencing(product, 0, 0, 10, 10);
+        GeoPos geoPos = new GeoPos(-45.0, -170.0); // crossing meridian example
+        PixelPos pixelPos = new PixelPos();
+
+        tileGeoreferencing.getPixelPos(geoPos, pixelPos);
+
+        assertNotNull(pixelPos);
+    }
+
+    @Test
+    public void testBandGeoCoding() {
+        Product product = TestUtils.createProduct("type", 10, 10);
+        Band band = TestUtils.createBand(product, "band1", 10, 10);
+
+        GeoCoding bandGeoCoding = band.getGeoCoding();
+        assertNotNull(bandGeoCoding);
+
+        TileGeoreferencing tileGeoreferencing = new TileGeoreferencing(bandGeoCoding, 0, 0, 10, 10);
+        GeoPos geoPos = new GeoPos();
+
+        tileGeoreferencing.getGeoPos(5, 5, geoPos);
+
+        assertNotNull(geoPos);
+    }
+}

--- a/snap-envi-reader/pom.xml
+++ b/snap-envi-reader/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-envi-reader</artifactId>

--- a/snap-envi-reader/pom.xml
+++ b/snap-envi-reader/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-envi-reader</artifactId>

--- a/snap-envi-reader/pom.xml
+++ b/snap-envi-reader/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-envi-reader</artifactId>

--- a/snap-envi-reader/pom.xml
+++ b/snap-envi-reader/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-envi-reader</artifactId>

--- a/snap-envi-reader/src/main/resources/org/esa/snap/dataio/envi/layer.xml
+++ b/snap-envi-reader/src/main/resources/org/esa/snap/dataio/envi/layer.xml
@@ -42,10 +42,12 @@
                     </file>
                 </folder>
                 <folder name="Optical Sensors">
-                    <file name="org-esa-snap-dataio-hico-ImportHicoProduct.shadow">
-                        <attr name="originalFile"
-                              stringvalue="Actions/Readers/org-esa-snap-dataio-hico-ImportHicoProduct.instance"/>
-                    </file>
+                    <folder name="Hico">
+                        <file name="org-esa-snap-dataio-hico-ImportHicoProduct.shadow">
+                            <attr name="originalFile"
+                                  stringvalue="Actions/Readers/org-esa-snap-dataio-hico-ImportHicoProduct.instance"/>
+                        </file>
+                    </folder>
                 </folder>
             </folder>
             <folder name="Export">

--- a/snap-envisat-reader/pom.xml
+++ b/snap-envisat-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-envisat-reader</artifactId>

--- a/snap-envisat-reader/pom.xml
+++ b/snap-envisat-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-envisat-reader</artifactId>

--- a/snap-envisat-reader/pom.xml
+++ b/snap-envisat-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-envisat-reader</artifactId>

--- a/snap-envisat-reader/pom.xml
+++ b/snap-envisat-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-envisat-reader</artifactId>

--- a/snap-envisat-reader/src/main/resources/org/esa/snap/dataio/envisat/layer.xml
+++ b/snap-envisat-reader/src/main/resources/org/esa/snap/dataio/envisat/layer.xml
@@ -43,22 +43,28 @@
         <folder name="File">
             <folder name="Import">
                 <folder name="Optical Sensors">
-                    <file name="org-esa-snap-dataio-envisat-ImportEnvisatProduct.shadow">
-                        <attr name="originalFile" stringvalue="Actions/Readers/org-esa-snap-dataio-envisat-ImportEnvisatProduct.instance"/>
-                    </file>
-                    <file name="org-esa-snap-dataio-envisat-ImportERSProduct.shadow">
-                        <attr name="originalFile" stringvalue="Actions/Readers/org-esa-snap-dataio-envisat-ImportERSProduct.instance"/>
-                    </file>
-                </folder>
-                <folder name="SAR Sensors">
-                    <file name="org-esa-snap-dataio-envisat-ImportEnvisatASARProduct.shadow">
-                        <attr name="originalFile" stringvalue="Actions/Readers/org-esa-snap-dataio-envisat-ImportEnvisatASARProduct.instance"/>
-                        <attr name="position" intvalue="400"/>
-                    </file>
-                    <file name="org-esa-snap-dataio-envisat-ImportErsSARProduct.shadow">
-                        <attr name="originalFile" stringvalue="Actions/Readers/org-esa-snap-dataio-envisat-ImportErsSARProduct.instance"/>
-                        <attr name="position" intvalue="555"/>
-                    </file>
+                    <folder name="Envisat">
+                        <file name="org-esa-snap-dataio-envisat-ImportEnvisatProduct.shadow">
+                            <attr name="originalFile"
+                                  stringvalue="Actions/Readers/org-esa-snap-dataio-envisat-ImportEnvisatProduct.instance"/>
+                        </file>
+                        <file name="org-esa-snap-dataio-envisat-ImportERSProduct.shadow">
+                            <attr name="originalFile"
+                                  stringvalue="Actions/Readers/org-esa-snap-dataio-envisat-ImportERSProduct.instance"/>
+                        </file>
+                    </folder>
+                    <folder name="SAR Sensors">
+                        <file name="org-esa-snap-dataio-envisat-ImportEnvisatASARProduct.shadow">
+                            <attr name="originalFile"
+                                  stringvalue="Actions/Readers/org-esa-snap-dataio-envisat-ImportEnvisatASARProduct.instance"/>
+                            <attr name="position" intvalue="400"/>
+                        </file>
+                        <file name="org-esa-snap-dataio-envisat-ImportErsSARProduct.shadow">
+                            <attr name="originalFile"
+                                  stringvalue="Actions/Readers/org-esa-snap-dataio-envisat-ImportErsSARProduct.instance"/>
+                            <attr name="position" intvalue="555"/>
+                        </file>
+                    </folder>
                 </folder>
             </folder>
         </folder>

--- a/snap-gdal-reader/pom.xml
+++ b/snap-gdal-reader/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-gdal-reader</artifactId>

--- a/snap-gdal-reader/pom.xml
+++ b/snap-gdal-reader/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-gdal-reader</artifactId>

--- a/snap-gdal-reader/pom.xml
+++ b/snap-gdal-reader/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-gdal-reader</artifactId>

--- a/snap-gdal-reader/pom.xml
+++ b/snap-gdal-reader/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-gdal-reader</artifactId>

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/BMPDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/BMPDriverProductReaderTest.java
@@ -35,7 +35,7 @@ public class BMPDriverProductReaderTest extends AbstractTestDriverProductReader 
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("MS Windows Device Independent Bitmap", finalProduct.getProductType());
             assertEquals(20, finalProduct.getSceneRasterWidth());
             assertEquals(30, finalProduct.getSceneRasterHeight());
 
@@ -81,7 +81,7 @@ public class BMPDriverProductReaderTest extends AbstractTestDriverProductReader 
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("MS Windows Device Independent Bitmap", finalProduct.getProductType());
             assertEquals(5, finalProduct.getSceneRasterWidth());
             assertEquals(16, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/BTDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/BTDriverProductReaderTest.java
@@ -35,7 +35,7 @@ public class BTDriverProductReaderTest extends AbstractTestDriverProductReader {
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("VTP .bt (Binary Terrain) 1.3 Format", finalProduct.getProductType());
             assertEquals(768, finalProduct.getSceneRasterWidth());
             assertEquals(512, finalProduct.getSceneRasterHeight());
 
@@ -83,7 +83,7 @@ public class BTDriverProductReaderTest extends AbstractTestDriverProductReader {
             assertEquals(1, finalProduct.getBands().length);
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("VTP .bt (Binary Terrain) 1.3 Format", finalProduct.getProductType());
             assertEquals(400, finalProduct.getSceneRasterWidth());
             assertEquals(300, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/GS7BGDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/GS7BGDriverProductReaderTest.java
@@ -36,7 +36,7 @@ public class GS7BGDriverProductReaderTest extends AbstractTestDriverProductReade
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Golden Software 7 Binary Grid", finalProduct.getProductType());
             assertEquals(768, finalProduct.getSceneRasterWidth());
             assertEquals(512, finalProduct.getSceneRasterHeight());
 
@@ -81,7 +81,7 @@ public class GS7BGDriverProductReaderTest extends AbstractTestDriverProductReade
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(1,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Golden Software 7 Binary Grid", finalProduct.getProductType());
             assertEquals(500, finalProduct.getSceneRasterWidth());
             assertEquals(300, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/GSBGDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/GSBGDriverProductReaderTest.java
@@ -35,7 +35,7 @@ public class GSBGDriverProductReaderTest extends AbstractTestDriverProductReader
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Golden Software Binary Grid", finalProduct.getProductType());
             assertEquals(768, finalProduct.getSceneRasterWidth());
             assertEquals(512, finalProduct.getSceneRasterHeight());
 
@@ -80,7 +80,7 @@ public class GSBGDriverProductReaderTest extends AbstractTestDriverProductReader
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Golden Software Binary Grid", finalProduct.getProductType());
             assertEquals(500, finalProduct.getSceneRasterWidth());
             assertEquals(300, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/GTXDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/GTXDriverProductReaderTest.java
@@ -41,7 +41,7 @@ public class GTXDriverProductReaderTest extends AbstractTestDriverProductReader 
             Product finalProduct = reader.readProductNodes(file, null);
             assertNotNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("NOAA Vertical Datum .GTX", finalProduct.getProductType());
             assertEquals(20, finalProduct.getSceneRasterWidth());
             assertEquals(30, finalProduct.getSceneRasterHeight());
 
@@ -89,7 +89,7 @@ public class GTXDriverProductReaderTest extends AbstractTestDriverProductReader 
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("NOAA Vertical Datum .GTX", finalProduct.getProductType());
             assertEquals(10, finalProduct.getSceneRasterWidth());
             assertEquals(20, finalProduct.getSceneRasterHeight());
             assertEquals(0,finalProduct.getTiePointGridGroup().getNodeNames().length);
@@ -164,7 +164,7 @@ public class GTXDriverProductReaderTest extends AbstractTestDriverProductReader 
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("NOAA Vertical Datum .GTX", finalProduct.getProductType());
             assertEquals(11, finalProduct.getSceneRasterWidth());
             assertEquals(21, finalProduct.getSceneRasterHeight());
             assertEquals(0,finalProduct.getTiePointGridGroup().getNodeNames().length);

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/GTiffDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/GTiffDriverProductReaderTest.java
@@ -40,7 +40,7 @@ public class GTiffDriverProductReaderTest extends AbstractTestDriverProductReade
             assertNotNull(product.getPreferredTileSize());
             assertNotNull(product.getProductReader());
             assertEquals(product.getProductReader(), reader);
-            assertEquals("GDAL", product.getProductType());
+            assertEquals("GeoTIFF (GDAL)", product.getProductType());
             assertEquals(25862, product.getSceneRasterWidth());
             assertEquals(16721, product.getSceneRasterHeight());
 
@@ -93,7 +93,7 @@ public class GTiffDriverProductReaderTest extends AbstractTestDriverProductReade
             assertNotNull(product.getPreferredTileSize());
             assertNotNull(product.getProductReader());
             assertEquals(product.getProductReader(), reader);
-            assertEquals("GDAL", product.getProductType());
+            assertEquals("GeoTIFF (GDAL)", product.getProductType());
             assertEquals(210, product.getSceneRasterWidth());
             assertEquals(200, product.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/HFADriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/HFADriverProductReaderTest.java
@@ -35,7 +35,7 @@ public class HFADriverProductReaderTest extends AbstractTestDriverProductReader 
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(3, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Erdas Imagine Images", finalProduct.getProductType());
             assertEquals(768, finalProduct.getSceneRasterWidth());
             assertEquals(512, finalProduct.getSceneRasterHeight());
 
@@ -80,7 +80,7 @@ public class HFADriverProductReaderTest extends AbstractTestDriverProductReader 
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(2, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Erdas Imagine Images", finalProduct.getProductType());
             assertEquals(500, finalProduct.getSceneRasterWidth());
             assertEquals(400, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/ILWISDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/ILWISDriverProductReaderTest.java
@@ -35,7 +35,7 @@ public class ILWISDriverProductReaderTest extends AbstractTestDriverProductReade
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("ILWIS Raster Map", finalProduct.getProductType());
             assertEquals(768, finalProduct.getSceneRasterWidth());
             assertEquals(512, finalProduct.getSceneRasterHeight());
 
@@ -80,7 +80,7 @@ public class ILWISDriverProductReaderTest extends AbstractTestDriverProductReade
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("ILWIS Raster Map", finalProduct.getProductType());
             assertEquals(500, finalProduct.getSceneRasterWidth());
             assertEquals(400, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/KRODriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/KRODriverProductReaderTest.java
@@ -36,7 +36,7 @@ public class KRODriverProductReaderTest extends AbstractTestDriverProductReader 
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(3, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("KOLOR Raw", finalProduct.getProductType());
             assertEquals(768, finalProduct.getSceneRasterWidth());
             assertEquals(512, finalProduct.getSceneRasterHeight());
 
@@ -68,7 +68,7 @@ public class KRODriverProductReaderTest extends AbstractTestDriverProductReader 
 
             Rectangle subsetRegion = new Rectangle(200, 100, 500, 400);
             ProductSubsetDef subsetDef = new ProductSubsetDef();
-            subsetDef.setNodeNames(new String[] { "band_1", "band_3", "mask_band_2"} );
+            subsetDef.setNodeNames(new String[] { "band_1", "band_3", "mask_band_3"} );
             subsetDef.setSubsetRegion(new PixelSubsetRegion(subsetRegion, 0));
             subsetDef.setSubSampling(1, 1);
 
@@ -81,11 +81,11 @@ public class KRODriverProductReaderTest extends AbstractTestDriverProductReader 
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(1,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(2, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("KOLOR Raw", finalProduct.getProductType());
             assertEquals(500, finalProduct.getSceneRasterWidth());
             assertEquals(400, finalProduct.getSceneRasterHeight());
 
-            Mask mask = finalProduct.getMaskGroup().get("mask_band_2");
+            Mask mask = finalProduct.getMaskGroup().get("mask_band_3");
             assertEquals(20, mask.getDataType());
             assertEquals(200000, mask.getNumDataElems());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/MFFDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/MFFDriverProductReaderTest.java
@@ -35,7 +35,7 @@ public class MFFDriverProductReaderTest extends AbstractTestDriverProductReader 
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Vexcel MFF Raster", finalProduct.getProductType());
             assertEquals(64, finalProduct.getSceneRasterWidth());
             assertEquals(64, finalProduct.getSceneRasterHeight());
 
@@ -80,7 +80,7 @@ public class MFFDriverProductReaderTest extends AbstractTestDriverProductReader 
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Vexcel MFF Raster", finalProduct.getProductType());
             assertEquals(50, finalProduct.getSceneRasterWidth());
             assertEquals(40, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/NITFDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/NITFDriverProductReaderTest.java
@@ -36,7 +36,7 @@ public class NITFDriverProductReaderTest extends AbstractTestDriverProductReader
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("National Imagery Transmission Format (GDAL)", finalProduct.getProductType());
             assertEquals(64, finalProduct.getSceneRasterWidth());
             assertEquals(64, finalProduct.getSceneRasterHeight());
 
@@ -81,7 +81,7 @@ public class NITFDriverProductReaderTest extends AbstractTestDriverProductReader
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(1,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("National Imagery Transmission Format (GDAL)", finalProduct.getProductType());
             assertEquals(40, finalProduct.getSceneRasterWidth());
             assertEquals(50, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/PCIDSKDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/PCIDSKDriverProductReaderTest.java
@@ -35,7 +35,7 @@ public class PCIDSKDriverProductReaderTest extends AbstractTestDriverProductRead
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("PCIDSK Database File", finalProduct.getProductType());
             assertEquals(1024, finalProduct.getSceneRasterWidth());
             assertEquals(1024, finalProduct.getSceneRasterHeight());
 
@@ -80,7 +80,7 @@ public class PCIDSKDriverProductReaderTest extends AbstractTestDriverProductRead
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("PCIDSK Database File", finalProduct.getProductType());
             assertEquals(500, finalProduct.getSceneRasterWidth());
             assertEquals(400, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/PNGDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/PNGDriverProductReaderTest.java
@@ -35,7 +35,7 @@ public class PNGDriverProductReaderTest extends AbstractTestDriverProductReader 
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(4, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Portable Network Graphics", finalProduct.getProductType());
             assertEquals(1920, finalProduct.getSceneRasterWidth());
             assertEquals(1200, finalProduct.getSceneRasterHeight());
 
@@ -80,7 +80,7 @@ public class PNGDriverProductReaderTest extends AbstractTestDriverProductReader 
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(3, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Portable Network Graphics", finalProduct.getProductType());
             assertEquals(1165, finalProduct.getSceneRasterWidth());
             assertEquals(1056, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/PNMDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/PNMDriverProductReaderTest.java
@@ -35,7 +35,7 @@ public class PNMDriverProductReaderTest extends AbstractTestDriverProductReader 
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(3, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Portable Pixmap Format", finalProduct.getProductType());
             assertEquals(768, finalProduct.getSceneRasterWidth());
             assertEquals(512, finalProduct.getSceneRasterHeight());
 
@@ -80,7 +80,7 @@ public class PNMDriverProductReaderTest extends AbstractTestDriverProductReader 
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(2, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Portable Pixmap Format", finalProduct.getProductType());
             assertEquals(500, finalProduct.getSceneRasterWidth());
             assertEquals(400, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/RMFDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/RMFDriverProductReaderTest.java
@@ -36,7 +36,7 @@ public class RMFDriverProductReaderTest extends AbstractTestDriverProductReader 
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(3, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Raster Matrix Format", finalProduct.getProductType());
             assertEquals(768, finalProduct.getSceneRasterWidth());
             assertEquals(512, finalProduct.getSceneRasterHeight());
 
@@ -68,7 +68,7 @@ public class RMFDriverProductReaderTest extends AbstractTestDriverProductReader 
 
             Rectangle subsetRegion = new Rectangle(200, 100, 500, 400);
             ProductSubsetDef subsetDef = new ProductSubsetDef();
-            subsetDef.setNodeNames(new String[] { "band_1", "band_3", "nodata_band_2"} );
+            subsetDef.setNodeNames(new String[] { "band_1", "band_3", "nodata_band_3"} );
             subsetDef.setSubsetRegion(new PixelSubsetRegion(subsetRegion, 0));
             subsetDef.setSubSampling(1, 1);
 
@@ -80,11 +80,11 @@ public class RMFDriverProductReaderTest extends AbstractTestDriverProductReader 
 
             assertEquals(1,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(2, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Raster Matrix Format", finalProduct.getProductType());
             assertEquals(500, finalProduct.getSceneRasterWidth());
             assertEquals(400, finalProduct.getSceneRasterHeight());
 
-            Mask mask = finalProduct.getMaskGroup().get("nodata_band_2");
+            Mask mask = finalProduct.getMaskGroup().get("nodata_band_3");
             assertEquals(20, mask.getDataType());
             assertEquals(200000, mask.getNumDataElems());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/RSTDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/RSTDriverProductReaderTest.java
@@ -42,7 +42,7 @@ public class RSTDriverProductReaderTest extends AbstractTestDriverProductReader 
             Product finalProduct = reader.readProductNodes(file, null);
             assertNotNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Idrisi Raster A.1", finalProduct.getProductType());
             assertEquals(20, finalProduct.getSceneRasterWidth());
             assertEquals(30, finalProduct.getSceneRasterHeight());
 
@@ -90,7 +90,7 @@ public class RSTDriverProductReaderTest extends AbstractTestDriverProductReader 
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("Idrisi Raster A.1", finalProduct.getProductType());
             assertEquals(15, finalProduct.getSceneRasterWidth());
             assertEquals(10, finalProduct.getSceneRasterHeight());
 
@@ -152,7 +152,7 @@ public class RSTDriverProductReaderTest extends AbstractTestDriverProductReader 
                assertNotNull(finalProduct.getMaskGroup());
                assertEquals(0, finalProduct.getMaskGroup().getNodeNames().length);
                assertEquals(1, finalProduct.getBands().length);
-               assertEquals("GDAL", finalProduct.getProductType());
+               assertEquals("Idrisi Raster A.1", finalProduct.getProductType());
                assertEquals(16, finalProduct.getSceneRasterWidth());
                assertEquals(11, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/SAGADriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/SAGADriverProductReaderTest.java
@@ -35,7 +35,7 @@ public class SAGADriverProductReaderTest extends AbstractTestDriverProductReader
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("SAGA GIS Binary Grid", finalProduct.getProductType());
             assertEquals(1024, finalProduct.getSceneRasterWidth());
             assertEquals(1024, finalProduct.getSceneRasterHeight());
 
@@ -80,7 +80,7 @@ public class SAGADriverProductReaderTest extends AbstractTestDriverProductReader
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(0,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(1, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("SAGA GIS Binary Grid", finalProduct.getProductType());
             assertEquals(700, finalProduct.getSceneRasterWidth());
             assertEquals(500, finalProduct.getSceneRasterHeight());
 

--- a/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/SGIDriverProductReaderTest.java
+++ b/snap-gdal-reader/src/test/java/org/esa/snap/dataio/gdal/gdal/reader/SGIDriverProductReaderTest.java
@@ -36,7 +36,7 @@ public class SGIDriverProductReaderTest extends AbstractTestDriverProductReader 
             Product finalProduct = reader.readProductNodes(file, null);
             assertNull(finalProduct.getSceneGeoCoding());
             assertEquals(3, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("SGI Image File Format 1.0", finalProduct.getProductType());
             assertEquals(768, finalProduct.getSceneRasterWidth());
             assertEquals(512, finalProduct.getSceneRasterHeight());
 
@@ -68,7 +68,7 @@ public class SGIDriverProductReaderTest extends AbstractTestDriverProductReader 
 
             Rectangle subsetRegion = new Rectangle(200, 100, 500, 400);
             ProductSubsetDef subsetDef = new ProductSubsetDef();
-            subsetDef.setNodeNames(new String[] { "band_1", "band_3", "mask_band_2"} );
+            subsetDef.setNodeNames(new String[] { "band_1", "band_3", "mask_band_3"} );
             subsetDef.setSubsetRegion(new PixelSubsetRegion(subsetRegion, 0));
             subsetDef.setSubSampling(1, 1);
 
@@ -81,11 +81,11 @@ public class SGIDriverProductReaderTest extends AbstractTestDriverProductReader 
             assertNotNull(finalProduct.getMaskGroup());
             assertEquals(1,finalProduct.getMaskGroup().getNodeNames().length);
             assertEquals(2, finalProduct.getBands().length);
-            assertEquals("GDAL", finalProduct.getProductType());
+            assertEquals("SGI Image File Format 1.0", finalProduct.getProductType());
             assertEquals(500, finalProduct.getSceneRasterWidth());
             assertEquals(400, finalProduct.getSceneRasterHeight());
 
-            Mask mask = finalProduct.getMaskGroup().get("mask_band_2");
+            Mask mask = finalProduct.getMaskGroup().get("mask_band_3");
             assertEquals(20, mask.getDataType());
             assertEquals(200000, mask.getNumDataElems());
 

--- a/snap-gdal-writer/pom.xml
+++ b/snap-gdal-writer/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-gdal-writer</artifactId>

--- a/snap-gdal-writer/pom.xml
+++ b/snap-gdal-writer/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-gdal-writer</artifactId>

--- a/snap-gdal-writer/pom.xml
+++ b/snap-gdal-writer/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-gdal-writer</artifactId>

--- a/snap-gdal-writer/pom.xml
+++ b/snap-gdal-writer/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-gdal-writer</artifactId>

--- a/snap-geotiff/pom.xml
+++ b/snap-geotiff/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-geotiff</artifactId>

--- a/snap-geotiff/pom.xml
+++ b/snap-geotiff/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-geotiff</artifactId>

--- a/snap-geotiff/pom.xml
+++ b/snap-geotiff/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-geotiff</artifactId>

--- a/snap-geotiff/pom.xml
+++ b/snap-geotiff/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-geotiff</artifactId>

--- a/snap-getasse30-dem/pom.xml
+++ b/snap-getasse30-dem/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-getasse30-dem</artifactId>

--- a/snap-getasse30-dem/pom.xml
+++ b/snap-getasse30-dem/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-getasse30-dem</artifactId>

--- a/snap-getasse30-dem/pom.xml
+++ b/snap-getasse30-dem/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-getasse30-dem</artifactId>

--- a/snap-getasse30-dem/pom.xml
+++ b/snap-getasse30-dem/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-getasse30-dem</artifactId>

--- a/snap-gpf/pom.xml
+++ b/snap-gpf/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-gpf</artifactId>

--- a/snap-gpf/pom.xml
+++ b/snap-gpf/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-gpf</artifactId>

--- a/snap-gpf/pom.xml
+++ b/snap-gpf/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-gpf</artifactId>

--- a/snap-gpf/pom.xml
+++ b/snap-gpf/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-gpf</artifactId>

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/reproject/WarpFromSourceCoordinates.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/reproject/WarpFromSourceCoordinates.java
@@ -61,7 +61,7 @@ class WarpFromSourceCoordinates extends Warp {
         int xIDNew = opImage.XToTileX(xmin);
         int yIDNew = opImage.YToTileY(ymin);
         Raster tile = opImage.getTile(xIDNew, yIDNew);
-        if (!tile.getBounds().contains(bounds)) {
+        if (tile == null || !tile.getBounds().contains(bounds)) {
             // Dont'n know why, but JAI can call with "width" or "height" == 0
             return destRect;
         }

--- a/snap-hdf5-writer/pom.xml
+++ b/snap-hdf5-writer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-hdf5-writer</artifactId>

--- a/snap-hdf5-writer/pom.xml
+++ b/snap-hdf5-writer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-hdf5-writer</artifactId>

--- a/snap-hdf5-writer/pom.xml
+++ b/snap-hdf5-writer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-hdf5-writer</artifactId>

--- a/snap-hdf5-writer/pom.xml
+++ b/snap-hdf5-writer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-hdf5-writer</artifactId>

--- a/snap-jp2-reader/pom.xml
+++ b/snap-jp2-reader/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-jp2-reader</artifactId>

--- a/snap-jp2-reader/pom.xml
+++ b/snap-jp2-reader/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-jp2-reader</artifactId>

--- a/snap-jp2-reader/pom.xml
+++ b/snap-jp2-reader/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-jp2-reader</artifactId>

--- a/snap-jp2-reader/pom.xml
+++ b/snap-jp2-reader/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-jp2-reader</artifactId>

--- a/snap-land-cover/pom.xml
+++ b/snap-land-cover/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-land-cover</artifactId>

--- a/snap-land-cover/pom.xml
+++ b/snap-land-cover/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-land-cover</artifactId>

--- a/snap-land-cover/pom.xml
+++ b/snap-land-cover/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-land-cover</artifactId>

--- a/snap-land-cover/pom.xml
+++ b/snap-land-cover/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-land-cover</artifactId>

--- a/snap-land-cover/src/main/java/org/esa/snap/landcover/dataio/StacLandCoverModel.java
+++ b/snap-land-cover/src/main/java/org/esa/snap/landcover/dataio/StacLandCoverModel.java
@@ -110,7 +110,7 @@ public class StacLandCoverModel implements LandCoverModel {
     }
 
     @Override
-    public synchronized double getLandCover(final GeoPos geoPos) throws Exception {
+    public double getLandCover(final GeoPos geoPos) throws Exception {
         try {
             if (tileList == null) {
                 search(aoiGeoJSON);
@@ -139,6 +139,9 @@ public class StacLandCoverModel implements LandCoverModel {
     }
 
     private synchronized void search(final JSONObject aoi) throws Exception {
+        if (tileList != null) {
+            return;
+        }
         StacItem[] results = client.search(
                 new String[]{descriptor.getCollectionId()},
                 aoi,

--- a/snap-netcdf/pom.xml
+++ b/snap-netcdf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-netcdf</artifactId>

--- a/snap-netcdf/pom.xml
+++ b/snap-netcdf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-netcdf</artifactId>

--- a/snap-netcdf/pom.xml
+++ b/snap-netcdf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-netcdf</artifactId>

--- a/snap-netcdf/pom.xml
+++ b/snap-netcdf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-netcdf</artifactId>

--- a/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/metadata/profiles/cf/CfBandPart.java
+++ b/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/metadata/profiles/cf/CfBandPart.java
@@ -56,6 +56,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static org.esa.snap.dataio.netcdf.util.ReaderUtils.*;
+
 public class CfBandPart extends ProfilePartIO {
 
     private static final DataTypeWorkarounds dataTypeWorkarounds = new DataTypeWorkarounds();
@@ -225,30 +227,9 @@ public class CfBandPart extends ProfilePartIO {
     }
 
 
-    private static double getScalingFactor(Variable variable) {
-        Attribute attribute = variable.findAttribute(Constants.SCALE_FACTOR_ATT_NAME);
-        if (attribute == null) {
-            attribute = variable.findAttribute(Constants.SLOPE_ATT_NAME);
-        }
-        if (attribute == null) {
-            attribute = variable.findAttribute("scaling_factor");
-        }
-        if (attribute != null) {
-            return getAttributeValue(attribute).doubleValue();
-        }
-        return 1.0;
-    }
 
-    private static double getAddOffset(Variable variable) {
-        Attribute attribute = variable.findAttribute(Constants.ADD_OFFSET_ATT_NAME);
-        if (attribute == null) {
-            attribute = variable.findAttribute(Constants.INTERCEPT_ATT_NAME);
-        }
-        if (attribute != null) {
-            return getAttributeValue(attribute).doubleValue();
-        }
-        return 0.0;
-    }
+
+
 
     static float getSpectralWavelength(Variable variable) {
         Attribute attribute = variable.findAttribute(Constants.RADIATION_WAVELENGTH);
@@ -294,22 +275,7 @@ public class CfBandPart extends ProfilePartIO {
         return null;
     }
 
-    private static Number getAttributeValue(Attribute attribute) {
-        if (attribute.isString()) {
-            String stringValue = attribute.getStringValue();
-            if (stringValue.endsWith("b")) {
-                // Special management for bytes; Can occur in e.g. ASCAT files from EUMETSAT
-                return Byte.parseByte(stringValue.substring(0, stringValue.length() - 1));
-            } else if (!stringValue.isEmpty()) {
-                return Double.parseDouble(stringValue);
-            } else {
-                return 0;
-            }
-        } else {
-            return attribute.getNumericValue();
-        }
 
-    }
 
     private static int getRasterDataType(Variable variable, DataTypeWorkarounds workarounds) {
         if (workarounds != null && workarounds.hasWorkaround(variable.getFullName(), variable.getDataType())) {

--- a/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/util/ReaderUtils.java
+++ b/snap-netcdf/src/main/java/org/esa/snap/dataio/netcdf/util/ReaderUtils.java
@@ -91,5 +91,54 @@ public class ReaderUtils {
         return name;
     }
 
+    public static double getScalingFactor(Variable variable) {
+        Attribute attribute = variable.findAttribute(Constants.SCALE_FACTOR_ATT_NAME);
+        if (attribute == null) {
+            attribute = variable.findAttribute(Constants.SLOPE_ATT_NAME);
+        }
+        if (attribute == null) {
+            attribute = variable.findAttribute("scaling_factor");
+        }
+        if (attribute != null) {
+            return getAttributeValue(attribute).doubleValue();
+        }
+        return 1.0;
+    }
+
+    public static double getAddOffset(Variable variable) {
+        Attribute attribute = variable.findAttribute(Constants.ADD_OFFSET_ATT_NAME);
+        if (attribute == null) {
+            attribute = variable.findAttribute(Constants.INTERCEPT_ATT_NAME);
+        }
+        if (attribute != null) {
+            return getAttributeValue(attribute).doubleValue();
+        }
+        return 0.0;
+    }
+
+    public static Number getAttributeValue(Attribute attribute) {
+        if (attribute.isString()) {
+            String stringValue = attribute.getStringValue();
+            if (stringValue.endsWith("b")) {
+                // Special management for bytes; Can occur in e.g. ASCAT files from EUMETSAT
+                return Byte.parseByte(stringValue.substring(0, stringValue.length() - 1));
+            } else if (!stringValue.isEmpty()) {
+                return Double.parseDouble(stringValue);
+            } else {
+                return 0;
+            }
+        } else {
+            return attribute.getNumericValue();
+        }
+
+    }
+
+    public static boolean mustScale(double scalefactor, double offset) {
+        if (scalefactor != 1.0) {
+            return true;
+        }
+
+        return offset != 0.0;
+    }
 }
 

--- a/snap-netcdf/src/test/java/org/esa/snap/dataio/netcdf/metadata/profiles/cf/CfGeocodingPartTest.java
+++ b/snap-netcdf/src/test/java/org/esa/snap/dataio/netcdf/metadata/profiles/cf/CfGeocodingPartTest.java
@@ -38,7 +38,7 @@ public class CfGeocodingPartTest {
     }
 
     @Test
-    @STTM("SNAP-3584")
+    @STTM("SNAP-3584,SNAP-3825")
     public void testReadVarAsDoubleArray() throws IOException {
         final Variable variable = mock(Variable.class);
         final Array array = mock(Array.class);
@@ -51,6 +51,7 @@ public class CfGeocodingPartTest {
         assertArrayEquals(data, dataRead, 1e-8);
 
         verify(variable, times(1)).read();
+        verify(variable, times(5)).findAttribute(anyString());
         verify(array, times(1)).get1DJavaArray(DataType.DOUBLE);
         verifyNoMoreInteractions(variable, array);
     }

--- a/snap-netcdf/src/test/java/org/esa/snap/dataio/netcdf/util/ReaderUtilsTest.java
+++ b/snap-netcdf/src/test/java/org/esa/snap/dataio/netcdf/util/ReaderUtilsTest.java
@@ -1,0 +1,111 @@
+package org.esa.snap.dataio.netcdf.util;
+
+import com.bc.ceres.annotation.STTM;
+import org.junit.Test;
+import ucar.nc2.Attribute;
+import ucar.nc2.Variable;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ReaderUtilsTest {
+
+    @Test
+    @STTM("SNAP-3825")
+    public void testGetScalingFactor_scale_factor() {
+        final Attribute scaleAttribute = mock(Attribute.class);
+        when(scaleAttribute.isString()).thenReturn(false);
+        when(scaleAttribute.getNumericValue()).thenReturn(26.98867);
+
+        final Variable variable = mock(Variable.class);
+        when(variable.findAttribute("scale_factor")).thenReturn(scaleAttribute);
+
+        double scalingFactor = ReaderUtils.getScalingFactor(variable);
+        assertEquals(26.98867, scalingFactor, 1e-8);
+    }
+
+    @Test
+    @STTM("SNAP-3825")
+    public void testGetScalingFactor_slope() {
+        final Attribute scaleAttribute = mock(Attribute.class);
+        when(scaleAttribute.isString()).thenReturn(false);
+        when(scaleAttribute.getNumericValue()).thenReturn(27.335);
+
+        final Variable variable = mock(Variable.class);
+        when(variable.findAttribute("slope")).thenReturn(scaleAttribute);
+
+        double scalingFactor = ReaderUtils.getScalingFactor(variable);
+        assertEquals(27.335, scalingFactor, 1e-8);
+    }
+
+    @Test
+    @STTM("SNAP-3825")
+    public void testGetScalingFactor_scaling_factor() {
+        final Attribute scaleAttribute = mock(Attribute.class);
+        when(scaleAttribute.isString()).thenReturn(false);
+        when(scaleAttribute.getNumericValue()).thenReturn(28.435);
+
+        final Variable variable = mock(Variable.class);
+        when(variable.findAttribute("scaling_factor")).thenReturn(scaleAttribute);
+
+        double scalingFactor = ReaderUtils.getScalingFactor(variable);
+        assertEquals(28.435, scalingFactor, 1e-8);
+    }
+
+    @Test
+    @STTM("SNAP-3825")
+    public void testGetScalingFactor_nonePresent() {
+        final Variable variable = mock(Variable.class);
+
+        double scalingFactor = ReaderUtils.getScalingFactor(variable);
+        assertEquals(1.0, scalingFactor, 1e-8);
+    }
+
+    @Test
+    @STTM("SNAP-3825")
+    public void testGetAddOffset_scale_factor() {
+        final Attribute offsetAttribute = mock(Attribute.class);
+        when(offsetAttribute.isString()).thenReturn(false);
+        when(offsetAttribute.getNumericValue()).thenReturn(-11.6);
+
+        final Variable variable = mock(Variable.class);
+        when(variable.findAttribute("add_offset")).thenReturn(offsetAttribute);
+
+        final double offset = ReaderUtils.getAddOffset(variable);
+        assertEquals(-11.6, offset, 1e-8);
+    }
+
+    @Test
+    @STTM("SNAP-3825")
+    public void testGetAddOffset_intercept() {
+        final Attribute offsetAttribute = mock(Attribute.class);
+        when(offsetAttribute.isString()).thenReturn(false);
+        when(offsetAttribute.getNumericValue()).thenReturn(-12.7);
+
+        final Variable variable = mock(Variable.class);
+        when(variable.findAttribute("intercept")).thenReturn(offsetAttribute);
+
+        final double offset = ReaderUtils.getAddOffset(variable);
+        assertEquals(-12.7, offset, 1e-8);
+    }
+
+    @Test
+    @STTM("SNAP-3825")
+    public void testGetAddOffset_nonePresent() {
+        final Variable variable = mock(Variable.class);
+
+        final double offset = ReaderUtils.getAddOffset(variable);
+        assertEquals(0.0, offset, 1e-8);
+    }
+
+    @Test
+    @STTM("SNAP-3825")
+    public void testMustScale() {
+        assertTrue(ReaderUtils.mustScale(0.8, 0.0));
+        assertTrue(ReaderUtils.mustScale(0.0, -273.0));
+        assertTrue(ReaderUtils.mustScale(100.0, 206.0));
+
+        assertFalse(ReaderUtils.mustScale(1.0, 0.0));
+    }
+}

--- a/snap-pconvert/pom.xml
+++ b/snap-pconvert/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-pconvert</artifactId>

--- a/snap-pconvert/pom.xml
+++ b/snap-pconvert/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-pconvert</artifactId>

--- a/snap-pconvert/pom.xml
+++ b/snap-pconvert/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-pconvert</artifactId>

--- a/snap-pconvert/pom.xml
+++ b/snap-pconvert/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-pconvert</artifactId>

--- a/snap-pgx-reader/pom.xml
+++ b/snap-pgx-reader/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-pgx-reader</artifactId>

--- a/snap-pgx-reader/pom.xml
+++ b/snap-pgx-reader/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-pgx-reader</artifactId>

--- a/snap-pgx-reader/pom.xml
+++ b/snap-pgx-reader/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-pgx-reader</artifactId>

--- a/snap-pgx-reader/pom.xml
+++ b/snap-pgx-reader/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-pgx-reader</artifactId>

--- a/snap-pixel-extraction/pom.xml
+++ b/snap-pixel-extraction/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-pixel-extraction</artifactId>

--- a/snap-pixel-extraction/pom.xml
+++ b/snap-pixel-extraction/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-pixel-extraction</artifactId>

--- a/snap-pixel-extraction/pom.xml
+++ b/snap-pixel-extraction/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-pixel-extraction</artifactId>

--- a/snap-pixel-extraction/pom.xml
+++ b/snap-pixel-extraction/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-pixel-extraction</artifactId>

--- a/snap-product-library-v2/pom.xml
+++ b/snap-product-library-v2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-product-library-v2</artifactId>

--- a/snap-product-library-v2/pom.xml
+++ b/snap-product-library-v2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-product-library-v2</artifactId>

--- a/snap-product-library-v2/pom.xml
+++ b/snap-product-library-v2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-product-library-v2</artifactId>

--- a/snap-product-library-v2/pom.xml
+++ b/snap-product-library-v2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-product-library-v2</artifactId>

--- a/snap-raster/pom.xml
+++ b/snap-raster/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-raster</artifactId>

--- a/snap-raster/pom.xml
+++ b/snap-raster/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-raster</artifactId>

--- a/snap-raster/pom.xml
+++ b/snap-raster/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-raster</artifactId>

--- a/snap-raster/pom.xml
+++ b/snap-raster/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-raster</artifactId>

--- a/snap-raster/src/main/java/org/esa/snap/raster/gpf/FilterOperator.java
+++ b/snap-raster/src/main/java/org/esa/snap/raster/gpf/FilterOperator.java
@@ -176,23 +176,6 @@ public class FilterOperator extends Operator {
         return targetBand;
     }
 
-    private static Band createFilterBand_bak(Filter filter, String bandName, Band band) {
-        FilterBand filterBand;
-        if (filter instanceof KernelFilter) {
-            final KernelFilter kernelFilter = (KernelFilter) filter;
-            filterBand = new ConvolutionFilterBand(bandName, band, kernelFilter.kernel, 1);
-        } else {
-            final GeneralFilter generalFilter = (GeneralFilter) filter;
-            filterBand = new GeneralFilterBand(bandName, band, generalFilter.operator, getKernel(generalFilter), 1);
-        }
-        final Band targetBand = new Band(bandName, ProductData.TYPE_FLOAT32, band.getRasterWidth(), band.getRasterHeight());
-        ProductUtils.copyRasterDataNodeProperties(band, targetBand);
-        ProductUtils.copySpectralBandProperties(band, targetBand);
-        targetBand.setDescription(String.format("Filter ''%s''", filter));
-        targetBand.setSourceImage(filterBand.getSourceImage());
-        return targetBand;
-    }
-
     private static Kernel getKernel(GeneralFilter filter) {
         final double[] kernelData = new double[filter.width * filter.height];
         Arrays.fill(kernelData, 1.0);

--- a/snap-raster/src/main/java/org/esa/snap/raster/gpf/masks/TerrainMaskOp.java
+++ b/snap-raster/src/main/java/org/esa/snap/raster/gpf/masks/TerrainMaskOp.java
@@ -92,8 +92,6 @@ public final class TerrainMaskOp extends Operator {
 
     private ElevationModel dem = null;
     private FilterWindow window;
-    private int sourceImageWidth = 0;
-    private int sourceImageHeight = 0;
     private boolean isElevationModelAvailable = false;
     private double demNoDataValue = 0; // no data value for DEM
 
@@ -116,8 +114,6 @@ public final class TerrainMaskOp extends Operator {
 
         try {
             window = new FilterWindow(windowSizeStr);
-            sourceImageWidth = sourceProduct.getSceneRasterWidth();
-            sourceImageHeight = sourceProduct.getSceneRasterHeight();
 
             createTargetProduct();
 
@@ -169,7 +165,8 @@ public final class TerrainMaskOp extends Operator {
 
         targetProduct = new Product(sourceProduct.getName(),
                 sourceProduct.getProductType(),
-                sourceImageWidth, sourceImageHeight);
+                sourceProduct.getSceneRasterWidth(),
+                sourceProduct.getSceneRasterHeight());
 
         ProductUtils.copyProductNodes(sourceProduct, targetProduct);
 
@@ -203,7 +200,8 @@ public final class TerrainMaskOp extends Operator {
         }
 
         final Band targetBand = new Band(TERRAIN_MASK_NAME, ProductData.TYPE_INT8,
-                                         sourceImageWidth, sourceImageHeight);
+                                         sourceProduct.getSceneRasterWidth(),
+                                         sourceProduct.getSceneRasterHeight());
         targetBand.setUnit(Unit.CLASS);
         targetProduct.addBand(targetBand);
     }
@@ -266,10 +264,12 @@ public final class TerrainMaskOp extends Operator {
         try {
             final int windowSize = window.getWindowSize();
             final double[][] localDEM = new double[h + windowSize + 2][w + windowSize + 2];
-            final TileGeoreferencing tileGeoRef = new TileGeoreferencing(targetProduct, x0, y0, w + windowSize, h + windowSize);
+            final TileGeoreferencing tileGeoRef = new TileGeoreferencing(targetBand.getGeoCoding(),
+                    x0, y0, w + windowSize, h + windowSize);
 
             final boolean valid = DEMFactory.getLocalDEM(
-                    dem, demNoDataValue, demResamplingMethod, tileGeoRef, x0, y0, w + windowSize, h + windowSize, sourceProduct, true, localDEM);
+                    dem, demNoDataValue, demResamplingMethod, tileGeoRef, x0, y0,
+                    w + windowSize, h + windowSize, sourceProduct, true, localDEM);
 
             if (!valid) {
                 return;

--- a/snap-remote-execution/pom.xml
+++ b/snap-remote-execution/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-remote-execution</artifactId>

--- a/snap-remote-execution/pom.xml
+++ b/snap-remote-execution/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-remote-execution</artifactId>

--- a/snap-remote-execution/pom.xml
+++ b/snap-remote-execution/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-remote-execution</artifactId>

--- a/snap-remote-execution/pom.xml
+++ b/snap-remote-execution/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-remote-execution</artifactId>

--- a/snap-remote-products-repository/pom.xml
+++ b/snap-remote-products-repository/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-remote-products-repository</artifactId>

--- a/snap-remote-products-repository/pom.xml
+++ b/snap-remote-products-repository/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-remote-products-repository</artifactId>

--- a/snap-remote-products-repository/pom.xml
+++ b/snap-remote-products-repository/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-remote-products-repository</artifactId>

--- a/snap-remote-products-repository/pom.xml
+++ b/snap-remote-products-repository/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-remote-products-repository</artifactId>

--- a/snap-rtp-codec/pom.xml
+++ b/snap-rtp-codec/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-rtp-codec</artifactId>

--- a/snap-rtp-codec/pom.xml
+++ b/snap-rtp-codec/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-rtp-codec</artifactId>

--- a/snap-rtp-codec/pom.xml
+++ b/snap-rtp-codec/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-rtp-codec</artifactId>

--- a/snap-rtp-codec/pom.xml
+++ b/snap-rtp-codec/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-rtp-codec</artifactId>

--- a/snap-runtime/pom.xml
+++ b/snap-runtime/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-runtime</artifactId>

--- a/snap-runtime/pom.xml
+++ b/snap-runtime/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-runtime</artifactId>

--- a/snap-runtime/pom.xml
+++ b/snap-runtime/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-runtime</artifactId>

--- a/snap-runtime/pom.xml
+++ b/snap-runtime/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-runtime</artifactId>

--- a/snap-smart-configurator/pom.xml
+++ b/snap-smart-configurator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-smart-configurator</artifactId>

--- a/snap-smart-configurator/pom.xml
+++ b/snap-smart-configurator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-smart-configurator</artifactId>

--- a/snap-smart-configurator/pom.xml
+++ b/snap-smart-configurator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-smart-configurator</artifactId>

--- a/snap-smart-configurator/pom.xml
+++ b/snap-smart-configurator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-smart-configurator</artifactId>

--- a/snap-sta/pom.xml
+++ b/snap-sta/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-sta</artifactId>

--- a/snap-sta/pom.xml
+++ b/snap-sta/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-sta</artifactId>

--- a/snap-sta/pom.xml
+++ b/snap-sta/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-sta</artifactId>

--- a/snap-sta/pom.xml
+++ b/snap-sta/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-sta</artifactId>

--- a/snap-stac/pom.xml
+++ b/snap-stac/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-stac</artifactId>

--- a/snap-stac/pom.xml
+++ b/snap-stac/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-stac</artifactId>

--- a/snap-stac/pom.xml
+++ b/snap-stac/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-stac</artifactId>

--- a/snap-stac/pom.xml
+++ b/snap-stac/pom.xml
@@ -56,12 +56,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
-            <scope>compile</scope>
-        </dependency>
         <!--dependency>
             <groupId>org.orbisgis</groupId>
             <artifactId>h2gis</artifactId>

--- a/snap-stac/pom.xml
+++ b/snap-stac/pom.xml
@@ -48,12 +48,6 @@
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-geotiff</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.esa.snap</groupId>
-            <artifactId>ceres-core</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
 
         <!--dependency>
             <groupId>org.orbisgis</groupId>
@@ -62,9 +56,14 @@
         </dependency-->
 
         <dependency>
+            <groupId>org.esa.snap</groupId>
+            <artifactId>ceres-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/snap-stac/pom.xml
+++ b/snap-stac/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-stac</artifactId>

--- a/snap-stac/pom.xml
+++ b/snap-stac/pom.xml
@@ -78,7 +78,6 @@
                 <configuration>
                     <publicPackages>
                         <publicPackage>org.esa.snap.*</publicPackage>
-                        <publicPackage>org.json.simple.*</publicPackage>
                     </publicPackages>
                 </configuration>
             </plugin>

--- a/snap-stac/pom.xml
+++ b/snap-stac/pom.xml
@@ -17,7 +17,6 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mockito.version>3.4.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -70,7 +69,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/snap-statistics/pom.xml
+++ b/snap-statistics/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-statistics</artifactId>

--- a/snap-statistics/pom.xml
+++ b/snap-statistics/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-statistics</artifactId>

--- a/snap-statistics/pom.xml
+++ b/snap-statistics/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-statistics</artifactId>

--- a/snap-statistics/pom.xml
+++ b/snap-statistics/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-statistics</artifactId>

--- a/snap-temporal-percentile/pom.xml
+++ b/snap-temporal-percentile/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-temporal-percentile</artifactId>

--- a/snap-temporal-percentile/pom.xml
+++ b/snap-temporal-percentile/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-temporal-percentile</artifactId>

--- a/snap-temporal-percentile/pom.xml
+++ b/snap-temporal-percentile/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-temporal-percentile</artifactId>

--- a/snap-temporal-percentile/pom.xml
+++ b/snap-temporal-percentile/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-temporal-percentile</artifactId>

--- a/snap-test-utils/pom.xml
+++ b/snap-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-test-utils</artifactId>

--- a/snap-test-utils/pom.xml
+++ b/snap-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-test-utils</artifactId>

--- a/snap-test-utils/pom.xml
+++ b/snap-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-test-utils</artifactId>

--- a/snap-test-utils/pom.xml
+++ b/snap-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-test-utils</artifactId>

--- a/snap-virtual-file-system/pom.xml
+++ b/snap-virtual-file-system/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-virtual-file-system</artifactId>

--- a/snap-virtual-file-system/pom.xml
+++ b/snap-virtual-file-system/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-virtual-file-system</artifactId>

--- a/snap-virtual-file-system/pom.xml
+++ b/snap-virtual-file-system/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-virtual-file-system</artifactId>

--- a/snap-virtual-file-system/pom.xml
+++ b/snap-virtual-file-system/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.esa.snap</groupId>
         <artifactId>snap-engine</artifactId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-virtual-file-system</artifactId>

--- a/snap-watermask/pom.xml
+++ b/snap-watermask/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-watermask</artifactId>

--- a/snap-watermask/pom.xml
+++ b/snap-watermask/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-watermask</artifactId>

--- a/snap-watermask/pom.xml
+++ b/snap-watermask/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-watermask</artifactId>

--- a/snap-watermask/pom.xml
+++ b/snap-watermask/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-watermask</artifactId>

--- a/snap-znap/pom.xml
+++ b/snap-znap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0</version>
+        <version>11.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-znap</artifactId>

--- a/snap-znap/pom.xml
+++ b/snap-znap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.1</version>
     </parent>
 
     <artifactId>snap-znap</artifactId>

--- a/snap-znap/pom.xml
+++ b/snap-znap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.1</version>
+        <version>11.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>snap-znap</artifactId>

--- a/snap-znap/pom.xml
+++ b/snap-znap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>snap-engine</artifactId>
         <groupId>org.esa.snap</groupId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0</version>
     </parent>
 
     <artifactId>snap-znap</artifactId>


### PR DESCRIPTION
for ComponentGeoCoding and not from the TiePointGrid

Updated `ComponentGeoCodingPersistenceConverter` to support parsing offset and subsampling properties. Adjusted tests to initialize `ComponentGeoCoding` with offset and subsampling values.

Additional information in the forum.
https://forum.step.esa.int/t/znap-format-does-not-preserve-tie-point-geo-dings-correctly/43047