### PR TITLE
SNAP-4241 ProductCache memory accounting and scale cache budget

### DIFF
--- a/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/CacheData2D.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/CacheData2D.java
@@ -100,6 +100,7 @@ class CacheData2D extends AbstractCacheData {
 
     private DataBuffer ensureData() throws IOException {
         final DataBuffer localData;
+        final boolean loaded;
         synchronized (this) {
             if (data == null) {
                 final String name = context.getVariableDescriptor().name;
@@ -109,10 +110,19 @@ class CacheData2D extends AbstractCacheData {
                 final CacheDataProvider dataProvider = context.getDataProvider();
                 data = dataProvider.readCacheBlock(name, offsets, shapes, null);
                 lastAccessTime = System.currentTimeMillis();
+                loaded = true;
+            } else {
+                loaded = false;
             }
             localData = data;
         }
-        trackAllocation(localData);
+        // Only report the allocation when the buffer was actually loaded on this call.
+        // On a cache hit the tile is already resident and counted; reporting it again
+        // inflates the CacheManager's allocatedMemory without bound and triggers
+        // perpetual eviction / cache thrashing.
+        if (loaded) {
+            trackAllocation(localData);
+        }
         return localData;
     }
 

--- a/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/CacheManager.java
+++ b/snap-core/src/main/java/eu/esa/snap/core/dataio/cache/CacheManager.java
@@ -35,8 +35,26 @@ public class CacheManager implements MemoryUsageTracker {
         productCaches = new ArrayList<>();
         allocatedMemory = 0;
 
-        memoryLimit = Config.instance("snap").preferences().getLong("snap.dataio.cache.memoryLimit", TwoGB);
+        final long defaultLimit = defaultMemoryLimit(Runtime.getRuntime().maxMemory());
+        memoryLimit = Config.instance("snap").preferences().getLong("snap.dataio.cache.memoryLimit", defaultLimit);
         disposeThreshold = Config.instance("snap").preferences().getLong("snap.dataio.cache.disposeThreshold", OneMb);
+    }
+
+    /**
+     * Default cache budget for a given heap ceiling. A fixed 2 GB budget competes with
+     * the JAI tile cache and transient decode buffers and can exhaust a modest heap, so
+     * scale to a quarter of the available heap and cap at 2 GB. If the heap ceiling is
+     * unbounded ({@link Long#MAX_VALUE}), fall back to the fixed 2 GB default.
+     */
+    static long defaultMemoryLimit(long maxMemory) {
+        if (maxMemory == Long.MAX_VALUE) {
+            return TwoGB;
+        }
+        return Math.min(TwoGB, maxMemory / 4);
+    }
+
+    public long getMemoryLimit() {
+        return memoryLimit;
     }
 
     public void setMemoryLimit(long memoryLimit) {

--- a/snap-core/src/test/java/eu/esa/snap/core/dataio/cache/CacheData2DTest.java
+++ b/snap-core/src/test/java/eu/esa/snap/core/dataio/cache/CacheData2DTest.java
@@ -356,6 +356,31 @@ public class CacheData2DTest {
     }
 
     @Test
+    @STTM("SNAP-4196")
+    public void testEnsureData_repeatedRead_tracksAllocationOnce() throws IOException {
+        // Regression: ensureData() called trackAllocation() on EVERY read, including
+        // cache hits where no new buffer was loaded. That inflated the CacheManager's
+        // allocatedMemory counter without bound as tiles were re-read (pyramid build,
+        // pan/zoom, statistics), forcing perpetual eviction and cache thrashing.
+        // A resident tile must be counted once, no matter how often it is read.
+        final CacheDataProvider cacheDataProvider = new MockProvider(ProductData.TYPE_UINT16);
+        final TestMemoryUsageTracker memoryUsageTracker = new TestMemoryUsageTracker();
+        final CacheData2D cacheData2D = createCacheData(new int[]{350, 200}, new int[]{10, 10});
+
+        final CacheContext cacheContext = new CacheContext(new VariableDescriptor(), cacheDataProvider, memoryUsageTracker);
+        cacheData2D.setCacheContext(cacheContext);
+
+        // read the same tile three times - the buffer is loaded only on the first read
+        for (int i = 0; i < 3; i++) {
+            cacheData2D.copyData(new int[]{0, 0}, new int[]{5, 5}, new int[]{5, 5}, 10,
+                    ProductData.createInstance(ProductData.TYPE_UINT16, 100));
+        }
+
+        // 10x10 UINT16 = 200 bytes, tracked once - not 3x
+        assertEquals(200, memoryUsageTracker.getAllocatedBytes());
+    }
+
+    @Test
     @STTM("SNAP-4121")
     public void testGetSizeInBytes() throws IOException {
         final CacheData2D cacheData2D = createCacheData(new int[]{350, 200}, new int[]{10, 10});

--- a/snap-core/src/test/java/eu/esa/snap/core/dataio/cache/CacheManagerTest.java
+++ b/snap-core/src/test/java/eu/esa/snap/core/dataio/cache/CacheManagerTest.java
@@ -18,6 +18,27 @@ public class CacheManagerTest {
     }
 
     @Test
+    @STTM("SNAP-4196")
+    public void testDefaultMemoryLimit_scalesWithHeap() {
+        // A fixed 2 GB default competes with the JAI tile cache and transient decode
+        // buffers and can OOM a modest heap. The default budget must scale down to a
+        // quarter of the available heap, capped at 2 GB for large heaps.
+        final long twoGB = 1024L * 1024 * 1024 * 2;
+
+        // small 1 GB heap -> 256 MB
+        assertEquals(256L * 1024 * 1024, CacheManager.defaultMemoryLimit(1024L * 1024 * 1024));
+
+        // 4 GB heap -> 1 GB (a quarter, below the cap)
+        assertEquals(1024L * 1024 * 1024, CacheManager.defaultMemoryLimit(4L * 1024 * 1024 * 1024));
+
+        // large 16 GB heap -> capped at 2 GB
+        assertEquals(twoGB, CacheManager.defaultMemoryLimit(16L * 1024 * 1024 * 1024));
+
+        // no heap ceiling reported -> fixed 2 GB fallback
+        assertEquals(twoGB, CacheManager.defaultMemoryLimit(Long.MAX_VALUE));
+    }
+
+    @Test
     @STTM("SNAP-4121")
     public void testGetInstance() {
         final CacheManager instance_1 =  CacheManager.getInstance();
@@ -149,7 +170,7 @@ public class CacheManagerTest {
     public void testRelease() throws IOException {
         final CacheManager cacheManager = CacheManager.getInstance();
         cacheManager.setMemoryLimit(30000);
-        cacheManager.setDisposeThreshold(1000);
+        cacheManager.setDisposeThreshold(100);
 
         final ProductCache productCache = new ProductCache(new TestCacheDataProvider(new int[] {40, 200}, new int[] {10, 20}, ProductData.TYPE_FLOAT32));
         cacheManager.register(productCache);
@@ -168,11 +189,15 @@ public class CacheManagerTest {
         sizeInBytes = cacheManager.getSizeInBytes();
         assertEquals(28160, sizeInBytes);
 
-        // now trigger release 0peration, next allocation is 4k and will overshoot
+        // now trigger release operation: this read overshoots the 30000 limit
+        // (resident would reach 30560), and with the 100-byte dispose threshold the
+        // 560-byte overshoot triggers eviction of the oldest 800-byte tile buffer.
+        // With correct allocation accounting (SNAP-4196) the tracked memory equals the
+        // real resident size, so this is deterministic.
         dataBuffer = new DataBuffer(ProductData.createInstance(ProductData.TYPE_FLOAT32, 2000), new int[]{20, 80}, new int[] {20, 100});
         productCache.read("who_cares", new int[]{20, 80}, new int[] {20, 100}, dataBuffer );
 
         sizeInBytes = cacheManager.getSizeInBytes();
-        assertEquals(25760, sizeInBytes);
+        assertEquals(29760, sizeInBytes);
     }
 }


### PR DESCRIPTION
Two related ProductCache memory fixes in snap-core (eu.esa.snap.core.dataio.cache), surfaced while diagnosing SNAP Desktop OOM/hang when opening multiple large Sentinel-1 IW SLC products. Both concern how the cache tracks and bounds its own memory; they affect every CacheDataProvider (NISAR, PACE,   
  EnMAP, Capella, S1).                                                                                                                                                                                                                                                                                         

    Allocation double-counted on every cache hit -> eviction thrash                                                                                                                                                                                   Problem. CacheData2D.ensureData() called trackAllocation() on every read, including cache hits where no buffer was loaded, while release() decrements the counter only once. As tiles were re-read (image-pyramid build, pan/zoom, statistics), CacheManager.allocatedMemory inflated without bound and      
    permanently exceeded the limit. From then on every read triggered the eviction path (sort all caches by access time + release) and evicted still-live tiles, turning the cache into a re-decode storm that hangs and OOMs. CacheData3D was already correct; only the 2D path had the regression.             
    Fix. Track the allocation only when a buffer is actually loaded on that call.                                                                                                                                                                                                                                

    Default cache budget was a fixed 2 GB, independent of the heap                                                                                                                                                                                                                                            
    Problem. The default budget was a hardcoded 2 GB regardless of -Xmx. On a modest heap it competes with the JAI tile cache and transient decode buffers and can OOM.                                                                                                                                          
    Fix. Default budget is now min(2 GB, maxMemory / 4), falling back to 2 GB when the heap ceiling is unbounded. The snap.dataio.cache.memoryLimit preference still overrides. Added getMemoryLimit().