### PR TITLE
Modified to estimate XY pixel spacing from pixel geo-position

### DIFF
--- a/snap-dem/src/main/java/org/esa/snap/dem/gpf/ComputeSlopeAspectOp.java
+++ b/snap-dem/src/main/java/org/esa/snap/dem/gpf/ComputeSlopeAspectOp.java
@@ -38,6 +38,7 @@ import org.esa.snap.engine_utilities.eo.Constants;
 import org.esa.snap.engine_utilities.gpf.OperatorUtils;
 import org.esa.snap.engine_utilities.gpf.TileGeoreferencing;
 import org.esa.snap.engine_utilities.gpf.TileIndex;
+import org.esa.snap.engine_utilities.eo.GeoUtils;
 
 import java.awt.Rectangle;
 import java.io.File;
@@ -133,16 +134,42 @@ public final class ComputeSlopeAspectOp extends Operator {
     private void getPixelSpacings() throws Exception {
 
         final MetadataElement absRoot = AbstractMetadata.getAbstractedMetadata(sourceProduct);
+        rangeSpacing = absRoot.getAttributeDouble(AbstractMetadata.range_spacing);
+        azimuthSpacing = absRoot.getAttributeDouble(AbstractMetadata.azimuth_spacing);
 
-        rangeSpacing = AbstractMetadata.getAttributeDouble(absRoot, AbstractMetadata.range_spacing);
-        if (rangeSpacing <= 0.0) {
-            throw new OperatorException("Invalid range pixel spacing: " + rangeSpacing);
+        if (rangeSpacing == AbstractMetadata.NO_METADATA || azimuthSpacing == AbstractMetadata.NO_METADATA ||
+                rangeSpacing == 0 || azimuthSpacing == 0) {
+            rangeSpacing = getResolutionXAtCentre(sourceProduct);
+            azimuthSpacing = getResolutionYAtCentre(sourceProduct);
         }
+    }
 
-        azimuthSpacing = AbstractMetadata.getAttributeDouble(absRoot, AbstractMetadata.azimuth_spacing);
-        if (azimuthSpacing <= 0.0) {
-            throw new OperatorException("Invalid azimuth pixel spacing: " + azimuthSpacing);
-        }
+    public static double getResolutionXAtCentre(final Product product) {
+        final int numPixelsX = Math.min(400, product.getSceneRasterWidth());
+        final int halfX = numPixelsX / 2;
+        final int centreX = product.getSceneRasterWidth() / 2;
+        final int centreY = product.getSceneRasterHeight() / 2;
+
+        final GeoCoding geoCoding = product.getSceneGeoCoding();
+        final GeoPos geoPosX1 = geoCoding.getGeoPos(new PixelPos(centreX - halfX, centreY), null);
+        final GeoPos geoPosX2 = geoCoding.getGeoPos(new PixelPos(centreX + halfX, centreY), null);
+        final GeoUtils.DistanceHeading distX = GeoUtils.vincenty_inverse(geoPosX1, geoPosX2);
+
+        return distX.distance / numPixelsX;
+    }
+
+    public static double getResolutionYAtCentre(final Product product) {
+        final int numPixelsY = Math.min(400, product.getSceneRasterHeight());
+        final int halfY = numPixelsY / 2;
+        final int centreX = product.getSceneRasterWidth() / 2;
+        final int centreY = product.getSceneRasterHeight() / 2;
+
+        final GeoCoding geoCoding = product.getSceneGeoCoding();
+        final GeoPos geoPosY1 = geoCoding.getGeoPos(new PixelPos(centreX, centreY - halfY), null);
+        final GeoPos geoPosY2 = geoCoding.getGeoPos(new PixelPos(centreX, centreY + halfY), null);
+        final GeoUtils.DistanceHeading distY = GeoUtils.vincenty_inverse(geoPosY1, geoPosY2);
+
+        return distY.distance / numPixelsY;
     }
 
     private void checkDEM() throws Exception {

--- a/snap-dem/src/main/java/org/esa/snap/dem/gpf/ComputeSlopeAspectOp.java
+++ b/snap-dem/src/main/java/org/esa/snap/dem/gpf/ComputeSlopeAspectOp.java
@@ -134,11 +134,13 @@ public final class ComputeSlopeAspectOp extends Operator {
     private void getPixelSpacings() throws Exception {
 
         final MetadataElement absRoot = AbstractMetadata.getAbstractedMetadata(sourceProduct);
-        rangeSpacing = absRoot.getAttributeDouble(AbstractMetadata.range_spacing);
-        azimuthSpacing = absRoot.getAttributeDouble(AbstractMetadata.azimuth_spacing);
+        if (absRoot != null) {
+            rangeSpacing = absRoot.getAttributeDouble(AbstractMetadata.range_spacing);
+            azimuthSpacing = absRoot.getAttributeDouble(AbstractMetadata.azimuth_spacing);
+        }
 
         if (rangeSpacing == AbstractMetadata.NO_METADATA || azimuthSpacing == AbstractMetadata.NO_METADATA ||
-                rangeSpacing == 0 || azimuthSpacing == 0) {
+                rangeSpacing == 0.0 || azimuthSpacing == 0.0) {
             rangeSpacing = getResolutionXAtCentre(sourceProduct);
             azimuthSpacing = getResolutionYAtCentre(sourceProduct);
         }

--- a/snap-dem/src/test/java/org/esa/snap/gpf/ComputeSlopeAspectOpTest.java
+++ b/snap-dem/src/test/java/org/esa/snap/gpf/ComputeSlopeAspectOpTest.java
@@ -1,0 +1,60 @@
+package org.esa.snap.gpf;
+
+import com.bc.ceres.annotation.STTM;
+import com.bc.ceres.test.LongTestRunner;
+import org.esa.snap.core.datamodel.*;
+import org.esa.snap.dem.gpf.ComputeSlopeAspectOp;
+import org.esa.snap.engine_utilities.datamodel.AbstractMetadata;
+import org.esa.snap.engine_utilities.gpf.OperatorUtils;
+import org.esa.snap.engine_utilities.gpf.ReaderUtils;
+import org.esa.snap.engine_utilities.util.TestUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assume.assumeTrue;
+
+public class ComputeSlopeAspectOpTest {
+
+    @Test
+    @STTM("SNAP-3894")
+    public void testComputeXYResolutions() {
+        Product product = createProduct("type", 7731, 7851);
+
+        ComputeSlopeAspectOp op = new ComputeSlopeAspectOp();
+        op.setSourceProduct(product);
+        final double xRes = op.getResolutionXAtCentre(product);
+        final double yRes = op.getResolutionYAtCentre(product);
+
+        final double xResExp = 29.98405034556281;
+        final double yResExp = 30.05407836258074;
+        assumeTrue(Math.abs(xRes - xResExp) <= 1e-3);
+        assumeTrue(Math.abs(yRes - yResExp) <= 1e-3);
+    }
+
+    public static Product createProduct(final String type, final int w, final int h) {
+        final Product product = new Product("name", type, w, h);
+
+        final ProductData.UTC startTime = AbstractMetadata.parseUTC("10-MAY-2008 20:30:46.890683");
+        final ProductData.UTC endTime = AbstractMetadata.parseUTC("10-MAY-2008 20:35:46.890683");
+        product.setStartTime(startTime);
+        product.setEndTime(endTime);
+        product.setDescription("description");
+
+        final TiePointGrid latGrid = new TiePointGrid(OperatorUtils.TPG_LATITUDE, 2, 2, 0.0f, 0.0f,
+                product.getSceneRasterWidth(), product.getSceneRasterHeight(), new float[]{44.243f, 44.220f, 42.123f, 42.101f});
+        final TiePointGrid lonGrid = new TiePointGrid(OperatorUtils.TPG_LONGITUDE, 2, 2, 0.0f, 0.0f,
+                product.getSceneRasterWidth(), product.getSceneRasterHeight(),
+                new float[]{-81.544f, -78.640f, -81.525f, -78.720f}, TiePointGrid.DISCONT_AT_180);
+        final TiePointGeoCoding tpGeoCoding = new TiePointGeoCoding(latGrid, lonGrid);
+        product.addTiePointGrid(latGrid);
+        product.addTiePointGrid(lonGrid);
+        product.setSceneGeoCoding(tpGeoCoding);
+
+        final MetadataElement absRoot = AbstractMetadata.addAbstractedMetadataHeader(product.getMetadataRoot());
+        absRoot.setAttributeUTC(AbstractMetadata.first_line_time, startTime);
+        absRoot.setAttributeUTC(AbstractMetadata.last_line_time, endTime);
+        absRoot.setAttributeDouble(AbstractMetadata.line_time_interval, ReaderUtils.getLineTimeInterval(startTime, endTime, h));
+
+        return product;
+    }
+
+}


### PR DESCRIPTION
The current Compute Slope and Aspect operator fails when pixel spacing is missing from the product metadata. The problem has been fixed by computing the pixel spacing using the geo-position information for pixels at the center of the image in case the pixel spacing is missing from the metadata. 