### PR TITLE
Refine dependencies in ceres-jai and snap-core for imageio-ext-tiff

### DIFF
--- a/ceres-jai/pom.xml
+++ b/ceres-jai/pom.xml
@@ -76,8 +76,9 @@
                         <publicPackage>com.bc.ceres.compiler</publicPackage>
                         <publicPackage>com.bc.ceres.multilevel.*</publicPackage>
                         <publicPackage>com.bc.ceres.jai.*</publicPackage>
-                        <publicPackage>it.geosolutions.imageio.plugins.tiff</publicPackage>
-                        <publicPackage>it.geosolutions.imageioimpl.plugins.tiff</publicPackage>
+                        <publicPackage>it.geosolutions.imageio.*</publicPackage>
+                        <publicPackage>it.geosolutions.imageioimpl.plugins.tiff.*</publicPackage>
+                        <publicPackage>it.geosolutions.io.*</publicPackage>
                         <publicPackage>org.mozilla.javascript.*</publicPackage>
                     </publicPackages>
                 </configuration>

--- a/snap-core/pom.xml
+++ b/snap-core/pom.xml
@@ -248,11 +248,6 @@
         </dependency>
 
         <dependency>
-            <groupId>it.geosolutions.imageio-ext</groupId>
-            <artifactId>imageio-ext-tiff</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
             <version>3.9.0</version>


### PR DESCRIPTION
Refine public package definitions for ceres-jai and remove imageio-ext-tiff dependency from snap-core.

It prevents the error:
WARNING [org.netbeans.ProxyClassLoader]: Will not load class it.geosolutions.imageio.stream.output.spi.FileImageOutputStreamExtImplSpi arbitrarily from one of ModuleCL@4907dfd5[org.esa.snap.ceres.jai] and ModuleCL@7a268f4a[org.esa.snap.snap.core] starting from SystemClassLoader[277 modules]; see http://wiki.netbeans.org/DevFaqModuleCCE SEVERE [org.openide.util.RequestProcessor]: Error in RequestProcessor org.esa.snap.rcp.SnapApp$StartOp java.util.ServiceConfigurationError: javax.imageio.spi.ImageOutputStreamSpi: Provider it.geosolutions.imageio.stream.output.spi.FileImageOutputStreamExtImplSpi not found
	at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:593)