### PR TITLE
S2reader commons-io dependency issue

### DIFF
--- a/snap-core/pom.xml
+++ b/snap-core/pom.xml
@@ -191,6 +191,11 @@
             <version>1.6</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.12.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-render</artifactId>
             <version>${geotools.version}</version>


### PR DESCRIPTION
Moved commons-io dependency from opttbx-s2msi-reader to snap-core to centralize its usage. This ensures consistent versioning across modules and avoids redundancy.

see also: https://forum.step.esa.int/t/commons-io-dependency-issue-in-s2msi-reader/44516

This should resolve the issue when a module depends on s2msi-reader, snap-core and commons-io. In this case the module does not know where to load the classes from.  
`java.lang.ClassNotFoundException: Will not load class org.apache.commons.io.input.ReversedLinesFileReader arbitrarily from one of ModuleCL@4bc08f13[eu.esa.opt.opttbx.s2msi.reader] and ModuleCL@29091e7a[org.esa.snap.snap.core] starting from ModuleCL@e56c0cf[org.eomasters.eomtbx]`

There is a related pull request for the opttbx https://github.com/senbox-org/optical-toolbox/pull/112