### PR TITLE
SNAP-4249_fix_open_from_vfs_14x

### DIFF
--- a/snap-core/src/main/java/org/esa/snap/core/util/ImageUtils.java
+++ b/snap-core/src/main/java/org/esa/snap/core/util/ImageUtils.java
@@ -513,7 +513,7 @@ public class ImageUtils {
         // ImageInputStream whose seek() must re-stream from position 0 - so a caller that
         // opens a fresh stream per tile and seeks to increasing offsets (DimapProductReader)
         // degrades to O(n^2), getting progressively slower down a large band.
-        if (!(input instanceof InputStream)) {
+        if (!(input instanceof InputStream || input.getClass().getName().contains("vfs"))) {
             final Path productPath = ProductUtils.getProductPath(input);
             if (Files.isRegularFile(productPath)) {
                 return new FileImageInputStream(productPath.toFile());


### PR DESCRIPTION
Fix for [SNAP-4249](https://senbox.atlassian.net/browse/SNAP-4249).

[SNAP-4249]: https://senbox.atlassian.net/browse/SNAP-4249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ