### PR TITLE
SNAP-4195 fix cachebuffer is null error

### DIFF
--- a/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/AbstractCacheData.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/AbstractCacheData.java
@@ -23,13 +23,17 @@ public abstract class AbstractCacheData implements CacheData, TimeStamped {
 
     @Override
     public long release(long bytesToRelease) {
-        if (data == null) {
-            return 0;
+        // Synchronize on the same monitor used by ensureData so callers capturing
+        // the data reference under lock won't see it nulled mid-copy.
+        synchronized (this) {
+            if (data == null) {
+                return 0;
+            }
+            final ProductData productData = data.getData();
+            final long size = (long) productData.getNumElems() * productData.getElemSize();
+            data = null;
+            return size;
         }
-        final ProductData productData = data.getData();
-        final long size = (long) productData.getNumElems() * productData.getElemSize();
-        data = null;
-        return size;
     }
 
     public long getLastAccessTime() {

--- a/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/CacheData2D.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/CacheData2D.java
@@ -61,16 +61,21 @@ class CacheData2D extends AbstractCacheData {
     }
 
     void copyData(int[] offsets, int[] targetOffsets, int[] targetShapes, int targetWidth, ProductData targetData) throws IOException {
-        ensureData();
+        // Capture the buffer reference under the same lock used by ensureData / release,
+        // so a concurrent release() can't null out `data` between ensureData and the copy.
+        final DataBuffer localData = ensureData();
 
-        copyDataBuffer(offsets, data, targetOffsets, targetShapes, targetWidth, targetData);
+        copyDataBuffer(offsets, localData, targetOffsets, targetShapes, targetWidth, targetData);
     }
 
     @Override
     public int getSizeInBytes() {
         int size = SIZE_WITHOUT_BUFFER;
-        if (data != null) {
-            final ProductData productData = data.getData();
+        // Snapshot the reference so a concurrent release() can't null it between
+        // the null check and the getData() call.
+        final DataBuffer snapshot = data;
+        if (snapshot != null) {
+            final ProductData productData = snapshot.getData();
             size += productData.getNumElems() * productData.getElemSize();
         }
         return size;
@@ -93,7 +98,8 @@ class CacheData2D extends AbstractCacheData {
         }
     }
 
-    private void ensureData() throws IOException {
+    private DataBuffer ensureData() throws IOException {
+        final DataBuffer localData;
         synchronized (this) {
             if (data == null) {
                 final String name = context.getVariableDescriptor().name;
@@ -104,14 +110,16 @@ class CacheData2D extends AbstractCacheData {
                 data = dataProvider.readCacheBlock(name, offsets, shapes, null);
                 lastAccessTime = System.currentTimeMillis();
             }
+            localData = data;
         }
-        trackAllocation();
+        trackAllocation(localData);
+        return localData;
     }
 
-    private void trackAllocation() {
+    private void trackAllocation(DataBuffer localData) {
         final MemoryUsageTracker memoryUsageTracker = context.getMemoryUsageTracker();
         if (memoryUsageTracker != null) {
-            memoryUsageTracker.allocated(data.getSizeInBytes());
+            memoryUsageTracker.allocated(localData.getSizeInBytes());
         }
     }
 

--- a/snap-core/src/test/java/eu/esa/snap/core/dataio/cache/CacheData2DTest.java
+++ b/snap-core/src/test/java/eu/esa/snap/core/dataio/cache/CacheData2DTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 
 import java.awt.*;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static eu.esa.snap.core.dataio.cache.CacheTestUtil.createPreparedBuffer;
 import static org.junit.Assert.*;
@@ -413,6 +415,71 @@ public class CacheData2DTest {
 
         released = cacheData2D.release(100000);
         assertEquals(200, released);
+    }
+
+    @Test
+    @STTM("SNAP-4195")
+    public void testCopyData_concurrentRelease_doesNotThrow() throws InterruptedException {
+        // Regression: under JAI parallel tile computation, CacheManager's
+        // memory-pressure eviction could call release() on a CacheData2D while
+        // another thread was mid-copy. ensureData wrote `data` under lock but
+        // copyDataBuffer read `this.data` without holding it, and release()
+        // itself was unsynchronized — so `data` could be nulled between the
+        // two, producing NPE at copyDataBuffer.
+        //
+        // After the fix (ensureData returns a local captured inside the lock;
+        // release() synchronizes on the same monitor), this stress loop must
+        // run without any exception.
+        //
+        // Multiple readers + a tight releaser are needed to hit the narrow
+        // window reliably — with a single reader the race rarely triggered.
+        final CacheDataProvider provider = new MockProvider(ProductData.TYPE_UINT16);
+        final CacheContext context = new CacheContext(
+                new VariableDescriptor(), provider, new TestMemoryUsageTracker());
+
+        final CacheData2D cacheData2D = createCacheData(new int[]{0, 0}, new int[]{10, 10});
+        cacheData2D.setCacheContext(context);
+
+        final int iterations = 20000;
+        final int numReaders = 4;
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final AtomicBoolean stopReleaser = new AtomicBoolean(false);
+
+        final Thread[] readers = new Thread[numReaders];
+        for (int r = 0; r < numReaders; r++) {
+            readers[r] = new Thread(() -> {
+                try {
+                    for (int i = 0; i < iterations && failure.get() == null; i++) {
+                        cacheData2D.copyData(new int[]{0, 0}, new int[]{5, 5}, new int[]{5, 5}, 10,
+                                ProductData.createInstance(ProductData.TYPE_UINT16, 100));
+                        // Also exercise getSizeInBytes: same snapshot-vs-release race.
+                        cacheData2D.getSizeInBytes();
+                    }
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            }, "cache-reader-" + r);
+        }
+
+        final Thread releaser = new Thread(() -> {
+            try {
+                while (!stopReleaser.get()) {
+                    cacheData2D.release(Long.MAX_VALUE);
+                }
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        }, "cache-releaser");
+
+        releaser.start();
+        for (Thread r : readers) r.start();
+        for (Thread r : readers) r.join();
+        stopReleaser.set(true);
+        releaser.join();
+
+        if (failure.get() != null) {
+            throw new AssertionError("concurrent copyData / release must not throw", failure.get());
+        }
     }
 
     private static @NonNull CacheData2D createCacheData(int[] offsets, int[] shapes) {


### PR DESCRIPTION
When benchmarking read/write operations for SAR readers I sometimes came across this issue.
When a reader backed by ProductCache is used from the JAI tile scheduler (parallel band writes), tile computation intermittently fails with:

  java.lang.NullPointerException: Cannot invoke "DataBuffer.getWidth()" because cacheBuffer is null
      at eu.esa.snap.core.dataio.cache.CacheData2D.copyDataBuffer(CacheData2D.java:85)
      at eu.esa.snap.core.dataio.cache.CacheData2D.copyData(CacheData2D.java:66)
      at eu.esa.snap.core.dataio.cache.VariableCache2D.read(VariableCache2D.java:134)

It occurs reliably under readers that push the 2 GB memoryLimit, e.g. writing a full Sentinel-1 GRD SLC through DIMAP: ~1.6 GB of raw tiles cached concurrently from 12 JAI workers.

The fixes are to close the window between the ensureData-synchronized write and the subsequent unsynchronized reads:

1. CacheData2D.copyData / ensureData — ensureData() now returns the DataBuffer reference captured inside the synchronized block; copyData passes this local to copyDataBuffer instead of re-reading this.data. trackAllocation takes the local too, since this.data could be nulled between the synchronized
    block exit and the tracker call. A later release() can still null the field, but the in-flight copy holds its own reference and completes safely.

2. CacheData2D.getSizeInBytes — Snapshots data into a local before the null-check + getData() deref, eliminating a second smaller NPE window on the same field.

3. AbstractCacheData.release — Now synchronizes on this (the same monitor used by ensureData), so its writes participate in the same happens-before chain and don't race with other readers of the field.