### PR TITLE
Enhanced gpf write and product io

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/dataio/ProductIO.java
+++ b/snap-core/src/main/java/org/esa/snap/core/dataio/ProductIO.java
@@ -17,6 +17,7 @@ package org.esa.snap.core.dataio;
 
 import com.bc.ceres.core.ProgressMonitor;
 import com.bc.ceres.core.SubProgressMonitor;
+import com.bc.ceres.glevel.MultiLevelImage;
 import org.esa.snap.core.dataio.dimap.DimapProductConstants;
 import org.esa.snap.core.dataio.dimap.DimapProductWriter;
 import org.esa.snap.core.datamodel.Band;
@@ -42,9 +43,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,6 +73,7 @@ public class ProductIO {
     public static final String SYSTEM_PROPERTY_CONCURRENT = "snap.productio.concurrent";
     public static final boolean DEFAULT_WRITE_RASTER_CONCURRENT = true;
 
+    private static final int SHUTDOWN_TIMEOUT_MINUTES = 15;
 
     /**
      * Gets a product reader for the given format name.
@@ -504,35 +504,112 @@ public class ProductIO {
     }
 
     private static void writeBandsConcurrent(ProgressMonitor pm, ArrayList<Band> bandsToWrite) throws IOException {
-        final int numBands = bandsToWrite.size();
-        final CountDownLatch bandsCountDown = new CountDownLatch(numBands);
-
-        final int numThreads = Config.instance().load().preferences().getInt("snap.parallelism", Runtime.getRuntime().availableProcessors());
-        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
-        List<IOException> ioExceptionCollector = new ArrayList<>();
-        for (Band band : bandsToWrite) {
+        try {
+            writeBandsWithRasterData(pm, bandsToWrite);
             if (pm.isCanceled()) {
-                bandsCountDown.countDown();
+                return;
+            }
+            writeBandsWithImages(pm, bandsToWrite);
+        } finally {
+            pm.done();
+        }
+    }
+
+    private static void writeBandsWithImages(ProgressMonitor pm, ArrayList<Band> bandsToWrite)
+            throws IOException {
+        final int numThreads = Config.instance().load().preferences()
+                .getInt("snap.parallelism", Runtime.getRuntime().availableProcessors());
+        final ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+        // Start thread one after the other, otherwise the shutdown from ExecutorService can expire.
+        // So the last thread is only started shortly before the shutdown process starts
+        Semaphore semaphore = new Semaphore(numThreads + 5); // Already have 5 more in the queue
+        try {
+            Rectangle minMaxTileIndices = calculateMinMaxTileIndices(bandsToWrite);
+            for (int y = minMaxTileIndices.y; y <= minMaxTileIndices.height; y++) {
+                for (int x = minMaxTileIndices.x; x <= minMaxTileIndices.width; x++) {
+                    for (Band band : bandsToWrite) {
+                        if (pm.isCanceled()) {
+                            break;
+                        }
+                        int finalX = x;
+                        int finalY = y;
+                        semaphore.acquireUninterruptibly();
+                        executorService.submit(() -> {
+                            try {
+                                processTileForBand(band, finalX, finalY);
+                                semaphore.release();
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+                    }
+                }
+            }
+        } finally {
+            shutdownExecutor(executorService);
+            pm.worked(bandsToWrite.size());
+        }
+    }
+
+    private static Rectangle calculateMinMaxTileIndices(ArrayList<Band> bandsToWrite) throws IOException {
+        // todo maybe this can be better implemented
+        Rectangle minMaxTileIndices = new Rectangle();
+        for (Band band : bandsToWrite) {
+            if (band.hasRasterData()) {
+                throw new IOException(String.format("Band '%s' should have been written before", band.getName()));
+            }
+
+            final PlanarImage sourceImage = band.getSourceImage();
+            Point[] tileIndices = sourceImage.getTileIndices(
+                    new Rectangle(0, 0, sourceImage.getWidth(), sourceImage.getHeight()));
+            if (tileIndices == null) {
+                continue;
+            }
+            minMaxTileIndices.add(tileIndices[0].x, tileIndices[0].y);
+            minMaxTileIndices.add(tileIndices[tileIndices.length - 1].x, tileIndices[tileIndices.length - 1].y);
+        }
+        return minMaxTileIndices;
+    }
+
+    private static void processTileForBand(Band band, int x, int y) throws IOException {
+        MultiLevelImage sourceImage = band.getSourceImage();
+        Point tileIndex = new Point(x, y);
+        if (isTileWithinBounds(sourceImage, tileIndex)) {
+            writeTile(sourceImage, tileIndex, band);
+        }
+    }
+
+    private static boolean isTileWithinBounds(MultiLevelImage sourceImage, Point tileIndex) {
+        return tileIndex.x >= sourceImage.getMinTileX() && tileIndex.x <= sourceImage.getMaxTileX() &&
+                tileIndex.y >= sourceImage.getMinTileY() && tileIndex.y <= sourceImage.getMaxTileY();
+    }
+
+    private static void shutdownExecutor(ExecutorService executorService) throws IOException {
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(SHUTDOWN_TIMEOUT_MINUTES, TimeUnit.MINUTES)) {
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executorService.shutdownNow();
+            throw new IOException("Writing of band tile data took too long", e);
+        }
+    }
+
+
+    private static void writeBandsWithRasterData(ProgressMonitor pm, ArrayList<Band> bandsToWrite) throws IOException {
+        Iterator<Band> iterator = bandsToWrite.iterator();
+        while (iterator.hasNext()) {
+            if (pm.isCanceled()) {
                 break;
             }
-            pm.setSubTaskName("Writing band '" + band.getName() + "'");
-            ProgressMonitor subPM = SubProgressMonitor.create(pm, 1);
-            writeRasterDataFully(subPM, band, executor, bandsCountDown, ioExceptionCollector);
-        }
-        while (bandsCountDown.getCount() > 0) {
-            try {
-                Thread.sleep(200);
-            } catch (InterruptedException e) {
-                EngineConfig.instance().logger().log(Level.WARNING,
-                                                     "Method ProductIO.writeAllBands(...)' unexpected termination", e);
+            Band band = iterator.next();
+            if (band.hasRasterData()) {
+                band.writeRasterData(0, 0, band.getRasterWidth(), band.getRasterHeight(), band.getRasterData(), pm);
+                band.removeCachedImageData();
+                iterator.remove();
+                pm.worked(1);
             }
-        }
-        executor.shutdown();
-        for (IOException e : ioExceptionCollector) {
-            SystemUtils.LOG.log(Level.SEVERE, e.getMessage(), e);
-        }
-        if (ioExceptionCollector.size() > 0) {
-            throw ioExceptionCollector.get(0);
         }
     }
 

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/WriteOp.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/WriteOp.java
@@ -410,6 +410,14 @@ public class WriteOp extends Operator {
         }
     }
 
+    /**
+     * Writes a row of tiles to a specified band. Optionally clears the cache for each tile row after writing.
+     *
+     * @param band                     The band to which the tile row is written.
+     * @param cacheLine                The array of tiles representing a row to be written.
+     * @param clearCacheAfterRowWrite  If true, clears the cache for each tile after the row is written.
+     * @throws IOException             If an I/O error occurs during writing.
+     */
     private void writeTileRow(Band band, Tile[] cacheLine, boolean clearCacheAfterRowWrite) throws IOException {
         int lineWidth = 0;
         for (Tile tile : cacheLine) {

--- a/snap-gpf/src/test/java/org/esa/snap/core/gpf/execution/OperatorExecutionsTest.java
+++ b/snap-gpf/src/test/java/org/esa/snap/core/gpf/execution/OperatorExecutionsTest.java
@@ -460,8 +460,7 @@ public class OperatorExecutionsTest {
 
     @Test
     public void testInitDoExecuteSetsJAIImageOperatorWorksWithWriteAndRead() throws IOException {
-        Product product = writeAndReadProduct(new Operators.InitDoExecuteSetsJAIImageOperator(),
-                "InitDoExecuteSetsJAIImage");
+        Product product = writeAndReadProduct(new Operators.InitDoExecuteSetsJAIImageOperator(), "InitDoExecuteSetsJAIImage");
         assertExpectedBandsExist(product, new String[]{"band1"});
     }
 


### PR DESCRIPTION
Hello!
This is the 4th PR in a series of pull-requests. The aim is to improve processing performance by enhancing cache handling and the sequence in which tiles are processed.

In this PR, the OperatorExecutor directly iterates over images instead of using OperatorTileStackComputationListener and calling getTile() which is blocking and prevented parallelization. Also, updated and simplified tests. Expected results are now better traceable.
ProductIO now iterates first over the tiles and then over the bands. Before it was the other way around. In case of a tile-stack operator all images of the stack had to be in cache. Now only one tile-stack needs to be kept by the cache.
WriteOp - calling TileCache.memoryControl() instead of TileCache.flush(). Flush() tries to clear the whole cache. MemoryControl() only those which are not used anymore. Additionally requesting removal of tiles from the cache.
This PR contains also the MultiLevelImage changes of 3b.