### PR TITLE
SNAP-4184 fix ProductCache race condition

### DIFF
--- a/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/CacheManager.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/CacheManager.java
@@ -104,7 +104,9 @@ public class CacheManager implements MemoryUsageTracker {
             }
 
             long disposed = 0;
-            productCaches.sort(new ReverseTimeComparator());
+            // Snapshot access times so the sort is stable even if other threads update
+            // them concurrently while this sort runs (prevents TimSort contract violation).
+            productCaches.sort(new ReverseTimeComparator(productCaches));
             for (ProductCache productCache : productCaches) {
                 disposed += productCache.release(toDispose - disposed);
                 if (disposed >= toDispose) {

--- a/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/ProductCache.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/ProductCache.java
@@ -88,7 +88,9 @@ public class ProductCache implements TimeStamped {
 
     private @NonNull ArrayList<VariableCache> getTimeOrderedList() {
         final ArrayList<VariableCache> variableCaches = new ArrayList<>(variableCacheMap.values());
-        variableCaches.sort(new ReverseTimeComparator());
+        // Snapshot access times so the sort is stable even if other threads update them
+        // concurrently while this sort runs (prevents TimSort contract violation).
+        variableCaches.sort(new ReverseTimeComparator(variableCaches));
         return variableCaches;
     }
 }

--- a/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/ReverseTimeComparator.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/ReverseTimeComparator.java
@@ -1,17 +1,41 @@
 package eu.esa.snap.core.dataio.cache;
 
+import java.util.Collection;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 
 public class ReverseTimeComparator implements Comparator<TimeStamped> {
 
+    private final IdentityHashMap<TimeStamped, Long> timeSnapshot;
+
+    /**
+     * Creates a comparator that reads each item's access time live on every compare.
+     * <p>
+     * NOT SAFE when items may be updated by other threads during a sort: the comparator
+     * contract can be violated (Java TimSort then throws "Comparison method violates its
+     * general contract!"). Prefer {@link #ReverseTimeComparator(Collection)} whenever the
+     * list is sorted while readers may concurrently touch the items.
+     */
+    public ReverseTimeComparator() {
+        this.timeSnapshot = null;
+    }
+
+    /**
+     * Creates a comparator that captures a snapshot of each item's access time at
+     * construction. compare() uses the snapshot, so the ordering is stable across the
+     * whole sort even if other threads update the items' access times concurrently.
+     */
+    public ReverseTimeComparator(Collection<? extends TimeStamped> items) {
+        this.timeSnapshot = new IdentityHashMap<>(items.size());
+        for (TimeStamped item : items) {
+            this.timeSnapshot.put(item, item.getLastAccessTime());
+        }
+    }
+
     @Override
     public int compare(TimeStamped lhs, TimeStamped rhs) {
-        if (lhs.getLastAccessTime() > rhs.getLastAccessTime()) {
-            return 1;
-        } else if (lhs.getLastAccessTime() < rhs.getLastAccessTime()) {
-            return -1;
-        }
-
-        return 0;
+        final long lTime = timeSnapshot != null ? timeSnapshot.get(lhs) : lhs.getLastAccessTime();
+        final long rTime = timeSnapshot != null ? timeSnapshot.get(rhs) : rhs.getLastAccessTime();
+        return Long.compare(lTime, rTime);
     }
 }

--- a/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/VariableCache2D.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/VariableCache2D.java
@@ -164,7 +164,9 @@ class VariableCache2D implements VariableCache {
             Collections.addAll(cacheDataList, cacheLine);
         }
 
-        cacheDataList.sort(new ReverseTimeComparator());
+        // Snapshot access times so the sort is stable even if other threads update them
+        // concurrently while this sort runs (prevents TimSort contract violation).
+        cacheDataList.sort(new ReverseTimeComparator(cacheDataList));
 
         return cacheDataList;
     }

--- a/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/VariableCache3D.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/VariableCache3D.java
@@ -197,7 +197,9 @@ class VariableCache3D implements VariableCache {
             }
         }
 
-        cacheDataList.sort(new ReverseTimeComparator());
+        // Snapshot access times so the sort is stable even if other threads update them
+        // concurrently while this sort runs (prevents TimSort contract violation).
+        cacheDataList.sort(new ReverseTimeComparator(cacheDataList));
 
         return cacheDataList;
     }

--- a/snap-core/src/test/java/eu/esa/snap/core/dataio/cache/CacheDataComparatorTest.java
+++ b/snap-core/src/test/java/eu/esa/snap/core/dataio/cache/CacheDataComparatorTest.java
@@ -3,6 +3,9 @@ package eu.esa.snap.core.dataio.cache;
 import com.bc.ceres.annotation.STTM;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 public class CacheDataComparatorTest {
@@ -27,5 +30,30 @@ public class CacheDataComparatorTest {
         // change time so that both have same timestamp
         two.setLastAccessTime(2000);
         assertEquals(0, cacheDataComparator.compare(one, two));
+    }
+
+    @Test
+    @STTM("SNAP-4184")
+    public void testSnapshotConstructor_isolatesSortFromConcurrentMutation() {
+        // Regression for: java.lang.IllegalArgumentException: Comparison method violates its
+        // general contract!  — raised from TimSort when access times change mid-sort.
+        // The snapshot constructor must freeze the compare keys at construction time.
+        final CacheData2D a = new CacheData2D(new int[]{0, 0}, new int[]{10, 10});
+        final CacheData2D b = new CacheData2D(new int[]{0, 10}, new int[]{10, 10});
+        a.setLastAccessTime(1000);
+        b.setLastAccessTime(2000);
+        final List<TimeStamped> items = Arrays.asList(a, b);
+
+        final ReverseTimeComparator snapshot = new ReverseTimeComparator(items);
+
+        // Mutate access times after the snapshot is taken — mimics what a concurrent
+        // reader thread would do while the sort is running.
+        a.setLastAccessTime(5000);
+        b.setLastAccessTime(500);
+
+        // compare() must still reflect the original (snapshotted) ordering: a (1000) < b (2000).
+        assertEquals(-1, snapshot.compare(a, b));
+        assertEquals(1, snapshot.compare(b, a));
+        assertEquals(0, snapshot.compare(a, a));
     }
 }


### PR DESCRIPTION
IllegalArgumentException: Comparison method violates its general contract! thrown by Java's TimSort during cache eviction.

lastAccessTime is a plain long that gets updated by JAI SunTileScheduler worker threads whenever tiles are read. During a sort, concurrent reader threads mutate the very keys being compared. TimSort requires the comparator to define a stable total order (transitivity: if a
   < b and b < c then a < c). When keys change mid-sort, this contract breaks and TimSort throws.

Problem surfaces when integrating into more SAR readers (NISAR, Cosmo-SkyMed, ICEYE, K5) that generate heavier cache traffic than the original EnMAP/PaceOCI use case.

Fix: ReverseTimeComparator gains a new snapshot constructor that freezes access times into an IdentityHashMap at construction time. All compare() calls during the sort read from this immutable snapshot, guaranteeing a stable ordering regardless of concurrent mutations.