### PR TITLE
Bug in GeoCodingFactory:estimateGroundResolutionInKm

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/dataio/geocoding/GeoCodingFactory.java
+++ b/snap-core/src/main/java/org/esa/snap/core/dataio/geocoding/GeoCodingFactory.java
@@ -150,7 +150,7 @@ public class GeoCodingFactory {
         final double[] measures = new double[3];
         // upper left, measure in y direction
         EllipsoidDistance distance = new EllipsoidDistance(longitudes[0], latitudes[0], DefaultEllipsoid.WGS84);
-        measures[0] = distance.distance(longitudes[width], latitudes[width]);
+        measures[0] = distance.distance(longitudes[width], latitudes[height]);
 
         // center, measuring in x direction
         final int yOff = height / 2;


### PR DESCRIPTION
I found a bug in the estimateGroundResolutionInKm method of "snap-engine/snap-core/src/main/java/org/esa/snap/core/dataio/geocoding/GeoCodingFactory.java” at line 153:

Currently it is:
        measures[0] = distance.distance(longitudes[width], latitudes[width]);

But it should be:
        measures[0] = distance.distance(longitudes[width], latitudes[height]);

This bug causes potential array out of bounds errors, as well as it returns the wrong pixel height.