### PR TITLE
Improve validation error messaging in ValueSetValidator

### DIFF
--- a/ceres-binding/src/main/java/com/bc/ceres/binding/validators/ValueSetValidator.java
+++ b/ceres-binding/src/main/java/com/bc/ceres/binding/validators/ValueSetValidator.java
@@ -16,14 +16,16 @@
 
 package com.bc.ceres.binding.validators;
 
+import com.bc.ceres.binding.Property;
+import com.bc.ceres.binding.PropertyDescriptor;
 import com.bc.ceres.binding.ValidationException;
 import com.bc.ceres.binding.Validator;
-import com.bc.ceres.binding.PropertyDescriptor;
-import com.bc.ceres.binding.Property;
-
+import com.bc.ceres.binding.ValueSet;
 import java.text.MessageFormat;
+import java.util.Arrays;
 
 public class ValueSetValidator implements Validator {
+
     private final PropertyDescriptor propertyDescriptor;
 
     public ValueSetValidator(PropertyDescriptor propertyDescriptor) {
@@ -33,9 +35,12 @@ public class ValueSetValidator implements Validator {
     @Override
     public void validateValue(Property property, Object value) throws ValidationException {
         if (value != null || propertyDescriptor.isNotNull()) {
-            if (!propertyDescriptor.getValueSet().contains(value)) {
-                throw new ValidationException(MessageFormat.format("Value for ''{0}'' is invalid: ''{1}''",
-                                                                   property.getDescriptor().getDisplayName(), value));
+            ValueSet valueSet = propertyDescriptor.getValueSet();
+            if (!valueSet.contains(value)) {
+                throw new ValidationException(
+                        MessageFormat.format("Value for ''{0}'' is invalid: ''{1}''. Allowed values are: {2}.",
+                                property.getDescriptor().getDisplayName(), value,
+                                Arrays.toString(valueSet.getItems())));
             }
         }
     }

--- a/ceres-binding/src/test/java/com/bc/ceres/binding/validators/ValueSetValidatorTest.java
+++ b/ceres-binding/src/test/java/com/bc/ceres/binding/validators/ValueSetValidatorTest.java
@@ -7,6 +7,9 @@ import com.bc.ceres.binding.ValueSet;
 import com.bc.ceres.binding.accessors.DefaultPropertyAccessor;
 import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 /**
  * @author Norman Fomferra
  */
@@ -36,12 +39,18 @@ public class ValueSetValidatorTest {
         validator.validateValue(createProperty(descriptor), "c");
     }
 
-    @Test(expected = ValidationException.class)
+    @Test()
     public void testBadValue() throws Exception {
         final PropertyDescriptor descriptor = createPropertyDescriptor();
         descriptor.setNotNull(false);
         final ValueSetValidator validator = new ValueSetValidator(descriptor);
-        validator.validateValue(createProperty(descriptor), "d");
+        try {
+            validator.validateValue(createProperty(descriptor), "d");
+            fail("ValidationException expected");
+        } catch (ValidationException e) {
+            String message = e.getMessage();
+            assertTrue(message.contains("Value for 'X' is invalid: 'd'. Allowed values are: [a, b, c]."));
+        }
     }
 
     private static Property createProperty(PropertyDescriptor descriptor) {


### PR DESCRIPTION
Enhanced the ValueSetValidator to include allowed values in the exception message for clearer context when validation fails. Updated the corresponding test to assert the new message format.