### PR TITLE
SNAP-4028 - issue with BandMaths with empty expression & Batch Processing

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/param/AbstractParamValidator.java
+++ b/snap-core/src/main/java/org/esa/snap/core/param/AbstractParamValidator.java
@@ -134,9 +134,7 @@ public abstract class AbstractParamValidator implements ParamValidator {
      */
     protected static boolean isAllowedNullText(Parameter parameter, String text) {
         Debug.assertNotNull(parameter);
-        Debug.assertNotNull(text);
-        return text.trim().length() == 0
-               && parameter.getProperties().isNullValueAllowed();
+        return parameter.getProperties().isNullValueAllowed() && (text == null || text.trim().length() == 0) ;
     }
 
     /**

--- a/snap-core/src/main/java/org/esa/snap/core/param/validators/StringValidator.java
+++ b/snap-core/src/main/java/org/esa/snap/core/param/validators/StringValidator.java
@@ -33,8 +33,6 @@ public class StringValidator extends AbstractParamValidator {
 
     public Object parse(Parameter parameter, String text) throws ParamParseException {
 
-        Debug.assertTrue(text != null);
-
         if (isAllowedNullText(parameter, text)) {
             return null;
         }

--- a/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/BandMathsOp.java
+++ b/snap-gpf/src/main/java/org/esa/snap/core/gpf/common/BandMathsOp.java
@@ -459,6 +459,9 @@ public class BandMathsOp extends Operator {
         Namespace namespace = createNamespace();
         final Term term;
         try {
+            if (StringUtils.isNullOrEmpty(expression)){
+                throw new ParseException("Empty expression.");
+            }
             Parser parser = new ParserImpl(namespace, performTypeChecking);
             term = parser.parse(expression);
         } catch (ParseException e) {


### PR DESCRIPTION
SNAP-4028 - Fix the issue where graphs with a BandMaths node containing an empty expression fail to load in Batch Processing.
(run SNAP with “-Dsnap.debug=true“ in the VM options)