### PR TITLE
SNAP-4240 fix ImageUtils band reads O(n²) on large products

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/util/ImageUtils.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/ImageUtils.java
@@ -28,6 +28,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.TransformException;
 
 import javax.imageio.ImageIO;
+import javax.imageio.stream.FileImageInputStream;
 import javax.imageio.stream.ImageInputStream;
 import javax.media.jai.ImageLayout;
 import javax.media.jai.PlanarImage;
@@ -54,6 +55,8 @@ import java.awt.image.SampleModel;
 import java.awt.image.WritableRaster;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Vector;
 
 /**
@@ -505,6 +508,17 @@ public class ImageUtils {
     }
 
     public static ImageInputStream getImageInputStream(Object input) throws IOException {
+        // For a real file, return a random-access FileImageInputStream whose seek() is O(1).
+        // Wrapping a plain InputStream (the previous behaviour) yields a forward-caching
+        // ImageInputStream whose seek() must re-stream from position 0 - so a caller that
+        // opens a fresh stream per tile and seeks to increasing offsets (DimapProductReader)
+        // degrades to O(n^2), getting progressively slower down a large band.
+        if (!(input instanceof InputStream)) {
+            final Path productPath = ProductUtils.getProductPath(input);
+            if (Files.isRegularFile(productPath)) {
+                return new FileImageInputStream(productPath.toFile());
+            }
+        }
         final InputStream imageIOInput = ProductUtils.getProductInputStream(input);
         return ImageIO.createImageInputStream(imageIOInput);
     }

--- a/snap-core/src/test/java/org/esa/snap/core/util/ImageUtilsTest.java
+++ b/snap-core/src/test/java/org/esa/snap/core/util/ImageUtilsTest.java
@@ -16,16 +16,55 @@
 
 package org.esa.snap.core.util;
 
+import com.bc.ceres.annotation.STTM;
 import org.esa.snap.core.datamodel.ProductData;
 import org.junit.Test;
 
+import javax.imageio.stream.FileImageInputStream;
+import javax.imageio.stream.ImageInputStream;
 import java.awt.image.DataBuffer;
 import java.awt.image.RenderedImage;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
 
 import static org.junit.Assert.*;
 
 
 public class ImageUtilsTest {
+
+    @Test
+    @STTM("SNAP-4240")
+    public void testGetImageInputStream_forFile_isRandomAccess() throws Exception {
+        // Regression: getImageInputStream wrapped a plain InputStream, yielding a
+        // forward-caching ImageInputStream whose seek() re-streams from position 0.
+        // Callers that open a fresh stream per tile and seek to increasing offsets
+        // (DimapProductReader) then become O(n^2). A File input must yield a
+        // random-access FileImageInputStream so seek() is O(1).
+        final File tmp = File.createTempFile("imageutils-randomaccess", ".img");
+        try {
+            try (DataOutputStream out = new DataOutputStream(new FileOutputStream(tmp))) {
+                for (int i = 0; i < 1000; i++) {
+                    out.writeShort(i);
+                }
+            }
+
+            try (ImageInputStream iis = ImageUtils.getImageInputStream(tmp)) {
+                assertTrue("expected random-access FileImageInputStream, got " + iis.getClass().getName(),
+                        iis instanceof FileImageInputStream);
+
+                // seek far forward then read - must return the right sample
+                iis.seek(900L * 2);
+                assertEquals(900, iis.readShort());
+                // seek backward - random access must still work
+                iis.seek(10L * 2);
+                assertEquals(10, iis.readShort());
+            }
+        } finally {
+            Files.deleteIfExists(tmp.toPath());
+        }
+    }
 
     @Test
     public void testCreateRenderedImage() {


### PR DESCRIPTION
ImageUtils.getImageInputStream(Object) returned a forward-caching image input stream for file inputs, which makes tiled band reads O(n^2) on large products. Surfaced while diagnosing an Apply-Orbit-File -> DIMAP write that got progressively slower as it ran.                                                                   
  Problem                                                                                                                                                                                                                                                                                      
  getImageInputStream wrapped a plain InputStream (ImageIO.createImageInputStream(Files.newInputStream(file))), yielding a forward-caching FileCacheImageInputStream whose seek(pos) must stream the file from byte 0 up to pos. DimapProductReader.readBandRasterDataImpl opens a fresh stream per tile and   
  seeks to the tile's row offset, so each tile lower in the image re-streams the whole file from the top: O(height^2), i.e. visibly slower as processing descends the band. The BSQ ENVI reader shares the same utility and the same latent bug.                                                               

  Reproduced on a real 23665x15040 int16 band (678 MB), reading one line per 512-row tile-row top to bottom:                                                                                                                                                                                                                         

    Before (forward-cache stream, per tile): per-tile-row time climbed 164 ms -> 1446 ms -> 5534 ms -> 9154 ms; total 129 s for 29 reads.                                                                                                                                                                      

    After (random-access FileImageInputStream): flat ~0.3 ms per read; total 40 ms.                                                                                                                                                                                                                       

 Fix                                                                                                                                                                             
    getImageInputStream returns a random-access FileImageInputStream (O(1) seek) when the input resolves to a regular file; genuine InputStream inputs keep the previous path. One-method change that benefits every file-based caller (DIMAP, ENVI, ...).  