### PR TITLE
SNAP-3758, error when subsetting sentinel-1 products

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/dataio/AbstractProductBuilder.java
+++ b/snap-core/src/main/java/org/esa/snap/core/dataio/AbstractProductBuilder.java
@@ -75,6 +75,9 @@ public abstract class AbstractProductBuilder extends AbstractProductReader {
         Guardian.assertNotNull("sourceProduct", sourceProduct);
         setNewProductName(name != null ? name : sourceProduct.getName());
         setNewProductDesc(desc != null ? desc : sourceProduct.getDescription());
+        if (subsetDef != null) {
+            subsetDef.setValidSubsetRegionMaps();
+        }
         final Product product = readProductNodes(sourceProduct, subsetDef);
         product.setModified(true);
         return product;

--- a/snap-core/src/main/java/org/esa/snap/core/dataio/ProductSubsetDef.java
+++ b/snap-core/src/main/java/org/esa/snap/core/dataio/ProductSubsetDef.java
@@ -21,10 +21,7 @@ import org.esa.snap.core.util.Guardian;
 
 import java.awt.Dimension;
 import java.awt.Rectangle;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * The <code>ProductSubsetDef</code> class describes a subset or portion of a remote sensing data product.
@@ -427,5 +424,26 @@ public class ProductSubsetDef {
 
     public void setSubsetRegion(AbstractSubsetRegion subsetRegion) {
         this.subsetRegion = subsetRegion;
+    }
+
+    /**
+     * Remove regions from non overlapping bands for multi-size products
+     */
+    public void setValidSubsetRegionMaps() {
+        if (this.regionMap == null || this.nodeNameList == null) {
+            return;
+        }
+
+        Iterator<Map.Entry<String, Rectangle>> iterator = this.regionMap.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, Rectangle> entry = iterator.next();
+            String nodeName = entry.getKey();
+            Rectangle rect = entry.getValue();
+
+            if (rect.height == 0 || rect.width == 0) {
+                iterator.remove();
+                this.nodeNameList.remove(nodeName);
+            }
+        }
     }
 }

--- a/snap-core/src/test/java/org/esa/snap/core/dataio/ProductSubsetDefTest.java
+++ b/snap-core/src/test/java/org/esa/snap/core/dataio/ProductSubsetDefTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.awt.*;
+import java.util.HashMap;
 
 import static org.junit.Assert.*;
 
@@ -293,5 +294,38 @@ public class ProductSubsetDefTest {
         assertTrue(subsetInfo.isIgnoreMetadata());
         subsetInfo.setIgnoreMetadata(false);
         assertFalse(subsetInfo.isIgnoreMetadata());
+    }
+
+    @Test
+    public void testSetValidSubsetRegionMaps() {
+        ProductSubsetDef subsetDef = new ProductSubsetDef();
+        HashMap<String, Rectangle> map = new HashMap<>();
+        Rectangle validRectangle = new Rectangle(0,0,4,23);
+        Rectangle invalidRectangle1 = new Rectangle(0,0,0,0);
+        Rectangle invalidRectangle2 = new Rectangle(0,0,4,0);
+        Rectangle invalidRectangle3 = new Rectangle(0,0,0,23);
+
+        map.put("valid_rectangle", validRectangle);
+        map.put("invalid_rectangle1", invalidRectangle1);
+        map.put("invalid_rectangle2", invalidRectangle2);
+        map.put("invalid_rectangle3", invalidRectangle3);
+
+        subsetDef.setRegionMap(map);
+        subsetDef.setNodeNames(new String[] {"valid_rectangle", "invalid_rectangle1", "invalid_rectangle2", "invalid_rectangle3"});
+        HashMap<String, Rectangle> updatedMap = subsetDef.getRegionMap();
+        String[] nodeNames = subsetDef.getNodeNames();
+
+        assertEquals(4, updatedMap.size());
+        assertEquals(4, nodeNames.length);
+
+        subsetDef.setValidSubsetRegionMaps();
+
+        assertEquals(1, updatedMap.size());
+        assertTrue(updatedMap.containsKey("valid_rectangle"));
+        assertEquals(validRectangle, updatedMap.get("valid_rectangle"));
+
+        nodeNames = subsetDef.getNodeNames();
+        assertEquals(1, nodeNames.length);
+        assertEquals("valid_rectangle", nodeNames[0]);
     }
 }


### PR DESCRIPTION
When subsetting multi-size products with bands that have non-overlapping regions, the regions rectangle for such bands is empty. Therefore, these bands are excluded from the subset